### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -52,6 +52,8 @@ const PROMPT_ROUTES = {
   },
 };
 
+const AGENT_EXECUTION_ACTIONS = new Set(['run', 'fix', 'conflict']);
+
 // Resolve default agent from registry
 let _defaultAgent = 'codex';
 try {
@@ -2049,6 +2051,13 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       ? 0
       : prevRoundsWithoutCompletion + (iteration > 0 ? 1 : 0);
 
+    // Track consecutive zero-activity rounds (no files + no tasks completed).
+    // Treat the persisted state as the source of truth; updateKeepaliveLoopSummary
+    // increments or resets this counter after each agent run.
+    const zeroActivityThreshold = 2;
+    const consecutiveZeroActivityRounds = toNumber(state.consecutive_zero_activity_rounds, 0);
+    const shouldStopForZeroActivity = consecutiveZeroActivityRounds >= zeroActivityThreshold;
+
     const prevCompleteGateFailureRounds = toNumber(state.complete_gate_failure_rounds, 0);
     const completeGateFailureRounds = allComplete && gateNormalized !== 'success'
       ? prevCompleteGateFailureRounds + 1
@@ -2071,9 +2080,10 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // An iteration is productive if it has a reasonable productivity score
     const isProductive = productivityScore >= 20 && !hasRecentFailures;
 
-    // max_iterations is a "stuck detection" threshold, not a hard cap
-    // Continue past max if productive work is happening
-    const shouldStopForMaxIterations = iteration >= maxIterations && !isProductive;
+    // max_iterations caps *unproductive* runs.
+    const hasMaxIterations = maxIterations > 0;
+    const reachedMaxIterations = hasMaxIterations && iteration >= maxIterations;
+    const shouldStopForMaxIterations = reachedMaxIterations && !isProductive;
 
     // Build task appendix for the agent prompt (after state load for reconciliation info)
     const taskAppendix = buildTaskAppendix(normalisedSections, checkboxCounts, state, { prBody: pr.body });
@@ -2173,6 +2183,16 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       } else {
         action = 'stop';
         reason = 'tasks-complete';
+      }
+    } else if (shouldStopForZeroActivity) {
+      // Zero files changed for multiple consecutive rounds = infrastructure failure.
+      // Stop immediately — no amount of retries will help without manual intervention.
+      action = 'stop';
+      reason = 'zero-activity-infrastructure';
+      if (core) {
+        core.warning(
+          `Agent produced 0 file changes for ${consecutiveZeroActivityRounds} consecutive rounds — likely infrastructure failure (auth, permissions, sandbox). Stopping.`,
+        );
       }
     } else if (shouldStopForMaxIterations && forceRetry && tasksRemaining) {
       action = 'run';
@@ -2604,6 +2624,17 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       allTasksComplete && gateConclusion && gateConclusion !== 'success'
         ? previousCompleteGateFailureRounds + 1
         : 0;
+    const previousZeroActivityRounds = toNumber(previousState?.consecutive_zero_activity_rounds, 0);
+    const previousTasksTotal = toNumber(previousTasks.total, tasksTotal);
+    const totalsStable = previousTasksTotal === tasksTotal;
+    const zeroActivityTaskDelta = totalsStable ? Math.max(0, tasksCompletedThisRound) : 0;
+    const actionRunsAgent = AGENT_EXECUTION_ACTIONS.has(action);
+    const consecutiveZeroActivityRounds =
+      !actionRunsAgent
+        ? previousZeroActivityRounds
+        : (currentIteration > 0 && agentFilesChanged === 0 && zeroActivityTaskDelta === 0
+            ? previousZeroActivityRounds + 1
+            : 0);
     const metricsIteration = action === 'run' ? currentIteration + 1 : currentIteration;
     const durationMs = resolveDurationMs({
       durationMs: toOptionalNumber(inputs.duration_ms ?? inputs.durationMs),
@@ -3031,11 +3062,18 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       running: false,
       // Track task reconciliation for next iteration
       needs_task_reconciliation: madeChangesButNoTasksChecked,
-      // Productivity tracking for evidence-based decisions
-      last_files_changed: agentFilesChanged,
-      prev_files_changed: toNumber(previousState?.last_files_changed, 0),
+      // Preserve last/previous file-change counts when no agent actually ran so
+      // that productivity history isn't destroyed by wait/review iterations.
+      last_files_changed: actionRunsAgent
+        ? agentFilesChanged
+        : toNumber(previousState?.last_files_changed, 0),
+      prev_files_changed: actionRunsAgent
+        ? toNumber(previousState?.last_files_changed, 0)
+        : toNumber(previousState?.prev_files_changed, 0),
       // Track consecutive rounds without task completion for progress review
       rounds_without_task_completion: roundsWithoutTaskCompletion,
+      // Infrastructure failure detection (zero files + zero tasks multiple rounds)
+      consecutive_zero_activity_rounds: consecutiveZeroActivityRounds,
       complete_gate_failure_rounds: completeGateFailureRounds,
       complete_gate_failure_rounds_max: completeGateFailureMax,
       // Quality metrics for analysis validation

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "minimatch": "^9.0.5"
+    "minimatch": "^10.0.1"
   }
 }

--- a/scripts/langchain/progress_reviewer.py
+++ b/scripts/langchain/progress_reviewer.py
@@ -258,9 +258,23 @@ def heuristic_alignment_check(
     return alignment_score, aligned, unaligned
 
 
-# ---------------------------------------------------------------------------
-# LLM-based review
-# ---------------------------------------------------------------------------
+# Patterns for orchestrator bookkeeping files that should not count as "agent work".
+# These files are written by the keepalive orchestrator, not the coding agent.
+_BOOKKEEPING_PATTERNS = re.compile(
+    r"(?:^|/)(?:"
+    r"claude-(?:prompt|output)-\d+\.md"
+    r"|codex-(?:prompt|output)-\d+\.md"
+    r"|claude-(?:session|analysis)-\d+\.(?:jsonl|json)"
+    r"|agents/claude-\d+\.md"
+    r"|\.agents/"
+    r"|autofix-[^/]*$"
+    r")",
+)
+
+
+def _filter_bookkeeping_files(files: list[str]) -> list[str]:
+    """Remove orchestrator bookkeeping files that don't represent agent work."""
+    return [f for f in files if not _BOOKKEEPING_PATTERNS.search(f)]
 
 
 def build_review_prompt(
@@ -537,6 +551,34 @@ def review_progress(
     Returns:
         ProgressReviewResult with recommendation and analysis
     """
+    # Filter out orchestrator bookkeeping files (claude-prompt-*.md, etc.)
+    # so they don't inflate alignment scores or file-change counts.
+    files_changed = _filter_bookkeeping_files(files_changed)
+
+    if not files_changed and rounds_without_completion >= 2:
+        return ProgressReviewResult(
+            recommendation="STOP",
+            confidence=0.9,
+            alignment_score=0.0,
+            trajectory="diverging",
+            analysis=ProgressAnalysis(
+                blocking_issues=[
+                    "Zero source files changed across multiple rounds",
+                    "Likely infrastructure failure: auth, permissions, or sandbox",
+                ],
+            ),
+            feedback_for_agent=(
+                "No source files have been modified. This indicates an infrastructure "
+                "issue (authentication, permissions, or sandbox configuration). "
+                "Human intervention is required."
+            ),
+            summary=(
+                f"Zero files changed for {rounds_without_completion} rounds — "
+                "infrastructure failure, not scope drift"
+            ),
+            used_llm=False,
+        )
+
     # Quick heuristic check first
     heuristic_score, aligned, unaligned = heuristic_alignment_check(
         acceptance_criteria, recent_commits, files_changed


### PR DESCRIPTION
## Sync Summary

### Files Updated
- package.json: Node package manifest for .github scripts (vendored minimatch)
- keepalive_loop.js: Core keepalive loop logic
- progress_reviewer.py: Progress reviewer - evaluates agent progress for keepalive rounds

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`