### PR TITLE
Deduplicate PR CI runs (Gate only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -42,7 +42,7 @@ jobs:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.11"]'
       coverage-min: "80"
       format_check: false  # Using ruff for formatting
       working-directory: "."


### PR DESCRIPTION
This removes redundant PR CI runs and cuts the PR matrix:

- `.github/workflows/ci.yml`: no longer runs on `pull_request` (push-only)
- `.github/workflows/pr-00-gate.yml`: runs `python-versions: ["3.11"]` only by default

Net effect on PRs: eliminates `CI / Python CI` duplicates and drops Gate from 2 runtimes to 1, which should bring PR time back down substantially.
