### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -91,6 +91,84 @@ runs:
         echo "📦 Installing @octokit dependencies in $INSTALL_DIR..."
         cd "$INSTALL_DIR"
 
+        declare -a VENDORED_ALIAS_DIRS=()
+
+        cleanup_vendor_aliases() {
+          if [ "${#VENDORED_ALIAS_DIRS[@]}" -eq 0 ]; then
+            return 0
+          fi
+
+          local cleanup_dir="$INSTALL_DIR"
+          if [ -z "$cleanup_dir" ]; then
+            echo "::warning::Install dir is empty, skipping vendored alias cleanup"
+            return 0
+          fi
+
+          if ! pushd "$cleanup_dir" >/dev/null 2>&1; then
+            echo "::warning::Failed to enter install dir \"$cleanup_dir\"; skipping vendored alias cleanup"
+            return 0
+          fi
+
+          for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
+            if [ -z "$vendored_alias" ]; then
+              continue
+            fi
+            rm -rf -- "$vendored_alias" || true
+            local parent_dir
+            parent_dir=$(dirname "$vendored_alias")
+            # Remove empty parent directories that may have been created for scoped packages
+            while [ "$parent_dir" != "." ] && [ "$parent_dir" != "/" ]; do
+              rmdir -- "$parent_dir" 2>/dev/null || break
+              parent_dir=$(dirname "$parent_dir")
+            done
+          done
+
+          popd >/dev/null 2>&1 || true
+        }
+
+        trap cleanup_vendor_aliases EXIT
+
+        create_vendor_aliases() {
+          if [ ! -f "package.json" ]; then
+            return 0
+          fi
+
+          local alias_tmp
+          alias_tmp=$(mktemp)
+
+          local helper_root="${GITHUB_ACTION_PATH:-${GITHUB_WORKSPACE}/.github/actions/setup-api-client}"
+          local alias_helper="${helper_root}/create_vendor_aliases.js"
+          if [ ! -f "$alias_helper" ]; then
+            echo "::error::Missing vendored alias helper: $alias_helper"
+            rm -f "$alias_tmp"
+            return 1
+          fi
+
+          if node "$alias_helper" "$INSTALL_DIR" >"$alias_tmp"; then
+            :
+          else
+            echo "::error::Failed to prepare vendored dependency aliases"
+            rm -f "$alias_tmp"
+            return 1
+          fi
+
+          while IFS= read -r vendored_alias; do
+            if [ -z "$vendored_alias" ]; then
+              continue
+            fi
+            VENDORED_ALIAS_DIRS+=("$vendored_alias")
+          done <"$alias_tmp"
+
+          rm -f "$alias_tmp"
+        }
+
+        create_vendor_aliases
+
+        # Vendored packages often ship lifecycle scripts (tshy builds, custom bundlers, etc.)
+        # that expect repo-specific tooling. Disable lifecycle scripts globally so npm install
+        # never invokes those hooks inside CI.
+        export npm_config_ignore_scripts=true
+
         # Track if we create package.json so we can clean it up
         CREATED_PACKAGE_JSON=false
         if [ ! -f "package.json" ]; then
@@ -121,22 +199,23 @@ runs:
           # Install with pinned versions for consistency
           # Capture stderr for debugging if the command fails
           npm_output=$(mktemp)
-          if npm install --no-save --location=project \
+          npm_cmd=(npm install --no-save --location=project \
             @octokit/rest@20.0.2 \
             @octokit/plugin-retry@6.0.1 \
             @octokit/plugin-paginate-rest@9.1.5 \
-            @octokit/auth-app@6.0.3 \
-            2>"$npm_output"; then
+            @octokit/auth-app@6.0.3)
+          if "${npm_cmd[@]}" 2>"$npm_output"; then
             rm -f "$npm_output"
           else
             echo "::warning::npm install failed with: $(cat "$npm_output")"
             echo "::warning::Retrying with --legacy-peer-deps"
             rm -f "$npm_output"
-            npm install --no-save --legacy-peer-deps --location=project \
+            npm_cmd=(npm install --no-save --legacy-peer-deps --location=project \
               @octokit/rest@20.0.2 \
               @octokit/plugin-retry@6.0.1 \
               @octokit/plugin-paginate-rest@9.1.5 \
-              @octokit/auth-app@6.0.3
+              @octokit/auth-app@6.0.3)
+            "${npm_cmd[@]}"
           fi
 
           # Restore vendored package metadata that npm may have overwritten
@@ -155,6 +234,8 @@ runs:
           echo "✅ @octokit dependencies installed"
         fi
 
+        cleanup_vendor_aliases
+        trap - EXIT
     - name: Export NODE_PATH for shared deps
       shell: bash
       run: |

--- a/.github/actions/setup-api-client/create_vendor_aliases.js
+++ b/.github/actions/setup-api-client/create_vendor_aliases.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const installDirArg = process.argv[2];
+
+if (!installDirArg) {
+  console.error('Usage: create_vendor_aliases.js <install_dir>');
+  process.exit(1);
+}
+
+const installDir = path.resolve(installDirArg);
+const pkgPath = path.join(installDir, 'package.json');
+
+if (!fs.existsSync(pkgPath)) {
+  console.info(`::notice::setup-api-client: ${pkgPath} not found; skipping vendored alias creation.`);
+  process.exit(0);
+}
+
+let pkg;
+try {
+  const pkgRaw = fs.readFileSync(pkgPath, 'utf8');
+  pkg = JSON.parse(pkgRaw);
+} catch (error) {
+  console.error(`::error::Failed to parse ${pkgPath}: ${error.message}`);
+  process.exit(1);
+}
+const sections = [pkg.dependencies || {}, pkg.devDependencies || {}];
+const seen = new Set();
+
+for (const section of sections) {
+  for (const spec of Object.values(section)) {
+    if (typeof spec === 'string' && spec.startsWith('file:node_modules/')) {
+      const trimmed = spec.slice('file:node_modules/'.length).replace(/\/+$/, '');
+      if (trimmed) {
+        seen.add(trimmed);
+      }
+    }
+  }
+}
+
+const sanitize = (value) => {
+  if (typeof value !== 'string') {
+    throw new Error('Vendored alias must be a string');
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error('Vendored alias cannot be empty');
+  }
+  if (normalized.startsWith('/') || normalized.startsWith('./') || normalized.startsWith('../')) {
+    throw new Error(`Vendored alias must be relative: "${normalized}"`);
+  }
+  if (normalized.includes('\\')) {
+    throw new Error(`Vendored alias must not contain backslashes: "${normalized}"`);
+  }
+
+  const segments = normalized.split('/');
+  if (segments[0].startsWith('@')) {
+    if (!/^@[A-Za-z0-9._-]+$/.test(segments[0])) {
+      throw new Error(`Invalid scope in vendored alias: "${normalized}"`);
+    }
+    if (segments.length < 2) {
+      throw new Error(`Scoped vendored alias must include a package name: "${normalized}"`);
+    }
+  }
+
+  const segmentPattern = /^[A-Za-z0-9._-]+$/;
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    if (!segment || segment === '.' || segment === '..') {
+      throw new Error(`Invalid path segment "${segment}" in "${normalized}"`);
+    }
+    if (segment.startsWith('@')) {
+      if (i !== 0 || !/^@[A-Za-z0-9._-]+$/.test(segment)) {
+        throw new Error(`Invalid scope segment "${segment}" in "${normalized}"`);
+      }
+      continue;
+    }
+    if (!segmentPattern.test(segment)) {
+      throw new Error(`Vendored alias segment "${segment}" contains invalid characters in "${normalized}"`);
+    }
+  }
+
+  return segments.join('/');
+};
+
+const resolveInsideInstallDir = (target, label) => {
+  const resolved = path.resolve(target);
+  const relative = path.relative(installDir, resolved);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Resolved vendored alias outside install dir: "${label}"`);
+  }
+  return resolved;
+};
+
+const created = [];
+for (const alias of seen) {
+  const sanitized = sanitize(alias);
+  const source = path.join(installDir, 'node_modules', sanitized);
+  if (!fs.existsSync(source)) {
+    console.warn(`::warning::Vendored dependency not found: ${sanitized}`);
+    continue;
+  }
+  const destination = path.join(installDir, sanitized);
+  const normalizedDestination = resolveInsideInstallDir(destination, sanitized);
+  const destinationDir = path.dirname(normalizedDestination);
+  fs.rmSync(normalizedDestination, { recursive: true, force: true });
+  fs.mkdirSync(destinationDir, { recursive: true });
+  fs.cpSync(source, normalizedDestination, { recursive: true });
+  created.push(sanitized);
+}
+
+if (created.length > 0) {
+  process.stdout.write(`${created.join('\n')}\n`);
+}

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2646,7 +2646,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       : actionRunsAgent
         ? 0
         : previousZeroActivityRounds;
-    const metricsIteration = nextIteration;
+    const metricsIteration = actionRunsAgent ? currentIteration + 1 : currentIteration;
     const durationMs = resolveDurationMs({
       durationMs: toOptionalNumber(inputs.duration_ms ?? inputs.durationMs),
       startTs: toOptionalNumber(inputs.start_ts ?? inputs.startTs),

--- a/.github/scripts/node_modules/minimatch/package.json
+++ b/.github/scripts/node_modules/minimatch/package.json
@@ -3,7 +3,7 @@
   "name": "minimatch",
   "description": "a glob matcher in javascript",
   "version": "10.0.1-vendored",
-  "_comment": "Vendored subset of minimatch for internal scripts.",
+  "_comment": "Vendored subset of minimatch for internal scripts (matches upstream version).",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/minimatch.git"
@@ -26,19 +26,6 @@
   "files": [
     "dist"
   ],
-  "scripts": {
-    "preversion": "npm test",
-    "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
-    "prepare": "tshy",
-    "pretest": "npm run prepare",
-    "presnap": "npm run prepare",
-    "test": "tap",
-    "snap": "tap",
-    "format": "prettier --write . --loglevel warn",
-    "benchmark": "node benchmark/index.js",
-    "typedoc": "typedoc --tsconfig tsconfig-esm.json ./src/*.ts"
-  },
   "prettier": {
     "semi": false,
     "printWidth": 80,
@@ -56,28 +43,9 @@
   "dependencies": {
     "brace-expansion": "^2.0.1"
   },
-  "devDependencies": {
-    "@types/brace-expansion": "^1.1.0",
-    "@types/node": "^18.15.11",
-    "@types/tap": "^15.0.8",
-    "eslint-config-prettier": "^8.6.0",
-    "mkdirp": "1",
-    "prettier": "^2.8.2",
-    "tap": "^18.7.2",
-    "ts-node": "^10.9.1",
-    "tshy": "^1.12.0",
-    "typedoc": "^0.23.21",
-    "typescript": "^4.9.3"
-  },
   "funding": {
     "url": "https://github.com/sponsors/isaacs"
   },
   "license": "ISC",
-  "tshy": {
-    "exports": {
-      "./package.json": "./package.json",
-      ".": "./src/index.ts"
-    }
-  },
   "type": "module"
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "minimatch": "10.0.1"
+    "minimatch": "file:node_modules/minimatch"
   }
 }

--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -30,15 +30,18 @@ env:
         secrets.ACTIONS_BOT_PAT ||
         secrets.SERVICE_BOT_PAT ||
         github.token }}
-  MANUAL_GATE_RUN_ID: ${{ inputs.gate_run_id || '' }}
-  MANUAL_PR_NUMBER: ${{ inputs.pr_number || '' }}
-  MANUAL_HEAD_SHA: ${{ inputs.head_sha || '' }}
+  MANUAL_GATE_RUN_ID: >-
+    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_run_id || '' }}
+  MANUAL_PR_NUMBER: >-
+    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || '' }}
+  MANUAL_HEAD_SHA: >-
+    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.head_sha || '' }}
 
 concurrency:
   group: >-
     agents-autofix-loop-${{
-      github.event.workflow_run.pull_requests[0].number ||
-      inputs.pr_number ||
+      (github.event.workflow_run && github.event.workflow_run.pull_requests[0].number) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number) ||
       github.run_id
     }}
   cancel-in-progress: false

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -45,10 +45,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts/agents-guard.js
             .github/scripts/github-api-with-retry.js
+            .github/scripts/package.json
+            .github/scripts/package-lock.json
+            .github/scripts/node_modules/minimatch
+            .github/scripts/node_modules/minimatch/**
             .github/scripts/token_load_balancer.js
             .github/workflows/agents-guard.yml
 
@@ -101,10 +106,15 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v6
         with:
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts/agents-guard.js
             .github/scripts/github-api-with-retry.js
+            .github/scripts/package.json
+            .github/scripts/package-lock.json
+            .github/scripts/node_modules/minimatch
+            .github/scripts/node_modules/minimatch/**
             .github/scripts/token_load_balancer.js
             .github/workflows/agents-guard.yml
       - name: Check API client action (head)


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-autofix-loop.yml: Autofix loop - dispatches Codex when autofix can't fix Gate failures (deprecated; replaced by agents-81-gate-followups.yml, removal no earlier than 2026-02-15)
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)
- package.json: Node package manifest for .github scripts (vendored minimatch)
- minimatch/ (1 files): Vendored minimatch dependency for .github scripts
- keepalive_loop.js: Core keepalive loop logic
- setup-api-client/ (2 files): Unified API client setup - installs @octokit deps and exports all load balancer tokens

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`