### PR TITLE
test: align pipeline run dir monkeypatch

### DIFF
--- a/tests/test_pipeline_run_dir.py
+++ b/tests/test_pipeline_run_dir.py
@@ -72,8 +72,10 @@ def test_pipeline_writes_outputs_only_to_repo_root_runs_date_dir(
         output.write_bytes(b"historical")
         return [output]
 
-    def _fake_write_outputs(*, run_dir: Path, config: Any, warnings: list[str]) -> list[Path]:
-        _ = (config, warnings)
+    def _fake_write_outputs(
+        *, run_dir: Path, config: Any, as_of_date: Any, warnings: list[str]
+    ) -> list[Path]:
+        _ = (config, as_of_date, warnings)
         workbook = run_dir / "current-month.xlsx"
         pptx = run_dir / "current-month.pptx"
         workbook.write_bytes(b"monthly-workbook")
@@ -141,8 +143,10 @@ def test_run_directory_creation_same_date_repeat_run_uses_unique_directory_suffi
         output.write_bytes(b"historical")
         return [output]
 
-    def _fake_write_outputs(*, run_dir: Path, config: Any, warnings: list[str]) -> list[Path]:
-        _ = (config, warnings)
+    def _fake_write_outputs(
+        *, run_dir: Path, config: Any, as_of_date: Any, warnings: list[str]
+    ) -> list[Path]:
+        _ = (config, as_of_date, warnings)
         output = run_dir / "current-month.xlsx"
         output.write_bytes(b"monthly-workbook")
         return [output]
@@ -197,7 +201,7 @@ def test_pipeline_run_directory_includes_run_date_when_configured(
     )
     monkeypatch.setattr(
         "counter_risk.pipeline.run._write_outputs",
-        lambda *, run_dir, config, warnings: [],
+        lambda *, run_dir, config, as_of_date, warnings: [],
     )
 
     run_dir = run_pipeline(config_path)


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #185

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Maintainers may want linked charts for ongoing edits; operators/recipients want a no-surprises deliverable.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#40](https://github.com/stranske/Counter_Risk/issues/40)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define output naming convention for PPT deliverables:
- [ ] Add logic to write the Master PPT output named `Monthly Counterparty Exposure Report (Master) - <as_of_date>.pptx`
- [ ] Add logic to write the Distribution PPT output named `Monthly Counterparty Exposure Report - <as_of_date>.pptx`
- [ ] Update the pipeline to generate the Master PPT first (to allow linked refresh), then derive the Distribution PPT from the Master
  - [ ] Implement the Master PPT generation logic with linked chart references (verify: confirm completion in repo)
  - [ ] Implement the Distribution PPT derivation logic that breaks links from the Master (verify: confirm completion in repo)
  - [ ] Define scope for: Add error handling for cases where Master PPT generation fails before Distribution creation (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add error handling for cases where Master PPT generation fails before Distribution creation (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add error handling for cases where Master PPT generation fails before Distribution creation (verify: confirm completion in repo)
  - [ ] Define scope for: Test that the Master-to-Distribution pipeline preserves all content except link metadata (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Test that the Master-to-Distribution pipeline preserves all content except link metadata (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Test that the Master-to-Distribution pipeline preserves all content except link metadata (verify: confirm completion in repo)
- [ ] Update the run manifest to include both PPT outputs and document their generation steps
  - [ ] Add fields to the run manifest schema for Master (verify: confirm completion in repo)
  - [ ] Distribution PPT file paths (verify: confirm completion in repo)
  - [ ] Document the generation steps (verify: confirm completion in repo) dependencies between Master (verify: dependencies updated)
  - [ ] Distribution outputs in the manifest (verify: confirm completion in repo)
  - [ ] Define scope for: Update manifest validation logic to ensure both PPT outputs are recorded when enabled (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Update manifest validation logic to ensure both PPT outputs are recorded when enabled (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Update manifest validation logic to ensure both PPT outputs are recorded when enabled (verify: confirm completion in repo)
- [ ] Write an operator-facing README in the run folder that states which PPT file to send externally

#### Acceptance criteria
- [ ] When PPT output is enabled, a run produces both `Monthly Counterparty Exposure Report (Master) - <as_of_date>.pptx` and `Monthly Counterparty Exposure Report - <as_of_date>.pptx`
- [ ] When PPT output is disabled, neither the Master nor Distribution PPT files are written
- [ ] The run folder contains an operator README with non-technical instructions indicating which PPT file to send

**Head SHA:** 6f027581b0596f4e559471b91e89aeb9c68a4278
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253105991) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253129429) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253129426) |
| Claude Code Review | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253108510) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253108897) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253108550) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253108567) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22253108523) |
<!-- auto-status-summary:end -->