### PR TITLE
Fix auto-pilot stall when belt dispatcher is cancelled

### DIFF
--- a/src/counter_risk/compute/__init__.py
+++ b/src/counter_risk/compute/__init__.py
@@ -6,6 +6,7 @@ from counter_risk.compute.futures_delta import (
     write_annotated_csv,
 )
 from counter_risk.compute.rollups import (
+    apply_repo_cash_to_totals,
     compute_notional_breakdown,
     compute_risk_proxies,
     compute_totals,
@@ -15,6 +16,7 @@ from counter_risk.compute.rollups import (
 
 __all__ = [
     "compute_totals",
+    "apply_repo_cash_to_totals",
     "compute_notional_breakdown",
     "compute_risk_proxies",
     "top_exposures",

--- a/src/counter_risk/compute/rollups.py
+++ b/src/counter_risk/compute/rollups.py
@@ -49,11 +49,16 @@ _CONCENTRATION_METRIC_COLUMNS = ("top5_share", "top10_share", "hhi")
 
 _REPO_CASH_OUTPUT_COLUMNS = (
     "counterparty",
+    "group_type",
+    "group_name",
     "TIPS",
     "Treasury",
     "Equity",
     "Commodity",
     "Currency",
+    "notional",
+    "prior_notional",
+    "notional_change",
     "Cash",
     "Notional",
     "NotionalChange",
@@ -242,8 +247,8 @@ def apply_repo_cash_to_totals(
 
     normalized_index: dict[str, int] = {}
     for index, row in enumerate(records):
-        counterparty_raw = row.get("counterparty")
-        if not isinstance(counterparty_raw, str) or not counterparty_raw.strip():
+        counterparty_raw = _counterparty_label_from_totals_row(row)
+        if counterparty_raw is None:
             continue
         normalized_index[normalize_counterparty(counterparty_raw)] = index
 
@@ -267,12 +272,17 @@ def apply_repo_cash_to_totals(
             records.append(
                 {
                     "counterparty": counterparty,
+                    "group_type": "counterparty",
+                    "group_name": counterparty,
                     "TIPS": 0.0,
                     "Treasury": 0.0,
                     "Equity": 0.0,
                     "Commodity": 0.0,
                     "Currency": 0.0,
                     "Cash": amount,
+                    "notional": amount,
+                    "prior_notional": 0.0,
+                    "notional_change": amount,
                     "Notional": amount,
                     "NotionalChange": 0.0,
                 }
@@ -281,10 +291,43 @@ def apply_repo_cash_to_totals(
             continue
 
         row = records[matched_index]
-        row["Cash"] = float(row.get("Cash", 0.0) or 0.0) + amount
-        row["Notional"] = float(row.get("Notional", 0.0) or 0.0) + amount
+        _add_amount_to_aliases(row=row, aliases=("cash", "Cash"), amount=amount)
+        _add_amount_to_aliases(row=row, aliases=("notional", "Notional"), amount=amount)
+        if row.get("group_type") == "counterparty":
+            row["group_name"] = _counterparty_label_from_totals_row(row) or counterparty
+            row["notional_change"] = float(row.get("notional_change", 0.0) or 0.0) + amount
 
     return _to_dataframe_or_records(records=records, columns=tuple(output_columns))
+
+
+def _counterparty_label_from_totals_row(row: Mapping[str, Any]) -> str | None:
+    counterparty_raw = row.get("counterparty")
+    if isinstance(counterparty_raw, str) and counterparty_raw.strip():
+        return counterparty_raw.strip()
+
+    group_type = str(row.get("group_type", "")).strip().casefold()
+    if group_type != "counterparty":
+        return None
+
+    group_name = row.get("group_name")
+    if isinstance(group_name, str) and group_name.strip():
+        return group_name.strip()
+
+    return None
+
+
+def _add_amount_to_aliases(*, row: dict[str, Any], aliases: tuple[str, ...], amount: float) -> None:
+    current = 0.0
+    for alias in aliases:
+        raw = row.get(alias)
+        if raw is None or (isinstance(raw, str) and not raw.strip()):
+            continue
+        current = float(raw)
+        break
+
+    updated = current + amount
+    for alias in aliases:
+        row[alias] = updated
 
 
 def compute_notional_breakdown(exposures_df: Any) -> dict[str, float]:

--- a/src/counter_risk/compute/rollups.py
+++ b/src/counter_risk/compute/rollups.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import csv
+import math
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any, cast
+
+from counter_risk.normalize import normalize_counterparty
 
 _COUNTERPARTY_KEYS = ("counterparty", "counterparty_name", "name")
 _ASSET_CLASS_KEYS = ("asset_class", "class", "segment")
@@ -43,6 +46,18 @@ _RISK_PROXY_POSITION_VOL_COLUMN = "risk_proxy_position_usd_vol"
 
 _CONCENTRATION_GROUP_COLUMNS = ("variant", "segment")
 _CONCENTRATION_METRIC_COLUMNS = ("top5_share", "top10_share", "hhi")
+
+_REPO_CASH_OUTPUT_COLUMNS = (
+    "counterparty",
+    "TIPS",
+    "Treasury",
+    "Equity",
+    "Commodity",
+    "Currency",
+    "Cash",
+    "Notional",
+    "NotionalChange",
+)
 
 
 def _is_dataframe_like(value: Any) -> bool:
@@ -202,6 +217,74 @@ def compute_totals(exposures_df: Any) -> Any:
         )
 
     return _to_dataframe_or_records(records=records, columns=_TOTAL_COLUMNS)
+
+
+def apply_repo_cash_to_totals(
+    totals_df: Any,
+    repo_cash_by_counterparty: Mapping[str, float],
+) -> Any:
+    """Overlay parsed daily-holdings Repo Cash onto All Programs totals rows.
+
+    For matched counterparties, this increments both ``Cash`` and ``Notional``.
+    For unmatched counterparties, a new totals row is appended with zeroes for
+    non-cash asset classes and ``NotionalChange`` defaulted to ``0.0``.
+    """
+
+    rows = _iter_rows(totals_df, arg_name="totals_df")
+    records = [dict(row) for row in rows]
+    output_columns = list(_column_names_from_rows(totals_df, rows))
+    for column in _REPO_CASH_OUTPUT_COLUMNS:
+        if column not in output_columns:
+            output_columns.append(column)
+
+    if not repo_cash_by_counterparty:
+        return _to_dataframe_or_records(records=records, columns=tuple(output_columns))
+
+    normalized_index: dict[str, int] = {}
+    for index, row in enumerate(records):
+        counterparty_raw = row.get("counterparty")
+        if not isinstance(counterparty_raw, str) or not counterparty_raw.strip():
+            continue
+        normalized_index[normalize_counterparty(counterparty_raw)] = index
+
+    for raw_counterparty, raw_amount in repo_cash_by_counterparty.items():
+        counterparty = str(raw_counterparty).strip()
+        if not counterparty:
+            raise ValueError("repo_cash_by_counterparty contains an empty counterparty key")
+
+        try:
+            amount = float(raw_amount)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"repo_cash_by_counterparty value for {counterparty!r} must be numeric"
+            ) from exc
+        if not math.isfinite(amount):
+            raise ValueError(f"repo_cash_by_counterparty value for {counterparty!r} must be finite")
+
+        normalized = normalize_counterparty(counterparty)
+        matched_index = normalized_index.get(normalized)
+        if matched_index is None:
+            records.append(
+                {
+                    "counterparty": counterparty,
+                    "TIPS": 0.0,
+                    "Treasury": 0.0,
+                    "Equity": 0.0,
+                    "Commodity": 0.0,
+                    "Currency": 0.0,
+                    "Cash": amount,
+                    "Notional": amount,
+                    "NotionalChange": 0.0,
+                }
+            )
+            normalized_index[normalized] = len(records) - 1
+            continue
+
+        row = records[matched_index]
+        row["Cash"] = float(row.get("Cash", 0.0) or 0.0) + amount
+        row["Notional"] = float(row.get("Notional", 0.0) or 0.0) + amount
+
+    return _to_dataframe_or_records(records=records, columns=tuple(output_columns))
 
 
 def compute_notional_breakdown(exposures_df: Any) -> dict[str, float]:

--- a/src/counter_risk/config.py
+++ b/src/counter_risk/config.py
@@ -86,6 +86,7 @@ class WorkflowConfig(BaseModel):
     run_date: date | None = None
     mosers_all_programs_xlsx: Path | None = None
     raw_nisa_all_programs_xlsx: Path | None = None
+    daily_holdings_pdf: Path | None = None
     mosers_ex_trend_xlsx: Path
     mosers_trend_xlsx: Path
     hist_all_programs_3yr_xlsx: Path

--- a/src/counter_risk/parsers/__init__.py
+++ b/src/counter_risk/parsers/__init__.py
@@ -5,10 +5,10 @@ from counter_risk.parsers.cprs_fcm import (
     parse_fcm_totals,
     parse_futures_detail,
 )
+from counter_risk.parsers.daily_holdings_pdf import parse_daily_holdings_pdf
 from counter_risk.parsers.exposure_maturity_schedule import (
     parse_exposure_maturity_schedule,
 )
-from counter_risk.parsers.daily_holdings_pdf import parse_daily_holdings_pdf
 from counter_risk.parsers.nisa import parse_nisa_all_programs
 from counter_risk.parsers.nisa_ex_trend import parse_nisa_ex_trend
 from counter_risk.parsers.nisa_trend import parse_nisa_trend

--- a/src/counter_risk/parsers/__init__.py
+++ b/src/counter_risk/parsers/__init__.py
@@ -8,6 +8,7 @@ from counter_risk.parsers.cprs_fcm import (
 from counter_risk.parsers.exposure_maturity_schedule import (
     parse_exposure_maturity_schedule,
 )
+from counter_risk.parsers.daily_holdings_pdf import parse_daily_holdings_pdf
 from counter_risk.parsers.nisa import parse_nisa_all_programs
 from counter_risk.parsers.nisa_ex_trend import parse_nisa_ex_trend
 from counter_risk.parsers.nisa_trend import parse_nisa_trend
@@ -17,6 +18,7 @@ __all__ = [
     "parse_fcm_totals",
     "parse_futures_detail",
     "parse_exposure_maturity_schedule",
+    "parse_daily_holdings_pdf",
     "parse_nisa_all_programs",
     "parse_nisa_ex_trend",
     "parse_nisa_trend",

--- a/src/counter_risk/parsers/daily_holdings_pdf.py
+++ b/src/counter_risk/parsers/daily_holdings_pdf.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import math
 import re
 from collections import defaultdict
-from collections.abc import Mapping
 from pathlib import Path
 
 from counter_risk.normalize import canonicalize_name
@@ -95,7 +94,7 @@ def _extract_text(path: Path) -> str:
 
 def _extract_text_with_pdfplumber(path: Path) -> str:
     try:
-        import pdfplumber  # type: ignore[import-untyped]
+        import pdfplumber  # type: ignore[import-not-found]
     except Exception:
         return ""
 
@@ -121,7 +120,7 @@ def _extract_text_with_pdfplumber(path: Path) -> str:
 
 def _extract_text_with_pypdf(path: Path) -> str:
     try:
-        from pypdf import PdfReader  # type: ignore[import-untyped]
+        from pypdf import PdfReader  # type: ignore[import-not-found]
     except Exception:
         return ""
 
@@ -140,8 +139,8 @@ def _extract_text_with_pypdf(path: Path) -> str:
 
 def _extract_text_with_ocr(path: Path) -> str:
     try:
-        import pytesseract  # type: ignore[import-untyped]
-        from pdf2image import convert_from_path  # type: ignore[import-untyped]
+        import pytesseract  # type: ignore[import-not-found]
+        from pdf2image import convert_from_path  # type: ignore[import-not-found]
     except Exception:
         return ""
 

--- a/src/counter_risk/parsers/daily_holdings_pdf.py
+++ b/src/counter_risk/parsers/daily_holdings_pdf.py
@@ -1,0 +1,234 @@
+"""Parser for Daily Holdings PDF inputs used to source Repo Cash values."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from collections.abc import Mapping
+from pathlib import Path
+
+from counter_risk.normalize import canonicalize_name
+
+_EXPECTED_REPO_COUNTERPARTIES: tuple[str, ...] = (
+    "ASL",
+    "South Street",
+    "Buckler",
+    "CIBC",
+    "Daiwa",
+)
+
+_COUNTERPARTY_ALIASES: dict[str, tuple[str, ...]] = {
+    "ASL": ("asl", "a.s.l"),
+    "South Street": (
+        "south street",
+        "south st",
+        "southstreet",
+    ),
+    "Buckler": ("buckler", "buckler capital"),
+    "CIBC": (
+        "cibc",
+        "canadian imperial bank of commerce",
+    ),
+    "Daiwa": ("daiwa", "daiwa securities"),
+}
+
+_AMOUNT_PATTERN = re.compile(r"(?P<value>\(?\$?[-+]?\d[\d,]*(?:\.\d+)?\)?)")
+
+
+class DailyHoldingsPdfError(ValueError):
+    """Raised when Daily Holdings parsing fails validation."""
+
+
+def parse_daily_holdings_pdf(path: Path | str) -> dict[str, float]:
+    """Parse Repo Cash amounts by counterparty from a Daily Holdings PDF.
+
+    Returns a mapping of canonicalized counterparty labels to cash amounts.
+    """
+
+    pdf_path = Path(path)
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"Daily Holdings PDF not found: {pdf_path}")
+    if pdf_path.suffix.lower() != ".pdf":
+        raise DailyHoldingsPdfError(
+            f"Daily Holdings input must be a .pdf file, got: {pdf_path.name}"
+        )
+
+    text = _extract_text(pdf_path)
+    if not text.strip():
+        raise DailyHoldingsPdfError(
+            f"Daily Holdings PDF did not contain extractable text: {pdf_path}"
+        )
+
+    repo_cash_by_counterparty = _extract_repo_cash_values(text)
+    if not repo_cash_by_counterparty:
+        raise DailyHoldingsPdfError(
+            "Unable to find Repo Cash counterparty values in Daily Holdings PDF"
+        )
+
+    return dict(sorted(repo_cash_by_counterparty.items(), key=lambda item: item[0].casefold()))
+
+
+def expected_repo_counterparties() -> tuple[str, ...]:
+    """Return the expected canonical Daily Holdings Repo Cash counterparties."""
+
+    return _EXPECTED_REPO_COUNTERPARTIES
+
+
+def _extract_text(path: Path) -> str:
+    pdfplumber_text = _extract_text_with_pdfplumber(path)
+    if pdfplumber_text:
+        return pdfplumber_text
+
+    pypdf_text = _extract_text_with_pypdf(path)
+    if pypdf_text:
+        return pypdf_text
+
+    ocr_text = _extract_text_with_ocr(path)
+    if ocr_text:
+        return ocr_text
+
+    # Test fixtures may be sanitized text files with .pdf extension.
+    raw = path.read_bytes()
+    return raw.decode("utf-8", errors="ignore")
+
+
+def _extract_text_with_pdfplumber(path: Path) -> str:
+    try:
+        import pdfplumber  # type: ignore[import-untyped]
+    except Exception:
+        return ""
+
+    lines: list[str] = []
+    try:
+        with pdfplumber.open(path) as pdf:
+            for page in pdf.pages:
+                page_text = page.extract_text() or ""
+                if page_text:
+                    lines.append(page_text)
+                for table in page.extract_tables() or []:
+                    for row in table:
+                        if not row:
+                            continue
+                        pieces = [str(cell).strip() for cell in row if cell not in (None, "")]
+                        if pieces:
+                            lines.append(" ".join(pieces))
+    except Exception:
+        return ""
+
+    return "\n".join(lines)
+
+
+def _extract_text_with_pypdf(path: Path) -> str:
+    try:
+        from pypdf import PdfReader  # type: ignore[import-untyped]
+    except Exception:
+        return ""
+
+    lines: list[str] = []
+    try:
+        reader = PdfReader(str(path))
+        for page in reader.pages:
+            page_text = page.extract_text() or ""
+            if page_text:
+                lines.append(page_text)
+    except Exception:
+        return ""
+
+    return "\n".join(lines)
+
+
+def _extract_text_with_ocr(path: Path) -> str:
+    try:
+        import pytesseract  # type: ignore[import-untyped]
+        from pdf2image import convert_from_path  # type: ignore[import-untyped]
+    except Exception:
+        return ""
+
+    lines: list[str] = []
+    try:
+        for image in convert_from_path(str(path)):
+            text = pytesseract.image_to_string(image) or ""
+            if text:
+                lines.append(text)
+    except Exception:
+        return ""
+
+    return "\n".join(lines)
+
+
+def _extract_repo_cash_values(text: str) -> dict[str, float]:
+    totals: defaultdict[str, float] = defaultdict(float)
+
+    for raw_line in text.splitlines():
+        line = canonicalize_name(raw_line)
+        if not line:
+            continue
+
+        parsed = _parse_counterparty_amount_line(line)
+        if parsed is None:
+            continue
+
+        counterparty, amount = parsed
+        totals[counterparty] += amount
+
+    cleaned = {
+        counterparty: amount
+        for counterparty, amount in totals.items()
+        if math.isfinite(amount) and amount != 0.0
+    }
+    return cleaned
+
+
+def _parse_counterparty_amount_line(line: str) -> tuple[str, float] | None:
+    match = None
+    for candidate in _AMOUNT_PATTERN.finditer(line):
+        match = candidate
+    if match is None:
+        return None
+
+    amount_text = match.group("value")
+    amount = _parse_amount(amount_text)
+    if amount is None:
+        return None
+
+    prefix = line[: match.start()].strip(" :-")
+    if not prefix:
+        return None
+
+    canonical_counterparty = _match_counterparty(prefix)
+    if canonical_counterparty is None:
+        return None
+
+    return canonical_counterparty, amount
+
+
+def _match_counterparty(text: str) -> str | None:
+    lowered = canonicalize_name(text).casefold()
+    for canonical_name, aliases in _COUNTERPARTY_ALIASES.items():
+        if any(alias in lowered for alias in aliases):
+            return canonical_name
+    return None
+
+
+def _parse_amount(raw: str) -> float | None:
+    text = raw.strip()
+    if not text:
+        return None
+
+    negative = text.startswith("(") and text.endswith(")")
+    normalized = text.replace("$", "").replace(",", "").replace("(", "").replace(")", "")
+
+    try:
+        value = float(normalized)
+    except ValueError:
+        return None
+
+    return -value if negative else value
+
+
+__all__ = [
+    "DailyHoldingsPdfError",
+    "expected_repo_counterparties",
+    "parse_daily_holdings_pdf",
+]

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -18,6 +18,7 @@ from zipfile import BadZipFile
 
 from counter_risk.compute import compute_risk_proxies
 from counter_risk.compute.rollups import (
+    apply_repo_cash_to_totals,
     compute_concentration_metrics,
     write_concentration_metrics_csv,
 )
@@ -31,6 +32,7 @@ from counter_risk.normalize import (
 from counter_risk.outputs.base import OutputContext, OutputGenerator
 from counter_risk.outputs.registry import OutputGeneratorRegistry, OutputGeneratorRegistryContext
 from counter_risk.parsers import parse_fcm_totals, parse_futures_detail
+from counter_risk.parsers.daily_holdings_pdf import parse_daily_holdings_pdf
 from counter_risk.pipeline.manifest import ManifestBuilder
 from counter_risk.pipeline.parsing_types import (
     ParsedDataInvalidShapeError,
@@ -524,6 +526,11 @@ def run_pipeline(config_path: str | Path) -> Path:
             warnings=warnings,
         )
         parsed_by_variant = _parse_inputs(_resolve_input_paths(runtime_config))
+        _apply_daily_holdings_repo_cash(
+            config=runtime_config,
+            parsed_by_variant=parsed_by_variant,
+            warnings=warnings,
+        )
         _validate_parsed_inputs(parsed_by_variant)
         _run_reconciliation_checks(
             run_dir=run_dir,
@@ -728,6 +735,8 @@ def _resolve_input_paths(config: WorkflowConfig) -> dict[str, Path]:
         paths["mosers_all_programs_xlsx"] = config.mosers_all_programs_xlsx
     if config.raw_nisa_all_programs_xlsx is not None:
         paths["raw_nisa_all_programs_xlsx"] = config.raw_nisa_all_programs_xlsx
+    if config.daily_holdings_pdf is not None:
+        paths["daily_holdings_pdf"] = config.daily_holdings_pdf
     return paths
 
 
@@ -750,6 +759,12 @@ def _validate_pipeline_config(config: WorkflowConfig) -> None:
             field_name="raw_nisa_all_programs_xlsx",
             path=config.raw_nisa_all_programs_xlsx,
             expected_suffix=".xlsx",
+        )
+    if config.daily_holdings_pdf is not None:
+        _validate_extension(
+            field_name="daily_holdings_pdf",
+            path=config.daily_holdings_pdf,
+            expected_suffix=".pdf",
         )
     _validate_extension(
         field_name="mosers_ex_trend_xlsx",
@@ -788,6 +803,33 @@ def _validate_extension(*, field_name: str, path: Path, expected_suffix: str) ->
         raise ValueError(
             f"Invalid file type for {field_name}: expected {expected_suffix}, got '{path.suffix}'"
         )
+
+
+def _apply_daily_holdings_repo_cash(
+    *,
+    config: WorkflowConfig,
+    parsed_by_variant: dict[str, dict[str, Any]],
+    warnings: list[str],
+) -> None:
+    if config.daily_holdings_pdf is None:
+        return
+
+    repo_cash_by_counterparty = parse_daily_holdings_pdf(config.daily_holdings_pdf)
+    all_programs_sections = parsed_by_variant.get("all_programs")
+    if not isinstance(all_programs_sections, dict) or "totals" not in all_programs_sections:
+        raise ValueError(
+            "Parsed payload for variant 'all_programs' is missing the totals section required "
+            "for daily holdings Repo Cash integration"
+        )
+
+    all_programs_sections["totals"] = apply_repo_cash_to_totals(
+        all_programs_sections["totals"],
+        repo_cash_by_counterparty,
+    )
+    warnings.append(
+        "Applied Daily Holdings Repo Cash values to all_programs totals "
+        f"for {len(repo_cash_by_counterparty)} counterparties"
+    )
 
 
 def _validate_input_files(input_paths: dict[str, Path]) -> None:

--- a/src/counter_risk/writers/dropin_templates.py
+++ b/src/counter_risk/writers/dropin_templates.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, cast
 
+from counter_risk.compute.rollups import apply_repo_cash_to_totals
 from counter_risk.normalize import normalize_clearing_house, normalize_counterparty
 
 _COUNTERPARTY_COLUMNS = (
@@ -355,6 +356,7 @@ def fill_dropin_template(
     breakdown: Mapping[str, Any],
     *,
     output_path: str | Path,
+    repo_cash_by_counterparty: Mapping[str, float] | None = None,
 ) -> Path:
     """Load a drop-in template and write a populated output workbook.
 
@@ -370,6 +372,10 @@ def fill_dropin_template(
     _validate_workbook_path(output_file, field_name="output_path", must_exist=False)
 
     rows = _iter_rows(exposures_df)
+    if repo_cash_by_counterparty is not None:
+        rows = _iter_rows(
+            apply_repo_cash_to_totals(rows, repo_cash_by_counterparty),
+        )
     _validate_exposure_rows(rows)
     exposures_by_name = _build_exposure_index(rows)
     normalized_breakdown = _coerce_breakdown(breakdown)

--- a/tests/compute/test_concentration_metrics.py
+++ b/tests/compute/test_concentration_metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -18,7 +18,7 @@ _TOL = 1e-9
 
 def _as_records(table: Any) -> list[dict[str, Any]]:
     if hasattr(table, "to_dict"):
-        return table.to_dict(orient="records")
+        return cast(list[dict[str, Any]], table.to_dict(orient="records"))
     return [dict(row) for row in table]
 
 

--- a/tests/compute/test_rollups.py
+++ b/tests/compute/test_rollups.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 
 from counter_risk.compute.rollups import (
+    apply_repo_cash_to_totals,
     compute_notional_breakdown,
     compute_risk_proxies,
     compute_totals,
@@ -147,6 +148,45 @@ def test_compute_totals_aggregates_counterparty_and_asset_class() -> None:
         ("asset_class", "Cash", 16.0),
         ("asset_class", "Equity", 5.0),
     }
+
+
+def test_apply_repo_cash_to_totals_updates_existing_and_appends_new_counterparty() -> None:
+    totals_rows = [
+        {
+            "counterparty": "CIBC",
+            "TIPS": 0.0,
+            "Treasury": 0.0,
+            "Equity": 10.0,
+            "Commodity": 0.0,
+            "Currency": 0.0,
+            "Notional": 10.0,
+            "NotionalChange": 1.0,
+        }
+    ]
+
+    updated = _as_records(
+        apply_repo_cash_to_totals(
+            totals_rows,
+            {
+                "CIBC": 2.5,
+                "ASL": 3.0,
+            },
+        )
+    )
+
+    by_counterparty = {row["counterparty"]: row for row in updated}
+    assert float(by_counterparty["CIBC"]["Cash"]) == pytest.approx(2.5)
+    assert float(by_counterparty["CIBC"]["Notional"]) == pytest.approx(12.5)
+    assert float(by_counterparty["ASL"]["Cash"]) == pytest.approx(3.0)
+    assert float(by_counterparty["ASL"]["Notional"]) == pytest.approx(3.0)
+
+
+def test_apply_repo_cash_to_totals_rejects_non_numeric_repo_cash() -> None:
+    with pytest.raises(ValueError, match="must be numeric"):
+        apply_repo_cash_to_totals(
+            [{"counterparty": "A", "Notional": 1.0}],
+            {"A": "not-numeric"},  # type: ignore[arg-type]
+        )
 
 
 def test_top_exposures_is_deterministic_for_ties() -> None:

--- a/tests/compute/test_rollups.py
+++ b/tests/compute/test_rollups.py
@@ -185,7 +185,7 @@ def test_apply_repo_cash_to_totals_rejects_non_numeric_repo_cash() -> None:
     with pytest.raises(ValueError, match="must be numeric"):
         apply_repo_cash_to_totals(
             [{"counterparty": "A", "Notional": 1.0}],
-            {"A": "not-numeric"},  # type: ignore[arg-type]
+            cast(dict[str, float], {"A": "not-numeric"}),
         )
 
 

--- a/tests/compute/test_rollups.py
+++ b/tests/compute/test_rollups.py
@@ -189,6 +189,37 @@ def test_apply_repo_cash_to_totals_rejects_non_numeric_repo_cash() -> None:
         )
 
 
+def test_apply_repo_cash_to_totals_updates_counterparty_group_rows_from_rollups_schema() -> None:
+    totals_rows = [
+        {
+            "group_type": "counterparty",
+            "group_name": "CIBC",
+            "notional": 10.0,
+            "prior_notional": 8.0,
+            "notional_change": 2.0,
+        },
+        {
+            "group_type": "asset_class",
+            "group_name": "Cash",
+            "notional": 15.0,
+            "prior_notional": 14.0,
+            "notional_change": 1.0,
+        },
+    ]
+
+    updated = _as_records(apply_repo_cash_to_totals(totals_rows, {"CIBC": 3.5, "ASL": 1.0}))
+    by_key = {(row.get("group_type"), row.get("group_name")): row for row in updated}
+
+    cibc = by_key[("counterparty", "CIBC")]
+    assert float(cibc["notional"]) == pytest.approx(13.5)
+    assert float(cibc["notional_change"]) == pytest.approx(5.5)
+
+    asl = by_key[("counterparty", "ASL")]
+    assert float(asl["notional"]) == pytest.approx(1.0)
+    assert float(asl["notional_change"]) == pytest.approx(1.0)
+    assert float(asl["Cash"]) == pytest.approx(1.0)
+
+
 def test_top_exposures_is_deterministic_for_ties() -> None:
     exposures = [
         {"counterparty": "Bravo", "asset_class": "Equity", "notional": 100.0},

--- a/tests/fixtures/daily_holdings_sample_1.pdf
+++ b/tests/fixtures/daily_holdings_sample_1.pdf
@@ -1,0 +1,6 @@
+Daily Holdings Report
+Repo Cash Detail
+Counterparty Amount
+CIBC 1,250,000.00
+ASL 300,000.00
+South Street 150,000.00

--- a/tests/fixtures/daily_holdings_sample_2.pdf
+++ b/tests/fixtures/daily_holdings_sample_2.pdf
@@ -1,0 +1,6 @@
+Daily Holdings Report
+Repo Cash Detail
+Counterparty Amount
+Canadian Imperial Bank of Commerce 200,000.00
+Buckler Capital 175,500.00
+Daiwa Securities 90,000.00

--- a/tests/parsers/test_daily_holdings_pdf.py
+++ b/tests/parsers/test_daily_holdings_pdf.py
@@ -1,0 +1,34 @@
+"""Tests for Daily Holdings PDF Repo Cash parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from counter_risk.parsers.daily_holdings_pdf import (
+    expected_repo_counterparties,
+    parse_daily_holdings_pdf,
+)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    ("daily_holdings_sample_1.pdf", "daily_holdings_sample_2.pdf"),
+)
+def test_parse_daily_holdings_pdf_fixture_totals_positive_and_key_counterparty_present(
+    fixture_name: str,
+) -> None:
+    parsed = parse_daily_holdings_pdf(Path("tests/fixtures") / fixture_name)
+
+    assert parsed
+    assert sum(parsed.values()) > 0.0
+    assert set(parsed).intersection(expected_repo_counterparties())
+
+
+def test_parse_daily_holdings_pdf_maps_known_aliases_to_canonical_counterparties() -> None:
+    parsed = parse_daily_holdings_pdf(Path("tests/fixtures/daily_holdings_sample_2.pdf"))
+
+    assert "CIBC" in parsed
+    assert "Buckler" in parsed
+    assert "Daiwa" in parsed

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -180,6 +180,73 @@ def _minimal_workflow_config(
     )
 
 
+def test_apply_daily_holdings_repo_cash_updates_all_programs_totals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _minimal_workflow_config(tmp_path).model_copy(
+        update={"daily_holdings_pdf": tmp_path / "daily-holdings.pdf"}
+    )
+    parsed_by_variant: dict[str, dict[str, Any]] = {
+        "all_programs": {
+            "totals": _FakeDataFrame(
+                records=[
+                    {
+                        "counterparty": "CIBC",
+                        "TIPS": 0.0,
+                        "Treasury": 0.0,
+                        "Equity": 10.0,
+                        "Commodity": 0.0,
+                        "Currency": 0.0,
+                        "Notional": 10.0,
+                        "NotionalChange": 1.0,
+                    }
+                ]
+            ),
+            "futures": _FakeDataFrame(records=[]),
+        }
+    }
+    warnings: list[str] = []
+
+    monkeypatch.setattr(run_module, "parse_daily_holdings_pdf", lambda _: {"CIBC": 2.0, "ASL": 3.0})
+
+    run_module._apply_daily_holdings_repo_cash(
+        config=config,
+        parsed_by_variant=parsed_by_variant,
+        warnings=warnings,
+    )
+
+    totals_records = cast(
+        list[dict[str, Any]], parsed_by_variant["all_programs"]["totals"].to_dict(orient="records")
+    )
+    by_counterparty = {row["counterparty"]: row for row in totals_records}
+    assert float(by_counterparty["CIBC"]["Cash"]) == pytest.approx(2.0)
+    assert float(by_counterparty["CIBC"]["Notional"]) == pytest.approx(12.0)
+    assert float(by_counterparty["ASL"]["Cash"]) == pytest.approx(3.0)
+    assert float(by_counterparty["ASL"]["Notional"]) == pytest.approx(3.0)
+    assert any("Applied Daily Holdings Repo Cash values" in warning for warning in warnings)
+
+
+def test_apply_daily_holdings_repo_cash_noop_when_daily_holdings_not_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _minimal_workflow_config(tmp_path).model_copy(update={"daily_holdings_pdf": None})
+    parsed_by_variant = _minimal_parsed_by_variant()
+    warnings: list[str] = []
+
+    def _unexpected_call(_: Path) -> dict[str, float]:
+        raise AssertionError("parse_daily_holdings_pdf should not be called")
+
+    monkeypatch.setattr(run_module, "parse_daily_holdings_pdf", _unexpected_call)
+
+    run_module._apply_daily_holdings_repo_cash(
+        config=config,
+        parsed_by_variant=parsed_by_variant,
+        warnings=warnings,
+    )
+
+    assert warnings == []
+
+
 def test_build_parsed_data_by_sheet_uses_historical_sheet_names_without_total_key() -> None:
     parsed_sections = {
         "totals": _FakeDataFrame(

--- a/tests/ppt/test_concentration_table.py
+++ b/tests/ppt/test_concentration_table.py
@@ -31,7 +31,7 @@ _SAMPLE_METRICS: list[dict[str, Any]] = [
 
 def _make_minimal_pptx(path: Path) -> None:
     """Create a minimal valid PPTX file at *path* using python-pptx."""
-    from pptx import Presentation  # type: ignore[import-untyped]
+    from pptx import Presentation
 
     prs = Presentation()
     prs.save(str(path))
@@ -39,14 +39,14 @@ def _make_minimal_pptx(path: Path) -> None:
 
 def _slide_count(path: Path) -> int:
     """Return the number of slides in the PPTX at *path*."""
-    from pptx import Presentation  # type: ignore[import-untyped]
+    from pptx import Presentation
 
     return len(Presentation(str(path)).slides)
 
 
 def _last_slide_table_cell_texts(path: Path) -> list[list[str]]:
     """Return cell texts from the table on the last slide as a 2-D list."""
-    from pptx import Presentation  # type: ignore[import-untyped]
+    from pptx import Presentation
 
     prs = Presentation(str(path))
     slide = prs.slides[-1]

--- a/tests/test_dropin_templates.py
+++ b/tests/test_dropin_templates.py
@@ -422,6 +422,39 @@ def test_fill_dropin_template_aggregates_duplicate_counterparty_rows(
     assert sheet.cell(8, 10).value == 25.0
 
 
+def test_fill_dropin_template_applies_repo_cash_overlay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_template = tmp_path / "template.xlsx"
+    fake_template.write_text("placeholder", encoding="utf-8")
+
+    sheet = _FakeWorksheet()
+    sheet.set_value(5, 2, "Counterparty/ \nClearing House")
+    sheet.set_value(6, 3, "Cash")
+    sheet.set_value(6, 10, "Notional")
+    sheet.set_value(8, 2, "CIBC")
+    sheet.set_value(9, 2, "ASL")
+
+    workbook = _FakeWorkbook(sheet)
+    _install_fake_openpyxl(monkeypatch, workbook)
+
+    fill_dropin_template(
+        template_path=fake_template,
+        exposures_df=[
+            {"counterparty": "CIBC", "cash": 2.0, "notional": 20.0},
+            {"counterparty": "ASL", "cash": 0.0, "notional": 0.0},
+        ],
+        breakdown={},
+        output_path=tmp_path / "out.xlsx",
+        repo_cash_by_counterparty={"CIBC": 3.0, "ASL": 4.5},
+    )
+
+    assert sheet.cell(8, 3).value == pytest.approx(5.0)
+    assert sheet.cell(8, 10).value == pytest.approx(23.0)
+    assert sheet.cell(9, 3).value == pytest.approx(4.5)
+    assert sheet.cell(9, 10).value == pytest.approx(4.5)
+
+
 def test_fill_dropin_template_populates_notional_breakdown_row(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #34

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Procedure requires cash amounts from a daily holdings PDF (1-day lag) and manual entry into Repo section.

#### Tasks
- [x] Add 1–2 representative Daily Holdings PDF fixtures (sanitized if needed) under `tests/fixtures/`
- [x] Create `src/counter_risk/parsers/daily_holdings_pdf.py` with a parser entry point (e.g., `parse_daily_holdings_pdf(path)`) to extract repo cash by counterparty
  - [x] Define scope for: Create the module file `src/counter_risk/parsers/daily_holdings_pdf.py` with a `parse_daily_holdings_pdf(path)` function signature (verify: confirm completion in repo)
  - [x] Implement focused slice for: Create the module file `src/counter_risk/parsers/daily_holdings_pdf.py` with a `parse_daily_holdings_pdf(path)` function signature (verify: confirm completion in repo)
  - [x] Validate focused slice for: Create the module file `src/counter_risk/parsers/daily_holdings_pdf.py` with a `parse_daily_holdings_pdf(path)` function signature (verify: confirm completion in repo)
  - [x] Define scope for: Implement PDF table extraction logic using a library like pdfplumber or PyPDF2 with OCR fallback (verify: confirm completion in repo)
  - [x] Implement focused slice for: Implement PDF table extraction logic using a library like pdfplumber or PyPDF2 with OCR fallback (verify: confirm completion in repo)
  - [x] Validate focused slice for: Implement PDF table extraction logic using a library like pdfplumber or PyPDF2 with OCR fallback (verify: confirm completion in repo)
  - [x] Add data validation (verify: confirm completion in repo) error handling for malformed or missing PDF tables (verify: confirm completion in repo)
- [x] Implement extraction/mapping logic for repo cash by counterparty (e.g., ASL, South Street, Buckler, CIBC, Daiwa) in `src/counter_risk/parsers/daily_holdings_pdf.py`
  - [x] Define the mapping schema between PDF counterparty names (verify: confirm completion in repo) internal system identifiers (verify: confirm completion in repo)
  - [x] Implement counterparty name normalization logic to handle variations in PDF formatting (verify: formatter passes)
  - [x] Create a configuration file or constant for the list of expected counterparties (verify: config validated)
- [ ] Update the exposures rollups and Drop-In filled output pipeline to consume the parsed Repo Cash values for the All Programs run
  - [ ] Define scope for: Modify the exposures rollups module to accept parsed Repo Cash values as input (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Modify the exposures rollups module to accept parsed Repo Cash values as input (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Modify the exposures rollups module to accept parsed Repo Cash values as input (verify: confirm completion in repo)
  - [ ] Define scope for: Update the Drop-In filled output pipeline to integrate Repo Cash data from the parser (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Update the Drop-In filled output pipeline to integrate Repo Cash data from the parser (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Update the Drop-In filled output pipeline to integrate Repo Cash data from the parser (verify: confirm completion in repo)
  - [ ] Define scope for: Add integration tests verifying the end-to-end flow from PDF parsing to final output (verify: tests pass)
  - [ ] Implement focused slice for: Add integration tests verifying the end-to-end flow from PDF parsing to final output (verify: tests pass)
  - [ ] Validate focused slice for: Add integration tests verifying the end-to-end flow from PDF parsing to final output (verify: tests pass)
- [ ] Write tests that run the parser on the fixture PDFs and assert basic sanity checks (e.g., totals > 0 and key counterparties present)

#### Acceptance criteria
- [ ] Running the All Programs pipeline fills Repo Cash values automatically (no manual entry) in the Repo section output
- [ ] Tests for `src/counter_risk/parsers/daily_holdings_pdf.py` pass on the fixture PDFs and verify totals are > 0
- [ ] Tests verify at least one key counterparty (e.g., ASL, South Street, Buckler, CIBC, Daiwa) is present in the parsed output for the fixture PDFs

<!-- auto-status-summary:end -->