### PR TITLE
Codex bootstrap for #40

### DIFF
--- a/agents/codex-40.md
+++ b/agents/codex-40.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #40 -->

--- a/src/counter_risk/pipeline/ppt_naming.py
+++ b/src/counter_risk/pipeline/ppt_naming.py
@@ -1,0 +1,27 @@
+"""Naming conventions for PowerPoint deliverables produced by pipeline runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+_MASTER_BASE_NAME = "Monthly Counterparty Exposure Report (Master)"
+_DISTRIBUTION_BASE_NAME = "Monthly Counterparty Exposure Report"
+
+
+@dataclass(frozen=True)
+class PptOutputNames:
+    """Resolved output filenames for Master and Distribution PPT deliverables."""
+
+    master_filename: str
+    distribution_filename: str
+
+
+def resolve_ppt_output_names(as_of_date: date) -> PptOutputNames:
+    """Return deterministic PowerPoint output names for a pipeline run date."""
+
+    date_token = as_of_date.isoformat()
+    return PptOutputNames(
+        master_filename=f"{_MASTER_BASE_NAME} - {date_token}.pptx",
+        distribution_filename=f"{_DISTRIBUTION_BASE_NAME} - {date_token}.pptx",
+    )

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import date
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from zipfile import BadZipFile, ZipFile
 
 from counter_risk.config import WorkflowConfig, load_config
@@ -787,7 +787,7 @@ def _remove_external_relationship_targets(xml_bytes: bytes) -> bytes:
 
     if not changed:
         return xml_bytes
-    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return cast(bytes, ET.tostring(root, encoding="utf-8", xml_declaration=True))
 
 
 def _assert_master_preserves_external_link_targets(

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -743,7 +743,9 @@ def test_run_pipeline_invokes_ppt_link_refresh(
     run_dir = run_pipeline(config_path)
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
 
-    assert seen["path"] == run_dir / "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx"
+    assert (
+        seen["path"] == run_dir / "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx"
+    )
     assert "PPT links not refreshed; COM refresh skipped" not in manifest["warnings"]
 
 

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -514,7 +514,7 @@ def test_run_pipeline_warn_mode_writes_mapping_updates_and_completes(
     )
     monkeypatch.setattr(
         "counter_risk.pipeline.run._write_outputs",
-        lambda *, run_dir, config, warnings: (
+        lambda *, run_dir, config, as_of_date, warnings: (
             [],
             run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
         ),

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -200,7 +200,8 @@ def test_run_pipeline_writes_expected_outputs_and_manifest(
         run_dir / "all_programs-mosers-input.xlsx",
         run_dir / "ex_trend-mosers-input.xlsx",
         run_dir / "trend-mosers-input.xlsx",
-        run_dir / "Monthly Counterparty Exposure Report.pptx",
+        run_dir / "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx",
+        run_dir / "Monthly Counterparty Exposure Report - 2025-12-31.pptx",
     ]
     for output_file in expected_outputs:
         assert output_file.exists(), f"Missing output file: {output_file}"
@@ -278,7 +279,7 @@ def test_run_pipeline_generates_all_programs_mosers_from_raw_nisa_input(
     )
     monkeypatch.setattr(
         "counter_risk.pipeline.run._write_outputs",
-        lambda *, run_dir, config, warnings: (
+        lambda *, run_dir, config, as_of_date, warnings: (
             [],
             run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
         ),
@@ -573,8 +574,8 @@ def test_run_pipeline_wraps_output_write_errors(
         lambda *, run_dir, config, parsed_by_variant, as_of_date, warnings: [],
     )
 
-    def _boom(*, run_dir: Path, config: Any, warnings: list[str]) -> list[Path]:
-        _ = (run_dir, config, warnings)
+    def _boom(*, run_dir: Path, config: Any, as_of_date: date, warnings: list[str]) -> list[Path]:
+        _ = (run_dir, config, as_of_date, warnings)
         raise OSError("disk full")
 
     monkeypatch.setattr("counter_risk.pipeline.run._write_outputs", _boom)
@@ -664,7 +665,7 @@ def test_run_pipeline_wraps_manifest_generation_errors(
     )
     monkeypatch.setattr(
         "counter_risk.pipeline.run._write_outputs",
-        lambda *, run_dir, config, warnings: (
+        lambda *, run_dir, config, as_of_date, warnings: (
             [],
             run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
         ),
@@ -742,7 +743,7 @@ def test_run_pipeline_invokes_ppt_link_refresh(
     run_dir = run_pipeline(config_path)
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
 
-    assert seen["path"] == run_dir / "Monthly Counterparty Exposure Report.pptx"
+    assert seen["path"] == run_dir / "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx"
     assert "PPT links not refreshed; COM refresh skipped" not in manifest["warnings"]
 
 
@@ -761,7 +762,7 @@ def test_run_pipeline_ignores_config_output_root_for_run_directory(
     )
     monkeypatch.setattr(
         "counter_risk.pipeline.run._write_outputs",
-        lambda *, run_dir, config, warnings: (
+        lambda *, run_dir, config, as_of_date, warnings: (
             [],
             run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
         ),

--- a/tests/test_pipeline_run_dir.py
+++ b/tests/test_pipeline_run_dir.py
@@ -72,8 +72,10 @@ def test_pipeline_writes_outputs_only_to_repo_root_runs_date_dir(
         output.write_bytes(b"historical")
         return [output]
 
-    def _fake_write_outputs(*, run_dir: Path, config: Any, warnings: list[str]) -> list[Path]:
-        _ = (config, warnings)
+    def _fake_write_outputs(
+        *, run_dir: Path, config: Any, as_of_date: Any, warnings: list[str]
+    ) -> list[Path]:
+        _ = (config, as_of_date, warnings)
         workbook = run_dir / "current-month.xlsx"
         pptx = run_dir / "current-month.pptx"
         workbook.write_bytes(b"monthly-workbook")
@@ -141,8 +143,10 @@ def test_run_directory_creation_same_date_repeat_run_uses_unique_directory_suffi
         output.write_bytes(b"historical")
         return [output]
 
-    def _fake_write_outputs(*, run_dir: Path, config: Any, warnings: list[str]) -> list[Path]:
-        _ = (config, warnings)
+    def _fake_write_outputs(
+        *, run_dir: Path, config: Any, as_of_date: Any, warnings: list[str]
+    ) -> list[Path]:
+        _ = (config, as_of_date, warnings)
         output = run_dir / "current-month.xlsx"
         output.write_bytes(b"monthly-workbook")
         return [output]

--- a/tests/test_pipeline_run_dir.py
+++ b/tests/test_pipeline_run_dir.py
@@ -201,7 +201,7 @@ def test_pipeline_run_directory_includes_run_date_when_configured(
     )
     monkeypatch.setattr(
         "counter_risk.pipeline.run._write_outputs",
-        lambda *, run_dir, config, warnings: [],
+        lambda *, run_dir, config, as_of_date, warnings: [],
     )
 
     run_dir = run_pipeline(config_path)

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from datetime import date
 from zipfile import ZipFile
 
 import counter_risk.pipeline.run as run_module
 from counter_risk.config import WorkflowConfig
+from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
 
 
 def _write_placeholder(path: Path, *, payload: bytes = b"fixture") -> None:
@@ -66,11 +68,21 @@ def test_write_outputs_screenshot_replacement_replaces_expected_number_of_media_
     source_ppt = config.monthly_pptx
     input_media = _read_media_payloads(source_ppt)
 
-    output_paths, _ = run_module._write_outputs(run_dir=run_dir, config=config, warnings=[])
-    output_ppt = run_dir / source_ppt.name
+    as_of_date = date(2025, 12, 31)
+    output_paths, _ = run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=as_of_date,
+        warnings=[],
+    )
+    output_names = resolve_ppt_output_names(as_of_date)
+    output_ppt = run_dir / output_names.master_filename
+    distribution_ppt = run_dir / output_names.distribution_filename
 
     assert output_ppt in output_paths
+    assert distribution_ppt in output_paths
     assert output_ppt.exists()
+    assert distribution_ppt.exists()
     assert output_ppt.read_bytes() != source_ppt.read_bytes()
 
     output_media = _read_media_payloads(output_ppt)

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from datetime import date
+from pathlib import Path
 from zipfile import ZipFile
 
 import counter_risk.pipeline.run as run_module

--- a/tests/test_pipeline_screenshot_replacement.py
+++ b/tests/test_pipeline_screenshot_replacement.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Literal
 from zipfile import ZipFile
-import xml.etree.ElementTree as ET
 
 import pytest
 

--- a/tests/unit/test_ppt_naming.py
+++ b/tests/unit/test_ppt_naming.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import date
+
+from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
+
+
+def test_resolve_ppt_output_names_uses_expected_master_and_distribution_patterns() -> None:
+    names = resolve_ppt_output_names(date(2026, 1, 31))
+
+    assert (
+        names.master_filename == "Monthly Counterparty Exposure Report (Master) - 2026-01-31.pptx"
+    )
+    assert names.distribution_filename == "Monthly Counterparty Exposure Report - 2026-01-31.pptx"
+
+
+def test_resolve_ppt_output_names_is_deterministic_for_same_date() -> None:
+    as_of_date = date(2025, 12, 31)
+
+    first = resolve_ppt_output_names(as_of_date)
+    second = resolve_ppt_output_names(as_of_date)
+
+    assert first == second


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Maintainers may want linked charts for ongoing edits; operators/recipients want a no-surprises deliverable.

#### Tasks
- [x] Define output naming convention for PPT deliverables:
- [ ] Add logic to write the Master PPT output named `Monthly Counterparty Exposure Report (Master) - <as_of_date>.pptx`
- [ ] Add logic to write the Distribution PPT output named `Monthly Counterparty Exposure Report - <as_of_date>.pptx`
- [x] Update the pipeline to generate the Master PPT first (to allow linked refresh), then derive the Distribution PPT from the Master
  - [ ] Implement the Master PPT generation logic with linked chart references (verify: confirm completion in repo)
  - [ ] Implement the Distribution PPT derivation logic that breaks links from the Master (verify: confirm completion in repo)
  - [ ] Define scope for: Add error handling for cases where Master PPT generation fails before Distribution creation (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add error handling for cases where Master PPT generation fails before Distribution creation (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add error handling for cases where Master PPT generation fails before Distribution creation (verify: confirm completion in repo)
  - [ ] Define scope for: Test that the Master-to-Distribution pipeline preserves all content except link metadata (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Test that the Master-to-Distribution pipeline preserves all content except link metadata (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Test that the Master-to-Distribution pipeline preserves all content except link metadata (verify: confirm completion in repo)
- [x] Update the run manifest to include both PPT outputs and document their generation steps
  - [ ] Add fields to the run manifest schema for Master (verify: confirm completion in repo)
  - [ ] Distribution PPT file paths (verify: confirm completion in repo)
  - [ ] Document the generation steps (verify: confirm completion in repo) dependencies between Master (verify: dependencies updated)
  - [ ] Distribution outputs in the manifest (verify: confirm completion in repo)
  - [ ] Define scope for: Update manifest validation logic to ensure both PPT outputs are recorded when enabled (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Update manifest validation logic to ensure both PPT outputs are recorded when enabled (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Update manifest validation logic to ensure both PPT outputs are recorded when enabled (verify: confirm completion in repo)
- [ ] Write an operator-facing README in the run folder that states which PPT file to send externally

#### Acceptance criteria
- [ ] When PPT output is enabled, a run produces both `Monthly Counterparty Exposure Report (Master) - <as_of_date>.pptx` and `Monthly Counterparty Exposure Report - <as_of_date>.pptx`
- [ ] When PPT output is disabled, neither the Master nor Distribution PPT files are written
- [ ] The run folder contains an operator README with non-technical instructions indicating which PPT file to send

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



Topic GUID: 5916927f-2cd4-53bc-9758-e4e4270078f1

## Why
Maintainers may want linked charts for ongoing edits; operators/recipients want a no-surprises deliverable.

## Scope
Define and implement a standard run output structure that always writes both artifacts (when enabled).

## Non-Goals
- Overhauling the existing PPT design

## Tasks
- [ ] Define output naming convention:
- [ ] Master: `Monthly Counterparty Exposure Report (Master) - <as_of_date>.pptx`
- [ ] Distribution: `Monthly Counterparty Exposure Report - <as_of_date>.pptx`
- [ ] Update pipeline to produce Master first (linked refresh), then derive Distribution from Master
- [ ] Update manifest to include both outputs and their generation steps
- [ ] Add a short operator-facing README in the run folder describing which file to send

## Acceptance Criteria
- [ ] Every run that produces PPT output writes both Master and Distribution (unless disabled)
- [ ] Operator instructions are present in the run folder and are non-technical

## Implementation Notes
_Not provided._

---
Synced by [workflow run](https://github.com/stranske/Counter_Risk/actions/runs/21970523258).



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #40

<!-- pr-preamble:end -->