### PR TITLE
Docs: CI runtime analysis (Gate py311)

### DIFF
--- a/docs/ci/2026-02-15-gate-ci-runtime-py311.md
+++ b/docs/ci/2026-02-15-gate-ci-runtime-py311.md
@@ -52,7 +52,7 @@ There are only a few levers that materially reduce a job where tests dominate:
    - Full suite runs on `push` to `main` and/or nightly.
 
 2. **Shard tests across multiple jobs** (parallelize at the workflow level)
-   - Split into 2–4 shards using `pytest_args` (e.g., via `pytest -k`/markers, or a split plugin).
+   - Run 2–4 workflow matrix jobs, each passing different shard parameters via `pytest_args` (for example, using a plugin such as `pytest-split` or `pytest-xdist`, or by computing `SHARD_INDEX`/`SHARD_TOTAL` in the workflow and passing an appropriate `-k`/`-m` selection to each job).
    - This reduces wall time but increases total compute; works best if shards are balanced.
 
 3. **Remove or reduce coverage on PR Gate** (if policy allows)


### PR DESCRIPTION
Adds a short write-up under docs/ci/ capturing the current Gate/CI runtime measurements and why pytest dominates wall time, plus concrete options for reducing PR loop duration (scoping/sharding via pytest_args, coverage policy, profiling).