### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2646,7 +2646,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       : actionRunsAgent
         ? 0
         : previousZeroActivityRounds;
-    const metricsIteration = nextIteration;
+    const metricsIteration = actionRunsAgent ? currentIteration + 1 : currentIteration;
     const durationMs = resolveDurationMs({
       durationMs: toOptionalNumber(inputs.duration_ms ?? inputs.durationMs),
       startTs: toOptionalNumber(inputs.start_ts ?? inputs.startTs),

--- a/.github/scripts/node_modules/minimatch/package.json
+++ b/.github/scripts/node_modules/minimatch/package.json
@@ -3,7 +3,7 @@
   "name": "minimatch",
   "description": "a glob matcher in javascript",
   "version": "10.0.1-vendored",
-  "_comment": "Vendored subset of minimatch for internal scripts.",
+  "_comment": "Vendored subset of minimatch for internal scripts (matches upstream version).",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/minimatch.git"
@@ -26,19 +26,6 @@
   "files": [
     "dist"
   ],
-  "scripts": {
-    "preversion": "npm test",
-    "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
-    "prepare": "tshy",
-    "pretest": "npm run prepare",
-    "presnap": "npm run prepare",
-    "test": "tap",
-    "snap": "tap",
-    "format": "prettier --write . --loglevel warn",
-    "benchmark": "node benchmark/index.js",
-    "typedoc": "typedoc --tsconfig tsconfig-esm.json ./src/*.ts"
-  },
   "prettier": {
     "semi": false,
     "printWidth": 80,
@@ -56,28 +43,9 @@
   "dependencies": {
     "brace-expansion": "^2.0.1"
   },
-  "devDependencies": {
-    "@types/brace-expansion": "^1.1.0",
-    "@types/node": "^18.15.11",
-    "@types/tap": "^15.0.8",
-    "eslint-config-prettier": "^8.6.0",
-    "mkdirp": "1",
-    "prettier": "^2.8.2",
-    "tap": "^18.7.2",
-    "ts-node": "^10.9.1",
-    "tshy": "^1.12.0",
-    "typedoc": "^0.23.21",
-    "typescript": "^4.9.3"
-  },
   "funding": {
     "url": "https://github.com/sponsors/isaacs"
   },
   "license": "ISC",
-  "tshy": {
-    "exports": {
-      "./package.json": "./package.json",
-      ".": "./src/index.ts"
-    }
-  },
   "type": "module"
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "minimatch": "10.0.1"
+    "minimatch": "file:node_modules/minimatch"
   }
 }

--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -30,15 +30,18 @@ env:
         secrets.ACTIONS_BOT_PAT ||
         secrets.SERVICE_BOT_PAT ||
         github.token }}
-  MANUAL_GATE_RUN_ID: ${{ inputs.gate_run_id || '' }}
-  MANUAL_PR_NUMBER: ${{ inputs.pr_number || '' }}
-  MANUAL_HEAD_SHA: ${{ inputs.head_sha || '' }}
+  MANUAL_GATE_RUN_ID: >-
+    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_run_id || '' }}
+  MANUAL_PR_NUMBER: >-
+    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || '' }}
+  MANUAL_HEAD_SHA: >-
+    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.head_sha || '' }}
 
 concurrency:
   group: >-
     agents-autofix-loop-${{
-      github.event.workflow_run.pull_requests[0].number ||
-      inputs.pr_number ||
+      (github.event.workflow_run && github.event.workflow_run.pull_requests[0].number) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number) ||
       github.run_id
     }}
   cancel-in-progress: false


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-autofix-loop.yml: Autofix loop - dispatches Codex when autofix can't fix Gate failures (deprecated; replaced by agents-81-gate-followups.yml, removal no earlier than 2026-02-15)
- package.json: Node package manifest for .github scripts (vendored minimatch)
- minimatch/ (1 files): Vendored minimatch dependency for .github scripts
- keepalive_loop.js: Core keepalive loop logic

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`