### PR TITLE
perf: reduce Gate CI time by mocking _parse_inputs and distributing t…

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -49,7 +49,7 @@ jobs:
       # Keep PR feedback fast by skipping heavy integration suites here.
       # Full test coverage remains enforced on main branch CI.
       pytest_markers: "not release"
-      pytest_args: "-n auto --dist loadscope --ignore=tests/integration --ignore=tests/integrations"
+      pytest_args: "-n auto --dist load --ignore=tests/integration --ignore=tests/integrations"
       working-directory: "."
       artifact-prefix: "gate-"
       enable-soft-gate: false

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1034,6 +1034,9 @@ def test_run_pipeline_wraps_compute_errors(
     tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config_path = _write_valid_config(tmp_path=tmp_path, output_root=tmp_path / "runs")
+    monkeypatch.setattr(
+        "counter_risk.pipeline.run._parse_inputs", lambda _: _minimal_parsed_by_variant()
+    )
 
     def _boom(
         _: dict[str, dict[str, Any]],
@@ -1053,6 +1056,9 @@ def test_run_pipeline_wraps_historical_update_errors(
     tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config_path = _write_valid_config(tmp_path=tmp_path, output_root=tmp_path / "runs")
+    monkeypatch.setattr(
+        "counter_risk.pipeline.run._parse_inputs", lambda _: _minimal_parsed_by_variant()
+    )
 
     def _boom(
         *,
@@ -1114,6 +1120,9 @@ def test_run_pipeline_passes_as_of_date_and_parsed_inputs_to_historical_update(
     tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config_path = _write_valid_config(tmp_path=tmp_path, output_root=tmp_path / "runs")
+    monkeypatch.setattr(
+        "counter_risk.pipeline.run._parse_inputs", lambda _: _minimal_parsed_by_variant()
+    )
     calls: list[dict[str, Any]] = []
 
     def _capture(


### PR DESCRIPTION
…ests evenly

Mock _parse_inputs in error-wrapping pipeline tests that don't need real Excel fixture I/O, avoiding expensive openpyxl parsing. Switch pytest-xdist from --dist loadscope to --dist load so pipeline tests are spread across workers instead of grouped on a single one.

https://claude.ai/code/session_01VtzHmRoYTL2kcxaacDgSqQ