### PR TITLE
Codex bootstrap for #236

### DIFF
--- a/agents/codex-236.md
+++ b/agents/codex-236.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #236 -->

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -28,6 +28,7 @@ from counter_risk.pipeline.parsing_types import (
 )
 from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
 from counter_risk.pipeline.ppt_validation import validate_distribution_ppt_standalone
+from counter_risk.pipeline.run_folder_outputs import build_run_folder_readme_content
 from counter_risk.pipeline.time_utils import utc_now_isoformat
 from counter_risk.writers import generate_mosers_workbook
 
@@ -944,6 +945,10 @@ def _write_outputs(
         warnings=warnings,
     )
     output_paths.extend(static_output_paths)
+    if config.ppt_output_enabled and any(path.suffix.lower() == ".pptx" for path in output_paths):
+        readme_path = run_dir / "README.txt"
+        readme_path.write_text(build_run_folder_readme_content(as_of_date), encoding="utf-8")
+        output_paths.append(readme_path)
 
     LOGGER.info("write_outputs_complete output_count=%s", len(output_paths))
     return output_paths, refresh_result

--- a/tests/compute/test_futures_delta.py
+++ b/tests/compute/test_futures_delta.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -17,7 +17,7 @@ from counter_risk.compute.futures_delta import (
 
 def _records(result: Any) -> list[dict[str, Any]]:
     if hasattr(result, "to_dict"):
-        return result.to_dict(orient="records")
+        return cast(list[dict[str, Any]], result.to_dict(orient="records"))
     return [dict(row) for row in result]
 
 

--- a/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
+++ b/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from datetime import date
 from pathlib import Path
 
@@ -9,6 +10,8 @@ import pytest
 
 import counter_risk.pipeline.run as run_module
 from counter_risk.config import WorkflowConfig
+from counter_risk.pipeline.manifest import ManifestBuilder
+from counter_risk.pipeline.ppt_validation import PptStandaloneValidationResult
 
 
 def _write_placeholder(path: Path, *, payload: bytes = b"fixture") -> None:
@@ -137,3 +140,91 @@ def test_master_refresh_failure_logs_error_and_skips_distribution_derivation(
         path.name != "Monthly Counterparty Exposure Report - 2025-12-31.pptx"
         for path in output_paths
     )
+
+
+def test_ppt_enabled_order_master_generated_before_distribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, enable_ppt_output=True)
+    config.enable_screenshot_replacement = True
+
+    call_order: list[str] = []
+
+    def _replace_master(source: Path, target: Path, screenshot_inputs: dict[str, Path]) -> None:
+        _ = screenshot_inputs
+        call_order.append("master_generation")
+        shutil.copy2(source, target)
+
+    def _refresh_links(_path: Path) -> run_module.PptProcessingResult:
+        call_order.append("master_refresh")
+        return run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS)
+
+    def _derive_distribution(*, master_pptx_path: Path, distribution_pptx_path: Path) -> None:
+        call_order.append("distribution_derivation")
+        shutil.copy2(master_pptx_path, distribution_pptx_path)
+
+    monkeypatch.setattr(run_module, "_resolve_screenshot_input_mapping", lambda _config: {})
+    monkeypatch.setattr(run_module, "_get_screenshot_replacer", lambda _impl: _replace_master)
+    monkeypatch.setattr(run_module, "_refresh_ppt_links", _refresh_links)
+    monkeypatch.setattr(run_module, "_derive_distribution_ppt", _derive_distribution)
+    monkeypatch.setattr(
+        run_module,
+        "validate_distribution_ppt_standalone",
+        lambda _path: PptStandaloneValidationResult(
+            is_valid=True,
+            external_relationship_count=0,
+            relationship_parts_scanned=(),
+            external_relationship_parts=(),
+        ),
+    )
+
+    run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=date(2025, 12, 31),
+        warnings=[],
+    )
+
+    assert call_order.index("master_generation") < call_order.index("distribution_derivation")
+    assert call_order.count("distribution_derivation") == 1
+
+
+def test_no_distribution_without_master_when_master_generation_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, enable_ppt_output=True)
+    as_of_date = date(2025, 12, 31)
+    distribution_name = f"Monthly Counterparty Exposure Report - {as_of_date.isoformat()}.pptx"
+
+    def _refresh_raises(_path: Path) -> run_module.PptProcessingResult:
+        raise RuntimeError("refresh exploded")
+
+    monkeypatch.setattr(run_module, "_refresh_ppt_links", _refresh_raises)
+
+    output_paths, _ppt_result = run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=as_of_date,
+        warnings=[],
+    )
+
+    assert not (run_dir / distribution_name).exists()
+
+    manifest = ManifestBuilder(
+        config=config,
+        as_of_date=as_of_date,
+        run_date=date(2026, 1, 2),
+    ).build(
+        run_dir=run_dir,
+        input_hashes={},
+        output_paths=output_paths,
+        top_exposures={},
+        top_changes_per_variant={},
+        warnings=[],
+        ppt_status=run_module.PptProcessingStatus.FAILED.value,
+    )
+    assert all(Path(path).name != distribution_name for path in manifest["output_paths"])

--- a/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
+++ b/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
@@ -53,7 +53,7 @@ def test_ppt_disabled_skips_ppt_entrypoint_and_produces_no_pptx(
     run_dir.mkdir(parents=True)
     config = _build_config(tmp_path, enable_ppt_output=False)
 
-    def _unexpected_call(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def _unexpected_call(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         raise AssertionError("PPT code path should not be called when PPT output is disabled")
 
@@ -112,7 +112,7 @@ def test_master_refresh_failure_logs_error_and_skips_distribution_derivation(
     def _refresh_raises(_path: Path) -> run_module.PptProcessingResult:
         raise RuntimeError("refresh exploded")
 
-    def _derive_distribution(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def _derive_distribution(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         calls["distribution"] += 1
 

--- a/tests/pipeline/test_run_folder_readme.py
+++ b/tests/pipeline/test_run_folder_readme.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import re
 from datetime import date
+from pathlib import Path
 
+import pytest
+
+import counter_risk.pipeline.run as run_module
+from counter_risk.config import WorkflowConfig
 from counter_risk.pipeline.run_folder_outputs import build_run_folder_readme_content
 
 
@@ -20,3 +25,80 @@ def test_readme_content_includes_filenames_and_three_numbered_steps_in_order() -
     assert step_2 is not None
     assert step_3 is not None
     assert step_1.start() < step_2.start() < step_3.start()
+
+
+def _write_placeholder(path: Path, *, payload: bytes = b"fixture") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _build_config(tmp_path: Path, *, enable_ppt_output: bool) -> WorkflowConfig:
+    inputs_dir = tmp_path / "inputs"
+    files = {
+        "all_programs": inputs_dir / "all_programs.xlsx",
+        "ex_trend": inputs_dir / "ex_trend.xlsx",
+        "trend": inputs_dir / "trend.xlsx",
+        "hist_all": inputs_dir / "hist_all.xlsx",
+        "hist_ex": inputs_dir / "hist_ex.xlsx",
+        "hist_llc": inputs_dir / "hist_llc.xlsx",
+    }
+    for input_path in files.values():
+        _write_placeholder(input_path)
+
+    return WorkflowConfig(
+        mosers_all_programs_xlsx=files["all_programs"],
+        mosers_ex_trend_xlsx=files["ex_trend"],
+        mosers_trend_xlsx=files["trend"],
+        hist_all_programs_3yr_xlsx=files["hist_all"],
+        hist_ex_llc_3yr_xlsx=files["hist_ex"],
+        hist_llc_3yr_xlsx=files["hist_llc"],
+        monthly_pptx=Path("tests/fixtures/Monthly Counterparty Exposure Report.pptx"),
+        output_root=tmp_path / "ignored-output-root",
+        enable_screenshot_replacement=False,
+        enable_ppt_output=enable_ppt_output,
+    )
+
+
+def test_run_folder_readme_created_when_ppt_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, enable_ppt_output=True)
+
+    monkeypatch.setattr(
+        run_module,
+        "_refresh_ppt_links",
+        lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
+    )
+
+    run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=date(2026, 1, 31),
+        warnings=[],
+    )
+
+    readme_path = run_dir / "README.txt"
+    assert readme_path.exists()
+    content = readme_path.read_text(encoding="utf-8")
+    assert "Monthly Counterparty Exposure Report (Master) - 2026-01-31.pptx" in content
+    assert "Monthly Counterparty Exposure Report - 2026-01-31.pptx" in content
+    assert "\n1." in content
+    assert "\n2." in content
+    assert "\n3." in content
+
+
+def test_run_folder_readme_not_created_when_ppt_disabled(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, enable_ppt_output=False)
+
+    run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=date(2026, 1, 31),
+        warnings=[],
+    )
+
+    assert not (run_dir / "README.txt").exists()

--- a/tests/pipeline/test_run_manifest_ppt_entries.py
+++ b/tests/pipeline/test_run_manifest_ppt_entries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from counter_risk.pipeline.manifest_schema import validate_manifest_ppt_outputs
 
@@ -28,7 +29,7 @@ def test_manifest_ppt_enabled_contains_both_outputs_with_existing_paths(tmp_path
     master.write_bytes(b"master")
     distribution.write_bytes(b"distribution")
 
-    manifest = {
+    manifest: dict[str, Any] = {
         "as_of_date": "2025-12-31",
         "run_date": "2026-01-02",
         "ppt_outputs": {

--- a/tests/pipeline/test_run_manifest_ppt_entries.py
+++ b/tests/pipeline/test_run_manifest_ppt_entries.py
@@ -43,3 +43,43 @@ def test_manifest_ppt_enabled_contains_both_outputs_with_existing_paths(tmp_path
     assert error is None
     assert Path(manifest["ppt_outputs"]["master"]["path"]).exists()
     assert Path(manifest["ppt_outputs"]["distribution"]["path"]).exists()
+
+
+def test_manifest_schema_ppt_rejects_only_master_entry(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    master = run_dir / "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx"
+    master.write_bytes(b"master")
+
+    manifest = {
+        "as_of_date": "2025-12-31",
+        "run_date": "2026-01-02",
+        "ppt_outputs": {
+            "master": {"path": str(master.resolve())},
+        },
+    }
+
+    is_valid, error = validate_manifest_ppt_outputs(manifest, ppt_enabled=True)
+
+    assert is_valid is False
+    assert error == "Manifest ppt_outputs is missing required Distribution PPT entry."
+
+
+def test_manifest_schema_ppt_rejects_only_distribution_entry(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    distribution = run_dir / "Monthly Counterparty Exposure Report - 2025-12-31.pptx"
+    distribution.write_bytes(b"distribution")
+
+    manifest = {
+        "as_of_date": "2025-12-31",
+        "run_date": "2026-01-02",
+        "ppt_outputs": {
+            "distribution": {"path": str(distribution.resolve())},
+        },
+    }
+
+    is_valid, error = validate_manifest_ppt_outputs(manifest, ppt_enabled=True)
+
+    assert is_valid is False
+    assert error == "Manifest ppt_outputs is missing required Master PPT entry."

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -95,13 +95,15 @@ def test_write_outputs_screenshot_replacement_replaces_expected_number_of_media_
     assert len(changed_media_parts) == len(screenshot_inputs)
 
 
-def test_write_outputs_skips_all_ppt_generation_when_disabled(tmp_path: Path, monkeypatch) -> None:
+def test_write_outputs_skips_all_ppt_generation_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     run_dir = tmp_path / "run"
     run_dir.mkdir(parents=True)
     config = _build_config(tmp_path, screenshot_inputs={})
     config = config.model_copy(update={"enable_ppt_output": False})
 
-    def _unexpected_call(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def _unexpected_call(*args: object, **kwargs: object) -> None:
         raise AssertionError("PPT generation should not be called when PPT output is disabled")
 
     monkeypatch.setattr(run_module, "_get_screenshot_replacer", _unexpected_call)
@@ -136,7 +138,7 @@ def test_write_outputs_skips_distribution_when_master_refresh_fails(
             error_detail="forced refresh failure",
         )
 
-    def _derive_distribution(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def _derive_distribution(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         called["derive_distribution"] += 1
 
@@ -173,7 +175,7 @@ def test_write_outputs_handles_master_refresh_exception_and_logs_error(
     def _refresh_raises(_path: Path) -> run_module.PptProcessingResult:
         raise RuntimeError("refresh exploded")
 
-    def _derive_distribution(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def _derive_distribution(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         called["derive_distribution"] += 1
 

--- a/tests/test_pipeline_screenshot_replacement.py
+++ b/tests/test_pipeline_screenshot_replacement.py
@@ -130,13 +130,13 @@ def test_write_outputs_calls_zip_backend_once_when_enabled(
     assert list(calls[0].mapping) == ["slide1", "slide2"]
     assert len(calls[0].mapping) == 2
     assert all(path.suffix.lower() == ".png" for path in calls[0].mapping.values())
-    assert (
-        output_paths[-2]
-        == run_dir / "Monthly Counterparty Exposure Report (Master) - 2026-02-13.pptx"
-    )
-    assert output_paths[-1] == run_dir / "Monthly Counterparty Exposure Report - 2026-02-13.pptx"
-    assert (run_dir / "Monthly Counterparty Exposure Report (Master) - 2026-02-13.pptx").exists()
-    assert (run_dir / "Monthly Counterparty Exposure Report - 2026-02-13.pptx").exists()
+    master = run_dir / "Monthly Counterparty Exposure Report (Master) - 2026-02-13.pptx"
+    distribution = run_dir / "Monthly Counterparty Exposure Report - 2026-02-13.pptx"
+    assert master in output_paths
+    assert distribution in output_paths
+    assert output_paths.index(master) < output_paths.index(distribution)
+    assert master.exists()
+    assert distribution.exists()
     assert all("not implemented" not in warning for warning in warnings)
     assert all("disabled; copied source deck unchanged" not in warning for warning in warnings)
 
@@ -218,7 +218,9 @@ def test_write_outputs_derives_distribution_from_refreshed_master(
 
     master = run_dir / "Monthly Counterparty Exposure Report (Master) - 2026-02-13.pptx"
     distribution = run_dir / "Monthly Counterparty Exposure Report - 2026-02-13.pptx"
-    assert output_paths[-2:] == [master, distribution]
+    assert master in output_paths
+    assert distribution in output_paths
+    assert output_paths.index(master) < output_paths.index(distribution)
     assert master.read_bytes().endswith(b"-refreshed")
     assert distribution.read_bytes() == master.read_bytes()
 
@@ -292,10 +294,11 @@ def test_write_outputs_keeps_master_external_links_when_backend_preserves_relati
         warnings=[],
     )
 
-    assert output_paths[-2:] == [
-        run_dir / "Monthly Counterparty Exposure Report (Master) - 2026-02-13.pptx",
-        run_dir / "Monthly Counterparty Exposure Report - 2026-02-13.pptx",
-    ]
+    master = run_dir / "Monthly Counterparty Exposure Report (Master) - 2026-02-13.pptx"
+    distribution = run_dir / "Monthly Counterparty Exposure Report - 2026-02-13.pptx"
+    assert master in output_paths
+    assert distribution in output_paths
+    assert output_paths.index(master) < output_paths.index(distribution)
 
 
 def test_derive_distribution_ppt_removes_external_link_relationships_from_master(


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #225 addressed most of the acceptance criteria from issue #222, but post-merge verification identified three remaining gaps: the README file is never written to the run folder (the content-generation function exists but is never called by the pipeline), two acceptance criteria lack matching tests (Master-before-Distribution ordering, no-distribution-without-master), and manifest validation for partial PPT entries has code but no test coverage.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#222](https://github.com/stranske/Counter_Risk/issues/222)
- [#225](https://github.com/stranske/Counter_Risk/issues/225)
- [#40](https://github.com/stranske/Counter_Risk/issues/40)
- [#185](https://github.com/stranske/Counter_Risk/issues/185)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
### README file creation in pipeline (implementation gap)
- [x] In `src/counter_risk/pipeline/run.py`, import `build_run_folder_readme_content` from `counter_risk.pipeline.run_folder_outputs` and call it at the end of the PPT generation block (after both Master and Distribution are produced) to write a `README.txt` (or `README.md`) into the run folder
- [x] Ensure the README is written **only** when `config.ppt_output_enabled` is `True` and at least one PPT file was successfully generated
- [x] Add the README path to `output_paths` so it appears in the manifest if applicable

### Missing test: Master-before-Distribution ordering (AC4)
- [x] Add a test in `tests/pipeline/test_monthly_pipeline_ppt_outputs.py` named to match `pytest -k "ppt_enabled.*order"` (e.g., `test_ppt_enabled_order_master_generated_before_distribution`) that uses mocks/spies to verify Master generation is invoked before Distribution derivation and that Distribution is invoked exactly once

### Missing test: No Distribution without Master (AC10)
- [x] Add a test in `tests/pipeline/test_monthly_pipeline_ppt_outputs.py` named to match `pytest -k "no_distribution_without_master"` (e.g., `test_no_distribution_without_master_when_master_generation_fails`) that verifies the run folder contains no Distribution `.pptx` and the manifest does not record a Distribution entry when Master PPT generation fails

### Missing tests: Manifest partial-entry rejection (AC6 supplement)
- [x] Add a test in `tests/pipeline/test_run_manifest_ppt_entries.py` named to match `pytest -k "manifest_schema.*ppt"` that verifies validation **fails** when only Master PPT entry is present (missing Distribution)
- [x] Add a test in `tests/pipeline/test_run_manifest_ppt_entries.py` named to match `pytest -k "manifest_schema.*ppt"` that verifies validation **fails** when only Distribution PPT entry is present (missing Master)

### Missing tests: README conditional creation (AC7 supplement)
- [x] Add a test in `tests/pipeline/test_run_folder_readme.py` verifying a README file **exists** in the run folder when PPT generation is enabled (after pipeline completes)
- [x] Add a test in `tests/pipeline/test_run_folder_readme.py` verifying a README file does **not** exist in the run folder when PPT generation is disabled

#### Acceptance criteria
- [x] `pytest -k "ppt_enabled.*order"` matches at least one passing test that uses mocks/spies to confirm Master is invoked before Distribution, and Distribution is invoked exactly once
- [x] `pytest -k "no_distribution_without_master"` matches at least one passing test confirming no Distribution `.pptx` and no Distribution manifest entry when Master generation fails
- [x] `pytest -k "manifest_schema.*ppt"` matches at least two passing tests: one for only-Master-present rejection, one for only-Distribution-present rejection
- [x] `pytest -k "run_folder_readme"` matches at least two passing tests: one verifying README exists on PPT-enabled runs, one verifying README does not exist on PPT-disabled runs
- [x] On a PPT-enabled pipeline run, a README file is written to the run folder containing both exact PPT filenames and at least three numbered steps
- [x] On a PPT-disabled pipeline run, no README file is written to the run folder
- [x] All existing tests in `test_monthly_pipeline_ppt_outputs.py`, `test_run_manifest_ppt_entries.py`, `test_run_folder_readme.py`, `test_manifest_schema.py`, `test_ppt_validation.py`, `test_run_folder_outputs.py`, and `test_ppt_naming.py` continue to pass

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



# Follow-up: Close remaining PPT output gaps from issue #222 (PR #225)

## Why
PR #225 addressed most of the acceptance criteria from issue #222, but post-merge verification identified three remaining gaps: the README file is never written to the run folder (the content-generation function exists but is never called by the pipeline), two acceptance criteria lack matching tests (Master-before-Distribution ordering, no-distribution-without-master), and manifest validation for partial PPT entries has code but no test coverage.

## What
Close the remaining acceptance-criteria gaps from issue #222 by:
1. Wiring the existing `build_run_folder_readme_content()` function into the pipeline so a README is actually written to the run folder on PPT-enabled runs (and not on disabled runs)
2. Adding the four missing tests that the original acceptance criteria explicitly required be verifiable via `pytest -k`

## Non-Goals
- Modifying any existing passing tests or implementation logic
- Addressing the advisory items from issue #222 (BadZipFile fallback, TargetMode stripping compatibility)

## Tasks

### README file creation in pipeline (implementation gap)
- [ ] In `src/counter_risk/pipeline/run.py`, import `build_run_folder_readme_content` from `counter_risk.pipeline.run_folder_outputs` and call it at the end of the PPT generation block (after both Master and Distribution are produced) to write a `README.txt` (or `README.md`) into the run folder
- [ ] Ensure the README is written **only** when `config.ppt_output_enabled` is `True` and at least one PPT file was successfully generated
- [ ] Add the README path to `output_paths` so it appears in the manifest if applicable

### Missing test: Master-before-Distribution ordering (AC4)
- [ ] Add a test in `tests/pipeline/test_monthly_pipeline_ppt_outputs.py` named to match `pytest -k "ppt_enabled.*order"` (e.g., `test_ppt_enabled_order_master_generated_before_distribution`) that uses mocks/spies to verify Master generation is invoked before Distribution derivation and that Distribution is invoked exactly once

### Missing test: No Distribution without Master (AC10)
- [ ] Add a test in `tests/pipeline/test_monthly_pipeline_ppt_outputs.py` named to match `pytest -k "no_distribution_without_master"` (e.g., `test_no_distribution_without_master_when_master_generation_fails`) that verifies the run folder contains no Distribution `.pptx` and the manifest does not record a Distribution entry when Master PPT generation fails

### Missing tests: Manifest partial-entry rejection (AC6 supplement)
- [ ] Add a test in `tests/pipeline/test_run_manifest_ppt_entries.py` named to match `pytest -k "manifest_schema.*ppt"` that verifies validation **fails** when only Master PPT entry is present (missing Distribution)
- [ ] Add a test in `tests/pipeline/test_run_manifest_ppt_entries.py` named to match `pytest -k "manifest_schema.*ppt"` that verifies validation **fails** when only Distribution PPT entry is present (missing Master)

### Missing tests: README conditional creation (AC7 supplement)
- [ ] Add a test in `tests/pipeline/test_run_folder_readme.py` verifying a README file **exists** in the run folder when PPT generation is enabled (after pipeline completes)
- [ ] Add a test in `tests/pipeline/test_run_folder_readme.py` verifying a README file does **not** exist in the run folder when PPT generation is disabled

## Acceptance Criteria
- [ ] `pytest -k "ppt_enabled.*order"` matches at least one passing test that uses mocks/spies to confirm Master is invoked before Distribution, and Distribution is invoked exactly once
- [ ] `pytest -k "no_distribution_without_master"` matches at least one passing test confirming no Distribution `.pptx` and no Distribution manifest entry when Master generation fails
- [ ] `pytest -k "manifest_schema.*ppt"` matches at least two passing tests: one for only-Master-present rejection, one for only-Distribution-present rejection
- [ ] `pytest -k "run_folder_readme"` matches at least two passing tests: one verifying README exists on PPT-enabled runs, one verifying README does not exist on PPT-disabled runs
- [ ] On a PPT-enabled pipeline run, a README file is written to the run folder containing both exact PPT filenames and at least three numbered steps
- [ ] On a PPT-disabled pipeline run, no README file is written to the run folder
- [ ] All existing tests in `test_monthly_pipeline_ppt_outputs.py`, `test_run_manifest_ppt_entries.py`, `test_run_folder_readme.py`, `test_manifest_schema.py`, `test_ppt_validation.py`, `test_run_folder_outputs.py`, and `test_ppt_naming.py` continue to pass

## Implementation Notes

**README integration point:**
- `build_run_folder_readme_content(as_of_date)` already exists in `src/counter_risk/pipeline/run_folder_outputs.py` and produces correct content (tested)
- It just needs to be called from the PPT block in `src/counter_risk/pipeline/run.py` (around line 900-920, after Distribution is produced)
- Write the file using `(run_folder / "README.txt").write_text(content)`

**Test naming:**
- Tests MUST be named so they match the `pytest -k` patterns specified in the original acceptance criteria from issue #222
- The existing test `test_master_refresh_failure_logs_error_and_skips_distribution_derivation` covers the refresh-failure scenario but does NOT match `pytest -k "no_distribution_without_master"` — the new test should be a dedicated test with the correct name

**Manifest partial-entry validation:**
- The validation code already works correctly (see `validate_manifest_ppt_outputs()` in `src/counter_risk/pipeline/manifest_schema.py` lines 60-82)
- Only test coverage is missing — the tests should call the validation function with crafted manifests containing only Master or only Distribution entries

## Context

### Source
- Parent issue: #222
- Merged PR: #225
- Original issue: #40
- Original PR: #185



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #236

<!-- pr-preamble:end -->