### PR TITLE
[Agent] [Ops] Make MOSERS CPRS-CH writes marker-driven (#281)

### DIFF
--- a/docs/macro_spec.md
+++ b/docs/macro_spec.md
@@ -78,6 +78,8 @@ Output expectations (ranges affected, invariants):
 - CPRS-CH annualized/allocation metric writes target the marker-resolved row block
   bounded by the `Goldman Sachs` and `Credit Agricole` rows before
   `Total by Counterparty/Clearing House`
+- Default template anchor for the marker-resolved block remains `CPRS - CH!C10:C20`
+  with values written to `CPRS - CH!D10:D20` and `CPRS - CH!E10:E20`
 - No blank numeric cells in the resolved CPRS-CH metric range
 - Marker rows required for writes are present and ordered consistently
 
@@ -99,6 +101,8 @@ Output expectations (ranges affected, invariants):
 - CPRS-CH annualized/allocation metric writes target the marker-resolved row block
   bounded by the `Goldman Sachs` and `Credit Agricole` rows before
   `Total by Counterparty/Clearing House`
+- Default template anchor for the marker-resolved block remains `CPRS - CH!C10:C20`
+  with values written to `CPRS - CH!D10:D20` and `CPRS - CH!E10:E20`
 - No blank numeric cells in the resolved CPRS-CH metric range
 - Marker rows required for writes are present and ordered consistently
 

--- a/docs/macro_spec.md
+++ b/docs/macro_spec.md
@@ -55,6 +55,8 @@ Output expectations (ranges affected, invariants):
 - CPRS-CH annualized/allocation metric writes target the marker-resolved row block
   bounded by the `Goldman Sachs` and `Credit Agricole` rows before
   `Total by Counterparty/Clearing House`
+- Default template anchor for the marker-resolved block remains `CPRS - CH!C10:C20`
+  with values written to `CPRS - CH!D10:D20` and `CPRS - CH!E10:E20`
 - No blank numeric cells in the resolved CPRS-CH metric range
 - Marker rows required for writes are present and ordered consistently
 

--- a/docs/macro_spec.md
+++ b/docs/macro_spec.md
@@ -92,10 +92,11 @@ Output expectations (ranges affected, invariants):
 - Uses Trend config for pipeline invocation
 - Generated workbook includes `CPRS - CH`
 - `CPRS - CH!B5` matches parsed lead counterparty from source
-- `CPRS - CH!D10:D20` reflects annualized-volatility transformation
-- `CPRS - CH!E10:E20` reflects notional-allocation transformation
-- No blank numeric cells in `CPRS - CH!D10:E20`
-- Headers in `CPRS - CH!C10:C20` match MOSERS template
+- CPRS-CH annualized/allocation metric writes target the marker-resolved row block
+  bounded by the `Goldman Sachs` and `Credit Agricole` rows before
+  `Total by Counterparty/Clearing House`
+- No blank numeric cells in the resolved CPRS-CH metric range
+- Marker rows required for writes are present and ordered consistently
 
 ### `OpenOutputFolder_Click`
 
@@ -113,7 +114,7 @@ Output expectations (ranges affected, invariants):
 
 - Floating-point comparisons for transformed numeric values use tolerance
   `rel_tol=1e-12` and `abs_tol=1e-12`.
-- Allocation percentages in `CPRS - CH!E10:E20` are derived from
+- Allocation percentages in the resolved CPRS-CH metric allocation column are derived from
   `row.notional / sum(notional)` with no additional discretionary rounding in tests.
 - Empty tail slots after available rows are accepted as blanks (`None`) in range-level
   checks, but invariant checks require non-blank values in the enforced core numeric

--- a/docs/macro_spec.md
+++ b/docs/macro_spec.md
@@ -52,10 +52,11 @@ Output expectations (ranges affected, invariants):
 - Uses All Programs config for pipeline invocation
 - Generated workbook includes `CPRS - CH`
 - `CPRS - CH!B5` matches parsed lead counterparty from source
-- `CPRS - CH!D10:D20` reflects annualized-volatility transformation
-- `CPRS - CH!E10:E20` reflects notional-allocation transformation
-- No blank numeric cells in `CPRS - CH!D10:E20`
-- Headers in `CPRS - CH!C10:C20` match MOSERS template
+- CPRS-CH annualized/allocation metric writes target the marker-resolved row block
+  bounded by the `Goldman Sachs` and `Credit Agricole` rows before
+  `Total by Counterparty/Clearing House`
+- No blank numeric cells in the resolved CPRS-CH metric range
+- Marker rows required for writes are present and ordered consistently
 
 ### `RunExTrend_Click`
 
@@ -72,10 +73,11 @@ Output expectations (ranges affected, invariants):
 - Uses Ex Trend config for pipeline invocation
 - Generated workbook includes `CPRS - CH`
 - `CPRS - CH!B5` matches parsed lead counterparty from source
-- `CPRS - CH!D10:D20` reflects annualized-volatility transformation
-- `CPRS - CH!E10:E20` reflects notional-allocation transformation
-- No blank numeric cells in `CPRS - CH!D10:E20`
-- Headers in `CPRS - CH!C10:C20` match MOSERS template
+- CPRS-CH annualized/allocation metric writes target the marker-resolved row block
+  bounded by the `Goldman Sachs` and `Credit Agricole` rows before
+  `Total by Counterparty/Clearing House`
+- No blank numeric cells in the resolved CPRS-CH metric range
+- Marker rows required for writes are present and ordered consistently
 
 ### `RunTrend_Click`
 

--- a/src/counter_risk/mosers/template.py
+++ b/src/counter_risk/mosers/template.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -32,3 +33,78 @@ def load_mosers_template_workbook() -> Any:
         raise RuntimeError("openpyxl is required to load MOSERS template workbooks") from exc
 
     return load_workbook(filename=get_mosers_template_path())
+
+
+@dataclass(frozen=True)
+class MarkerBoundRange:
+    """Inclusive row range discovered from text markers."""
+
+    start_row: int
+    end_row: int
+
+
+def normalize_template_text(value: object) -> str:
+    """Return normalized text for resilient marker matching."""
+
+    return " ".join(str(value or "").split()).strip().casefold()
+
+
+def find_row_containing_text(
+    worksheet: Any,
+    text: str,
+    *,
+    min_row: int = 1,
+    max_row: int | None = None,
+) -> int | None:
+    """Return the first row in *worksheet* containing *text* in any column."""
+
+    if min_row < 1:
+        min_row = 1
+    end_row = int(worksheet.max_row) if max_row is None else max(1, int(max_row))
+    if end_row < min_row:
+        return None
+
+    marker = normalize_template_text(text)
+    if not marker:
+        return None
+
+    max_column = int(worksheet.max_column)
+    for row_number in range(min_row, end_row + 1):
+        for column_number in range(1, max_column + 1):
+            value = worksheet.cell(row=row_number, column=column_number).value
+            if marker in normalize_template_text(value):
+                return row_number
+    return None
+
+
+def resolve_marker_bound_range(
+    worksheet: Any,
+    *,
+    start_marker: str,
+    end_marker: str,
+    min_row: int = 1,
+    max_row: int | None = None,
+) -> MarkerBoundRange:
+    """Resolve inclusive row bounds by locating *start_marker* and *end_marker*."""
+
+    start_row = find_row_containing_text(
+        worksheet, start_marker, min_row=min_row, max_row=max_row
+    )
+    if start_row is None:
+        raise ValueError(
+            f"Unable to locate marker {start_marker!r} in sheet {worksheet.title!r}."
+        )
+    end_row = find_row_containing_text(
+        worksheet,
+        end_marker,
+        min_row=start_row,
+        max_row=max_row,
+    )
+    if end_row is None:
+        raise ValueError(f"Unable to locate marker {end_marker!r} in sheet {worksheet.title!r}.")
+    if end_row < start_row:
+        raise ValueError(
+            f"Marker ordering invalid in sheet {worksheet.title!r}: "
+            f"start marker {start_marker!r} occurs after end marker {end_marker!r}."
+        )
+    return MarkerBoundRange(start_row=start_row, end_row=end_row)

--- a/src/counter_risk/mosers/template.py
+++ b/src/counter_risk/mosers/template.py
@@ -60,7 +60,7 @@ def find_row_containing_text(
 
     if min_row < 1:
         min_row = 1
-    end_row = int(worksheet.max_row) if max_row is None else max(1, int(max_row))
+    end_row = int(worksheet.max_row) if max_row is None else int(max_row)
     if end_row < min_row:
         return None
 
@@ -102,9 +102,4 @@ def resolve_marker_bound_range(
     )
     if end_row is None:
         raise ValueError(f"Unable to locate marker {end_marker!r} in sheet {worksheet.title!r}.")
-    if end_row < start_row:
-        raise ValueError(
-            f"Marker ordering invalid in sheet {worksheet.title!r}: "
-            f"start marker {start_marker!r} occurs after end marker {end_marker!r}."
-        )
     return MarkerBoundRange(start_row=start_row, end_row=end_row)

--- a/src/counter_risk/mosers/workbook_generation.py
+++ b/src/counter_risk/mosers/workbook_generation.py
@@ -434,6 +434,8 @@ def _resolve_section_bounds(
 def _resolve_cprs_ch_metric_row_bounds_from_template() -> tuple[int, int]:
     workbook = load_mosers_template_workbook()
     try:
+        if _TARGET_SHEET not in workbook.sheetnames:
+            raise ValueError(f"Unable to locate required MOSERS template sheet {_TARGET_SHEET!r}.")
         worksheet = workbook[_TARGET_SHEET]
         return _resolve_cprs_ch_metric_row_bounds(worksheet)
     finally:

--- a/src/counter_risk/mosers/workbook_generation.py
+++ b/src/counter_risk/mosers/workbook_generation.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeAlias
 
-from counter_risk.mosers.template import load_mosers_template_workbook
+from counter_risk.mosers.template import (
+    find_row_containing_text,
+    load_mosers_template_workbook,
+    resolve_marker_bound_range,
+)
 from counter_risk.parsers.nisa import (
     NisaAllProgramsData,
     NisaTotalsRow,
@@ -23,9 +27,12 @@ _REQUIRED_SHEETS = ("CPRS - CH", "CPRS - FCM")
 _TARGET_SHEET = "CPRS - CH"
 _FCM_SHEET = "CPRS - FCM"
 _PROGRAM_NAME_CELL = "B5"
-_SECTION_LABEL_COLUMN = "C"
-_CH_METRIC_START_ROW = 10
-_CH_METRIC_END_ROW = 20
+_CH_METRIC_START_MARKER = "Goldman Sachs"
+_CH_METRIC_END_MARKER = "Credit Agricole"
+_CH_METRIC_REQUIRED_HEADERS: tuple[tuple[str, ...], ...] = (
+    ("Annualized Volatility",),
+    ("Allocation %", "%"),
+)
 _CH_TOTALS_MARKER = "Total by Counterparty/Clearing House"
 _CH_TOTALS_STOP_MARKERS = ("Total Current Exposure", "MOSERS Program", "Notional Breakdown")
 _FCM_TOTALS_MARKER = "Total by Counterparty/ FCM"
@@ -94,12 +101,13 @@ class MosersPlugValuesMappingRequirements:
 def get_mosers_all_programs_output_structure() -> MosersAllProgramsOutputStructure:
     """Return the output-structure contract used for All Programs workbook generation."""
 
+    metric_start_row, metric_end_row = _resolve_cprs_ch_metric_row_bounds_from_template()
     return MosersAllProgramsOutputStructure(
         required_sheets=_REQUIRED_SHEETS,
         cprs_ch_sheet=_TARGET_SHEET,
         program_name_cell=_PROGRAM_NAME_CELL,
-        cprs_ch_metric_start_row=_CH_METRIC_START_ROW,
-        cprs_ch_metric_end_row=_CH_METRIC_END_ROW,
+        cprs_ch_metric_start_row=metric_start_row,
+        cprs_ch_metric_end_row=metric_end_row,
     )
 
 
@@ -120,12 +128,13 @@ def get_mosers_all_programs_transformation_scope() -> MosersAllProgramsTransform
 def get_mosers_ex_trend_output_structure() -> MosersAllProgramsOutputStructure:
     """Return the output-structure contract used for Ex Trend workbook generation."""
 
+    metric_start_row, metric_end_row = _resolve_cprs_ch_metric_row_bounds_from_template()
     return MosersAllProgramsOutputStructure(
         required_sheets=_REQUIRED_SHEETS,
         cprs_ch_sheet=_TARGET_SHEET,
         program_name_cell=_PROGRAM_NAME_CELL,
-        cprs_ch_metric_start_row=_CH_METRIC_START_ROW,
-        cprs_ch_metric_end_row=_CH_METRIC_END_ROW,
+        cprs_ch_metric_start_row=metric_start_row,
+        cprs_ch_metric_end_row=metric_end_row,
     )
 
 
@@ -146,12 +155,13 @@ def get_mosers_ex_trend_transformation_scope() -> MosersAllProgramsTransformatio
 def get_mosers_trend_output_structure() -> MosersAllProgramsOutputStructure:
     """Return the output-structure contract used for Trend workbook generation."""
 
+    metric_start_row, metric_end_row = _resolve_cprs_ch_metric_row_bounds_from_template()
     return MosersAllProgramsOutputStructure(
         required_sheets=_REQUIRED_SHEETS,
         cprs_ch_sheet=_TARGET_SHEET,
         program_name_cell=_PROGRAM_NAME_CELL,
-        cprs_ch_metric_start_row=_CH_METRIC_START_ROW,
-        cprs_ch_metric_end_row=_CH_METRIC_END_ROW,
+        cprs_ch_metric_start_row=metric_start_row,
+        cprs_ch_metric_end_row=metric_end_row,
     )
 
 
@@ -268,12 +278,13 @@ def _generate_mosers_workbook_from_parser(
     first_program = parsed.ch_rows[0].counterparty if parsed.ch_rows else ""
     worksheet[resolved_structure.program_name_cell] = first_program
 
+    metric_start_row, metric_end_row = _resolve_cprs_ch_metric_row_bounds(worksheet)
     for transform in resolved_transformation_scope.cprs_ch_transforms:
         _write_vertical_values(
             worksheet=worksheet,
             column_letter=transform.target_column,
-            start_row=resolved_structure.cprs_ch_metric_start_row,
-            end_row=resolved_structure.cprs_ch_metric_end_row,
+            start_row=metric_start_row,
+            end_row=metric_end_row,
             values=_build_totals_metric_values(parsed.totals_rows, transform.source_metric),
         )
 
@@ -337,7 +348,9 @@ def _write_totals_rows_by_marker(
         stop_markers=stop_markers,
     )
     if section_bounds is None:
-        return
+        raise ValueError(
+            f"Unable to resolve section marker {section_marker!r} in sheet {worksheet.title!r}."
+        )
     start_row, end_row = section_bounds
 
     total_slots = (end_row - start_row) + 1
@@ -386,23 +399,19 @@ def _get_totals_row_field_value(*, row: NisaTotalsRow, source_field: str) -> Any
 
 
 def _find_marker_row(*, worksheet: Worksheet, marker_text: str) -> int | None:
-    marker = _normalize_marker_text(marker_text)
-    for row_number in range(1, int(worksheet.max_row) + 1):
-        cell_text = worksheet[f"{_SECTION_LABEL_COLUMN}{row_number}"].value
-        if marker in _normalize_marker_text(cell_text):
-            return row_number
-    return None
+    return find_row_containing_text(worksheet, marker_text)
 
 
 def _find_stop_row(
     *, worksheet: Worksheet, start_row: int, stop_markers: tuple[str, ...]
 ) -> int | None:
-    normalized_markers = tuple(_normalize_marker_text(marker) for marker in stop_markers)
-    for row_number in range(start_row, int(worksheet.max_row) + 1):
-        cell_text = _normalize_marker_text(worksheet[f"{_SECTION_LABEL_COLUMN}{row_number}"].value)
-        if any(marker in cell_text for marker in normalized_markers):
-            return row_number
-    return None
+    candidate_rows = [
+        find_row_containing_text(worksheet, marker, min_row=start_row) for marker in stop_markers
+    ]
+    matches = [row for row in candidate_rows if row is not None]
+    if not matches:
+        return None
+    return min(matches)
 
 
 def _resolve_section_bounds(
@@ -422,5 +431,40 @@ def _resolve_section_bounds(
     return start_row, end_row
 
 
-def _normalize_marker_text(value: object) -> str:
-    return " ".join(str(value or "").split()).strip().casefold()
+def _resolve_cprs_ch_metric_row_bounds_from_template() -> tuple[int, int]:
+    workbook = load_mosers_template_workbook()
+    try:
+        worksheet = workbook[_TARGET_SHEET]
+        return _resolve_cprs_ch_metric_row_bounds(worksheet)
+    finally:
+        workbook.close()
+
+
+def _resolve_cprs_ch_metric_row_bounds(worksheet: Worksheet) -> tuple[int, int]:
+    _validate_metric_headers_present(worksheet)
+    totals_marker_row = _find_marker_row(worksheet=worksheet, marker_text=_CH_TOTALS_MARKER)
+    if totals_marker_row is None:
+        raise ValueError(
+            f"Unable to locate {_CH_TOTALS_MARKER!r} marker in sheet {worksheet.title!r}."
+        )
+    marker_range = resolve_marker_bound_range(
+        worksheet,
+        start_marker=_CH_METRIC_START_MARKER,
+        end_marker=_CH_METRIC_END_MARKER,
+        max_row=totals_marker_row - 1,
+    )
+    return marker_range.start_row, marker_range.end_row
+
+
+def _validate_metric_headers_present(worksheet: Worksheet) -> None:
+    for aliases in _CH_METRIC_REQUIRED_HEADERS:
+        if any(
+            _find_marker_row(worksheet=worksheet, marker_text=alias) is not None
+            for alias in aliases
+        ):
+            continue
+        joined_aliases = ", ".join(repr(alias) for alias in aliases)
+        raise ValueError(
+            "Unable to locate expected CPRS-CH metric header "
+            f"({joined_aliases}) in sheet {worksheet.title!r}."
+        )

--- a/tests/test_mosers_all_programs_output_structure.py
+++ b/tests/test_mosers_all_programs_output_structure.py
@@ -18,8 +18,8 @@ def test_all_programs_output_structure_defines_expected_cprs_layout() -> None:
     assert structure.required_sheets == ("CPRS - CH", "CPRS - FCM")
     assert structure.cprs_ch_sheet == "CPRS - CH"
     assert structure.program_name_cell == "B5"
-    assert structure.cprs_ch_metric_start_row == 10
-    assert structure.cprs_ch_metric_end_row == 20
+    assert structure.cprs_ch_metric_start_row >= 1
+    assert structure.cprs_ch_metric_end_row > structure.cprs_ch_metric_start_row
 
 
 def test_all_programs_transformation_scope_defines_core_mappings() -> None:
@@ -71,5 +71,4 @@ def test_all_programs_fixture_generates_using_documented_layout_contract() -> No
         assert worksheet[first_alloc_cell].value == expected_allocation
     finally:
         workbook.close()
-
 

--- a/tests/test_mosers_ex_trend_output_structure.py
+++ b/tests/test_mosers_ex_trend_output_structure.py
@@ -18,8 +18,8 @@ def test_ex_trend_output_structure_defines_expected_cprs_layout() -> None:
     assert structure.required_sheets == ("CPRS - CH", "CPRS - FCM")
     assert structure.cprs_ch_sheet == "CPRS - CH"
     assert structure.program_name_cell == "B5"
-    assert structure.cprs_ch_metric_start_row == 10
-    assert structure.cprs_ch_metric_end_row == 20
+    assert structure.cprs_ch_metric_start_row >= 1
+    assert structure.cprs_ch_metric_end_row > structure.cprs_ch_metric_start_row
 
 
 def test_ex_trend_transformation_scope_defines_core_mappings() -> None:
@@ -71,5 +71,4 @@ def test_ex_trend_fixture_generates_using_documented_layout_contract() -> None:
         assert worksheet[first_alloc_cell].value == expected_allocation
     finally:
         workbook.close()
-
 

--- a/tests/test_mosers_trend_output_structure.py
+++ b/tests/test_mosers_trend_output_structure.py
@@ -18,8 +18,8 @@ def test_trend_output_structure_defines_expected_cprs_layout() -> None:
     assert structure.required_sheets == ("CPRS - CH", "CPRS - FCM")
     assert structure.cprs_ch_sheet == "CPRS - CH"
     assert structure.program_name_cell == "B5"
-    assert structure.cprs_ch_metric_start_row == 10
-    assert structure.cprs_ch_metric_end_row == 20
+    assert structure.cprs_ch_metric_start_row >= 1
+    assert structure.cprs_ch_metric_end_row > structure.cprs_ch_metric_start_row
 
 
 def test_trend_transformation_scope_defines_core_mappings() -> None:
@@ -71,5 +71,4 @@ def test_trend_fixture_generates_using_documented_layout_contract() -> None:
         assert worksheet[first_alloc_cell].value == expected_allocation
     finally:
         workbook.close()
-
 

--- a/tests/test_mosers_workbook.py
+++ b/tests/test_mosers_workbook.py
@@ -372,7 +372,12 @@ def test_generate_mosers_workbook_fails_when_required_markers_are_missing(
     workbook = workbook_generation_module.load_mosers_template_workbook()
     try:
         worksheet = workbook["CPRS - CH"]
-        worksheet["C30"] = "missing marker"
+        marker_row = workbook_generation_module._find_marker_row(
+            worksheet=worksheet,
+            marker_text="Total by Counterparty/Clearing House",
+        )
+        assert marker_row is not None
+        worksheet[f"C{marker_row}"] = "missing marker"
 
         monkeypatch.setattr(
             workbook_generation_module,
@@ -390,16 +395,23 @@ def test_find_marker_row_handles_column_shifts() -> None:
     workbook = workbook_generation_module.load_mosers_template_workbook()
     try:
         worksheet = workbook["CPRS - CH"]
-        marker_value = worksheet["C30"].value
-        worksheet["B30"] = marker_value
-        worksheet["C30"] = None
+        marker_text = "Total by Counterparty/Clearing House"
+        marker_row = workbook_generation_module._find_marker_row(
+            worksheet=worksheet,
+            marker_text=marker_text,
+        )
+        assert marker_row is not None
+
+        marker_value = worksheet[f"C{marker_row}"].value
+        worksheet[f"B{marker_row}"] = marker_value
+        worksheet[f"C{marker_row}"] = None
 
         assert (
             workbook_generation_module._find_marker_row(
                 worksheet=worksheet,
-                marker_text="Total by Counterparty/Clearing House",
+                marker_text=marker_text,
             )
-            == 30
+            == marker_row
         )
     finally:
         workbook.close()

--- a/tests/test_mosers_workbook.py
+++ b/tests/test_mosers_workbook.py
@@ -348,6 +348,63 @@ def test_generate_mosers_workbook_trend_populates_values_from_trend_fixture() ->
         workbook.close()
 
 
+def test_resolve_cprs_ch_metric_row_bounds_tracks_template_row_shifts() -> None:
+    workbook = workbook_generation_module.load_mosers_template_workbook()
+    try:
+        worksheet = workbook["CPRS - CH"]
+        baseline_start, baseline_end = workbook_generation_module._resolve_cprs_ch_metric_row_bounds(
+            worksheet
+        )
+        worksheet.insert_rows(baseline_start, amount=2)
+        shifted_start, shifted_end = workbook_generation_module._resolve_cprs_ch_metric_row_bounds(
+            worksheet
+        )
+
+        assert shifted_start == baseline_start + 2
+        assert shifted_end == baseline_end + 2
+    finally:
+        workbook.close()
+
+
+def test_generate_mosers_workbook_fails_when_required_markers_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workbook = workbook_generation_module.load_mosers_template_workbook()
+    try:
+        worksheet = workbook["CPRS - CH"]
+        worksheet["C30"] = "missing marker"
+
+        monkeypatch.setattr(
+            workbook_generation_module,
+            "load_mosers_template_workbook",
+            lambda: workbook,
+        )
+
+        with pytest.raises(ValueError, match="Total by Counterparty/Clearing House"):
+            generate_mosers_workbook(Path("tests/fixtures/raw_nisa_all_programs.xlsx"))
+    finally:
+        workbook.close()
+
+
+def test_find_marker_row_handles_column_shifts() -> None:
+    workbook = workbook_generation_module.load_mosers_template_workbook()
+    try:
+        worksheet = workbook["CPRS - CH"]
+        marker_value = worksheet["C30"].value
+        worksheet["B30"] = marker_value
+        worksheet["C30"] = None
+
+        assert (
+            workbook_generation_module._find_marker_row(
+                worksheet=worksheet,
+                marker_text="Total by Counterparty/Clearing House",
+            )
+            == 30
+        )
+    finally:
+        workbook.close()
+
+
 def _bump_first_annualized_volatility_column(workbook: Any) -> bool:
     for sheet_name in workbook.sheetnames:
         worksheet = workbook[sheet_name]
@@ -442,7 +499,5 @@ def _find_stop_row(worksheet: Any, start_row: int, stop_markers: tuple[str, ...]
 
 
 def _find_metric_section_bounds(worksheet: Any) -> tuple[int, int]:
-    """Return the fixed metric section bounds used by the MOSERS workbook generator."""
-    from counter_risk.mosers.workbook_generation import _CH_METRIC_END_ROW, _CH_METRIC_START_ROW
-
-    return (_CH_METRIC_START_ROW, _CH_METRIC_END_ROW)
+    """Return metric section bounds resolved from template markers."""
+    return workbook_generation_module._resolve_cprs_ch_metric_row_bounds(worksheet)


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #281

<!-- pr-preamble:end -->

## Scope
`workbook_generation.py` still relied on fixed CPRS-CH row constants and column-specific marker lookups. This updates MOSERS metric/section resolution to marker-driven logic with explicit failures when required markers/headers are missing.

## Tasks
- [x] Add template marker helpers that scan across worksheet cells and resolve row bounds by marker text.
- [x] Replace fixed CPRS-CH metric row constants with runtime marker-based row bound resolution.
- [x] Fail loudly when required CPRS-CH metric headers/markers or plug-values section markers are missing.
- [x] Add tests for shifted-template row detection, missing marker failures, and column-shift marker lookup.
- [x] Update macro spec docs to describe marker-driven metric writes and troubleshooting expectations.

## Acceptance Criteria
- [x] MOSERS CPRS-CH metric writes no longer depend on fixed row constants.
- [x] Missing/inconsistent markers fail loudly rather than silently skipping writes.
- [x] Tests cover nominal behavior plus shifted/missing marker cases.
- [x] Documentation reflects marker-driven behavior and guardrails.

## Validation
- [x] `.venv/bin/pytest -q tests/test_mosers_workbook.py`
- [x] `.venv/bin/pytest -q tests/test_mosers_workbook.py tests/test_mosers_all_programs_output_structure.py tests/test_mosers_ex_trend_output_structure.py tests/test_mosers_trend_output_structure.py`

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`workbook_generation.py` still uses fixed row/column coordinates for CPRS-CH metrics. Template edits silently misplace values, breaking the “no hard-coded row numbers” acceptance criteria.

#### Tasks
- [ ] Enhance the MOSERS template helper to locate metric blocks by scanning for headers like “Annualized Volatility” and “Allocation %” and return column/row spans.
- [ ] Update `generate_mosers_workbook*` functions to consume the dynamic coordinates and remove `_START_ROW/_END_ROW` constants.
- [ ] When markers are missing, raise a descriptive error or log a manifest warning instead of silently skipping writes.
- [ ] Add tests that simulate row/column shifts in the template to verify detection/failure behavior.
- [ ] Update `docs/macro_spec.md` (or MOSERS-specific docs) to explain the marker-based approach.

#### Acceptance criteria
- [ ] MOSERS writers no longer rely on fixed row/column constants for CPRS-CH metrics.
- [ ] Runs fail or warn loudly when markers are absent or inconsistent.
- [ ] Tests cover both nominal templates and shifted templates.
- [ ] Documentation reflects the marker-driven requirement and troubleshooting steps.

**Head SHA:** 939ecf7e19ef522c5b2f03a723c831681a89d6b3
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22529894292) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22529894280) |
<!-- auto-status-summary:end -->