### PR TITLE
Gate: skip integration tests on PRs

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -45,6 +45,9 @@ jobs:
       python-versions: '["3.11"]'
       coverage-min: "80"
       format_check: false  # Using ruff for formatting
+      # Keep PR feedback fast by skipping heavy integration suites here.
+      # Full test coverage remains enforced on main branch CI.
+      pytest_args: "--ignore=tests/integration --ignore=tests/integrations"
       working-directory: "."
       artifact-prefix: "gate-"
       # Enable soft coverage gate for trend tracking and hotspot reporting


### PR DESCRIPTION
PR Gate changes (fast feedback):
- Runs pytest in parallel via xdist: -n auto --dist loadscope
- Disables coverage on PR Gate (coverage remains on main-branch CI)
- Skips integration dirs on PR Gate: --ignore=tests/integration --ignore=tests/integrations
- Skips release/packaging tests on PR Gate via marker: -m 'not release'

Release/packaging validation (slow):
- Adds .github/workflows/release-e2e.yml
- Runs nightly and via PR label 'run-release'
- Executes only -m release tests (PyInstaller build + packaged executable)