### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -91,6 +91,61 @@ runs:
         echo "📦 Installing @octokit dependencies in $INSTALL_DIR..."
         cd "$INSTALL_DIR"
 
+        declare -a VENDORED_ALIAS_DIRS=()
+
+        cleanup_vendor_aliases() {
+          if [ "${#VENDORED_ALIAS_DIRS[@]}" -gt 0 ]; then
+            for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
+              rm -rf "$vendored_alias" || true
+              local parent
+              parent=$(dirname "$vendored_alias")
+              if [ "$parent" != "." ]; then
+                rmdir "$parent" 2>/dev/null || true
+              fi
+            done
+          fi
+        }
+
+        trap cleanup_vendor_aliases EXIT
+
+        create_vendor_aliases() {
+          if [ ! -f "package.json" ]; then
+            return 0
+          fi
+
+          local aliases=()
+          mapfile -t aliases < <(
+            node -e 'const fs=require("fs");const path=require("path");const pkgPath=path.resolve("package.json");if(!fs.existsSync(pkgPath)){process.exit(0);}const pkg=JSON.parse(fs.readFileSync(pkgPath,"utf8"));const sections=[pkg.dependencies||{},pkg.devDependencies||{}];const seen=new Set();for(const section of sections){for(const spec of Object.values(section)){if(typeof spec==="string"&&spec.startsWith("file:node_modules/")){const trimmed=spec.slice("file:node_modules/".length).replace(/\/+$/,"");if(trimmed){seen.add(trimmed);}}}}process.stdout.write(Array.from(seen).join("\n"));'
+          )
+
+          for vendored_alias in "${aliases[@]}"; do
+            if [ -z "$vendored_alias" ]; then
+              continue
+            fi
+            local source_path="node_modules/${vendored_alias}"
+            if [ ! -d "$source_path" ]; then
+              continue
+            fi
+            if [ -e "$vendored_alias" ]; then
+              continue
+            fi
+            local parent_dir
+            parent_dir=$(dirname "$vendored_alias")
+            if [ "$parent_dir" != "." ]; then
+              mkdir -p "$parent_dir"
+            fi
+            rm -rf "$vendored_alias" || true
+            cp -R "$source_path" "$vendored_alias"
+            VENDORED_ALIAS_DIRS+=("$vendored_alias")
+          done
+        }
+
+        create_vendor_aliases
+
+        # npm scripts for vendored packages can invoke missing tools (tshy, etc.).
+        # Disable lifecycle scripts globally for this step.
+        export npm_config_ignore_scripts=true
+
         # Track if we create package.json so we can clean it up
         CREATED_PACKAGE_JSON=false
         if [ ! -f "package.json" ]; then
@@ -154,6 +209,9 @@ runs:
 
           echo "✅ @octokit dependencies installed"
         fi
+
+        cleanup_vendor_aliases
+        trap - EXIT
 
     - name: Export NODE_PATH for shared deps
       shell: bash

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2646,7 +2646,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       : actionRunsAgent
         ? 0
         : previousZeroActivityRounds;
-    const metricsIteration = nextIteration;
+    const metricsIteration = actionRunsAgent ? currentIteration + 1 : currentIteration;
     const durationMs = resolveDurationMs({
       durationMs: toOptionalNumber(inputs.duration_ms ?? inputs.durationMs),
       startTs: toOptionalNumber(inputs.start_ts ?? inputs.startTs),

--- a/.github/scripts/node_modules/minimatch/package.json
+++ b/.github/scripts/node_modules/minimatch/package.json
@@ -3,7 +3,7 @@
   "name": "minimatch",
   "description": "a glob matcher in javascript",
   "version": "10.0.1-vendored",
-  "_comment": "Vendored subset of minimatch for internal scripts.",
+  "_comment": "Vendored subset of minimatch for internal scripts (matches upstream version).",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/minimatch.git"
@@ -26,19 +26,6 @@
   "files": [
     "dist"
   ],
-  "scripts": {
-    "preversion": "npm test",
-    "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
-    "prepare": "tshy",
-    "pretest": "npm run prepare",
-    "presnap": "npm run prepare",
-    "test": "tap",
-    "snap": "tap",
-    "format": "prettier --write . --loglevel warn",
-    "benchmark": "node benchmark/index.js",
-    "typedoc": "typedoc --tsconfig tsconfig-esm.json ./src/*.ts"
-  },
   "prettier": {
     "semi": false,
     "printWidth": 80,
@@ -56,28 +43,9 @@
   "dependencies": {
     "brace-expansion": "^2.0.1"
   },
-  "devDependencies": {
-    "@types/brace-expansion": "^1.1.0",
-    "@types/node": "^18.15.11",
-    "@types/tap": "^15.0.8",
-    "eslint-config-prettier": "^8.6.0",
-    "mkdirp": "1",
-    "prettier": "^2.8.2",
-    "tap": "^18.7.2",
-    "ts-node": "^10.9.1",
-    "tshy": "^1.12.0",
-    "typedoc": "^0.23.21",
-    "typescript": "^4.9.3"
-  },
   "funding": {
     "url": "https://github.com/sponsors/isaacs"
   },
   "license": "ISC",
-  "tshy": {
-    "exports": {
-      "./package.json": "./package.json",
-      ".": "./src/index.ts"
-    }
-  },
   "type": "module"
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "minimatch": "10.0.1"
+    "minimatch": "file:node_modules/minimatch"
   }
 }


### PR DESCRIPTION
## Sync Summary

### Files Updated
- package.json: Node package manifest for .github scripts (vendored minimatch)
- minimatch/ (1 files): Vendored minimatch dependency for .github scripts
- keepalive_loop.js: Core keepalive loop logic
- setup-api-client/ (1 files): Unified API client setup - installs @octokit deps and exports all load balancer tokens

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`