### PR TITLE
[Agent] [Chat] Persist chat transcripts with trace metadata (#283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ The run-context chat assistant now uses LangChain-backed providers (instead of s
   - `CLAUDE_API_STRANSKE` (Anthropic path)
 - Optional routing/model overrides are also documented in `.env.example` (`LANGCHAIN_PROVIDER`,
   `LANGCHAIN_MODEL`, slot overrides, timeout/retry settings).
+- Chat transcripts are written per run under `runs/<...>/chat_logs/`; see
+  [docs/chat_logging.md](docs/chat_logging.md) for payload fields and LangSmith trace linkage.
 
 ## Features
 

--- a/docs/chat_logging.md
+++ b/docs/chat_logging.md
@@ -1,0 +1,34 @@
+# Chat Logging
+
+Counter_Risk persists each chat interaction to the active run folder for auditability.
+
+## Log Location
+
+- Directory: `runs/<as_of_timestamp>/chat_logs/`
+- File pattern: `chat_log_<YYYYMMDD>.jsonl`
+- Format: one JSON object per line (one line per chat submission)
+
+## Logged Fields
+
+Each JSONL row contains:
+
+- `interaction`: incrementing interaction number in the current session
+- `timestamp`: UTC timestamp (`Z` suffix)
+- `selected_provider` / `selected_model`: provider/model chosen by the operator
+- `provider` / `model`: resolved provider/model used for the actual invocation
+- `question`: validated user question text
+- `prompt`: guarded prompt payload sent to provider
+- `response`: assistant text returned by provider
+- `trace_id`: LangSmith trace ID when available
+- `trace_url`: full LangSmith trace URL when available
+
+## LangSmith Correlation
+
+When LangSmith tracing is enabled and the provider returns a trace/run ID, the
+`trace_id` and `trace_url` fields are populated so operators can correlate a chat
+turn in the run folder with the LangSmith trace view.
+
+## Failure Behavior
+
+If the chat log directory/file cannot be written, the chat submission fails with a
+clear error so operators know transcript persistence did not succeed.

--- a/src/counter_risk/chat/__init__.py
+++ b/src/counter_risk/chat/__init__.py
@@ -4,6 +4,7 @@ from counter_risk.chat.context import (
     RunContext,
     RunContextError,
     extract_key_warnings_and_deltas,
+    load_chat_logs,
     load_manifest,
     load_run_context,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "SubmitResult",
     "build_guarded_prompt",
     "extract_key_warnings_and_deltas",
+    "load_chat_logs",
     "get_provider_models",
     "is_provider_model_supported",
     "load_manifest",

--- a/src/counter_risk/chat/context.py
+++ b/src/counter_risk/chat/context.py
@@ -37,6 +37,7 @@ class RunContext:
     tables: dict[str, list[dict[str, Any]]]
     warnings: list[str]
     deltas: dict[str, list[dict[str, Any]]]
+    chat_logs: list[dict[str, Any]]
 
     def summary(self) -> str:
         """Build a compact summary string for chat prompt bootstrap."""
@@ -49,7 +50,8 @@ class RunContext:
             f"As-of date: {self.manifest.get('as_of_date', 'unknown')}; "
             f"Warnings: {len(self.warnings)}; "
             f"Variants: {variant_summary}; "
-            f"Tables: {table_summary}"
+            f"Tables: {table_summary}; "
+            f"Chat turns: {len(self.chat_logs)}"
         )
 
 
@@ -63,6 +65,7 @@ def load_run_context(run_dir: Path | str) -> RunContext:
     manifest = load_manifest(run_path)
     tables = discover_tables(run_path)
     warnings, deltas = extract_key_warnings_and_deltas(manifest)
+    chat_logs = load_chat_logs(run_path)
 
     return RunContext(
         run_dir=run_path,
@@ -70,6 +73,7 @@ def load_run_context(run_dir: Path | str) -> RunContext:
         tables=tables,
         warnings=warnings,
         deltas=deltas,
+        chat_logs=chat_logs,
     )
 
 
@@ -107,6 +111,32 @@ def discover_tables(run_dir: Path | str) -> dict[str, list[dict[str, Any]]]:
             tables[table_key] = _load_parquet_table(table_path)
 
     return tables
+
+
+def load_chat_logs(run_dir: Path | str) -> list[dict[str, Any]]:
+    """Load JSONL chat transcripts from ``run_dir/chat_logs``."""
+
+    run_path = Path(run_dir)
+    chat_dir = run_path / "chat_logs"
+    if not chat_dir.is_dir():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for log_path in sorted(chat_dir.glob("*.jsonl")):
+        try:
+            with log_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    payload = json.loads(stripped)
+                    if isinstance(payload, dict):
+                        records.append(dict(payload))
+        except json.JSONDecodeError as exc:
+            raise RunContextError(f"Malformed chat log file: {log_path}") from exc
+        except OSError as exc:
+            raise RunContextError(f"Failed to read chat log file: {log_path}") from exc
+    return records
 
 
 def extract_key_warnings_and_deltas(

--- a/src/counter_risk/chat/context.py
+++ b/src/counter_risk/chat/context.py
@@ -125,13 +125,17 @@ def load_chat_logs(run_dir: Path | str) -> list[dict[str, Any]]:
     for log_path in sorted(chat_dir.glob("*.jsonl")):
         try:
             with log_path.open("r", encoding="utf-8") as handle:
-                for line in handle:
+                for line_number, line in enumerate(handle, start=1):
                     stripped = line.strip()
                     if not stripped:
                         continue
                     payload = json.loads(stripped)
-                    if isinstance(payload, dict):
-                        records.append(dict(payload))
+                    if not isinstance(payload, dict):
+                        raise RunContextError(
+                            "Malformed chat log file: "
+                            f"{log_path} contains non-object JSON on line {line_number}"
+                        )
+                    records.append(dict(payload))
         except json.JSONDecodeError as exc:
             raise RunContextError(f"Malformed chat log file: {log_path}") from exc
         except OSError as exc:

--- a/src/counter_risk/chat/session.py
+++ b/src/counter_risk/chat/session.py
@@ -198,18 +198,41 @@ class ChatSession:
         provider_client = _PROVIDER_CLIENTS[selected_provider]
         context_answer = self._answer_from_context(clean_question)
         messages = self._build_provider_messages(prompt=prompt, question=clean_question)
+        provider_response_metadata: dict[str, object] = {}
         answer = provider_client.generate(
             messages=messages,
             model=selected_model,
             context_answer=context_answer,
+            response_metadata=provider_response_metadata,
         )
 
         self.history.append(ChatMessage(role="user", content=clean_question))
         self.history.append(ChatMessage(role="assistant", content=answer))
+        self._interaction_counter += 1
         _LOGGER.debug("Built guarded prompt of %s characters", len(prompt))
 
+        resolved_provider = str(provider_response_metadata.get("provider") or selected_provider)
+        resolved_model = str(provider_response_metadata.get("model") or selected_model)
+        trace_id_raw = provider_response_metadata.get("trace_id")
+        trace_url_raw = provider_response_metadata.get("trace_url")
+        trace_id = None if trace_id_raw in (None, "") else str(trace_id_raw)
+        trace_url = None if trace_url_raw in (None, "") else str(trace_url_raw)
+
+        _append_chat_turn_log(
+            run_dir=self.context.run_dir,
+            interaction_number=self._interaction_counter,
+            question=clean_question,
+            prompt=prompt,
+            response=answer,
+            selected_provider=selected_provider,
+            selected_model=selected_model,
+            resolved_provider=resolved_provider,
+            resolved_model=resolved_model,
+            trace_id=trace_id,
+            trace_url=trace_url,
+        )
+
         if self.enable_llm_logging:
-            self._interaction_counter += 1
             _write_llm_log(
                 run_dir=self.context.run_dir,
                 interaction_number=self._interaction_counter,
@@ -635,6 +658,52 @@ def _find_delta_metric(record: dict[str, object]) -> tuple[str, str]:
 
 
 _LLM_LOG_DIR_NAME: Final[str] = "llm_logs"
+_CHAT_LOG_DIR_NAME: Final[str] = "chat_logs"
+
+
+def _append_chat_turn_log(
+    *,
+    run_dir: Path,
+    interaction_number: int,
+    question: str,
+    prompt: str,
+    response: str,
+    selected_provider: str,
+    selected_model: str,
+    resolved_provider: str,
+    resolved_model: str,
+    trace_id: str | None,
+    trace_url: str | None,
+) -> None:
+    """Append one chat interaction to the run-level JSONL transcript."""
+
+    now = datetime.now(tz=UTC)
+    timestamp = now.isoformat().replace("+00:00", "Z")
+    daystamp = now.strftime("%Y%m%d")
+    log_dir = run_dir / _CHAT_LOG_DIR_NAME
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"chat_log_{daystamp}.jsonl"
+
+    payload = {
+        "interaction": interaction_number,
+        "timestamp": timestamp,
+        "selected_provider": selected_provider,
+        "selected_model": selected_model,
+        "provider": resolved_provider,
+        "model": resolved_model,
+        "question": question,
+        "prompt": prompt,
+        "response": response,
+        "trace_id": trace_id,
+        "trace_url": trace_url,
+    }
+
+    try:
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True))
+            handle.write("\n")
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write chat log transcript: {log_path}") from exc
 
 
 def _write_llm_log(

--- a/src/counter_risk/chat/session.py
+++ b/src/counter_risk/chat/session.py
@@ -681,7 +681,6 @@ def _append_chat_turn_log(
     timestamp = now.isoformat().replace("+00:00", "Z")
     daystamp = now.strftime("%Y%m%d")
     log_dir = run_dir / _CHAT_LOG_DIR_NAME
-    log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"chat_log_{daystamp}.jsonl"
 
     payload = {
@@ -699,6 +698,7 @@ def _append_chat_turn_log(
     }
 
     try:
+        log_dir.mkdir(parents=True, exist_ok=True)
         with log_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(payload, sort_keys=True))
             handle.write("\n")

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -13,6 +13,7 @@ from counter_risk.chat.context import (
     RunContextError,
     _load_parquet_table,
     discover_tables,
+    load_chat_logs,
     load_manifest,
     load_run_context,
 )
@@ -36,12 +37,30 @@ def test_load_run_context_returns_non_empty_summary(tmp_path: Path) -> None:
         "counterparty,Notional,NotionalChange\nA,10.0,2.5\n",
         encoding="utf-8",
     )
+    chat_dir = run_dir / "chat_logs"
+    chat_dir.mkdir()
+    (chat_dir / "chat_log_20260213.jsonl").write_text(
+        json.dumps(
+            {
+                "interaction": 1,
+                "provider": "openai",
+                "model": "gpt-5.2",
+                "question": "top exposures",
+                "response": "ok",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     context = load_run_context(run_dir)
 
     assert context.warnings
     assert context.deltas["all_programs"][0]["counterparty"] == "A"
     assert "totals.csv" in context.tables
+    assert len(context.chat_logs) == 1
+    assert context.chat_logs[0]["provider"] == "openai"
+    assert "Chat turns: 1" in context.summary()
     assert context.summary().strip() != ""
 
 
@@ -125,3 +144,20 @@ def test_load_parquet_table_pyarrow_io_error_message(
         _load_parquet_table(parquet_path)
 
     assert "Check file path and permissions" in str(exc_info.value)
+
+
+def test_load_chat_logs_returns_empty_when_directory_missing(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    assert load_chat_logs(run_dir) == []
+
+
+def test_load_chat_logs_raises_for_malformed_jsonl(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    chat_dir = run_dir / "chat_logs"
+    chat_dir.mkdir(parents=True)
+    (chat_dir / "chat_log_20260213.jsonl").write_text("{bad-json\n", encoding="utf-8")
+
+    with pytest.raises(RunContextError, match="Malformed chat log file"):
+        load_chat_logs(run_dir)

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -161,3 +161,13 @@ def test_load_chat_logs_raises_for_malformed_jsonl(tmp_path: Path) -> None:
 
     with pytest.raises(RunContextError, match="Malformed chat log file"):
         load_chat_logs(run_dir)
+
+
+def test_load_chat_logs_raises_for_non_object_json_payload(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    chat_dir = run_dir / "chat_logs"
+    chat_dir.mkdir(parents=True)
+    (chat_dir / "chat_log_20260213.jsonl").write_text('["not-an-object"]\n', encoding="utf-8")
+
+    with pytest.raises(RunContextError, match="non-object JSON on line 1"):
+        load_chat_logs(run_dir)

--- a/tests/test_chat_provider_clients.py
+++ b/tests/test_chat_provider_clients.py
@@ -55,6 +55,10 @@ def test_langchain_provider_client_uses_fallback_provider_when_first_unavailable
             "anthropic": set(),
         },
     )
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
     calls: list[tuple[str | None, str | None]] = []
 
     def _fake_build_chat_client(

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -454,3 +454,28 @@ def test_chat_session_surfaces_chat_log_write_failures(
 
     with pytest.raises(RuntimeError, match="Failed to write chat log transcript"):
         session.ask("top exposures")
+
+
+def test_chat_session_surfaces_chat_log_directory_create_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = load_run_context(_write_minimal_run(tmp_path))
+    session = ChatSession(context=context, provider="local", model=_MODEL_KEY)
+
+    original_mkdir = Path.mkdir
+
+    def _failing_mkdir(
+        self: Path,
+        mode: int = 0o777,
+        parents: bool = False,
+        exist_ok: bool = False,
+    ) -> None:
+        if self.name == _CHAT_LOG_DIR_NAME:
+            raise OSError("permission denied")
+        original_mkdir(self, mode=mode, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", _failing_mkdir)
+
+    with pytest.raises(RuntimeError, match="Failed to write chat log transcript"):
+        session.ask("top exposures")

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import IO, Any
 
 import pytest
 
 from counter_risk.chat import session as session_module
 from counter_risk.chat.context import load_run_context
 from counter_risk.chat.session import (
+    _CHAT_LOG_DIR_NAME,
     _LLM_LOG_DIR_NAME,
     ChatSession,
     ChatSessionError,
@@ -340,6 +342,10 @@ def test_llm_logging_writes_prompt_response_artifacts_when_enabled(tmp_path: Pat
     assert payload["model"] == _MODEL_KEY
     assert payload["response"]
 
+    chat_log_dir = context.run_dir / _CHAT_LOG_DIR_NAME
+    chat_logs = sorted(chat_log_dir.glob("*.jsonl"))
+    assert len(chat_logs) == 1
+
 
 def test_llm_logging_writes_multiple_artifacts_for_multiple_interactions(tmp_path: Path) -> None:
     context = load_run_context(_write_minimal_run(tmp_path))
@@ -370,3 +376,81 @@ def test_llm_logging_disabled_writes_no_artifacts(tmp_path: Path) -> None:
 
     log_dir = context.run_dir / _LLM_LOG_DIR_NAME
     assert not log_dir.exists()
+
+    chat_log_dir = context.run_dir / _CHAT_LOG_DIR_NAME
+    chat_logs = sorted(chat_log_dir.glob("*.jsonl"))
+    assert len(chat_logs) == 1
+
+
+def test_chat_session_writes_jsonl_chat_log_with_trace_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = load_run_context(_write_minimal_run(tmp_path))
+    openai_model = _provider_model("openai")
+
+    class _TraceProvider:
+        def generate(self, messages: list[dict[str, str]], model: str, **kwargs: object) -> str:
+            _ = messages
+            metadata = kwargs.get("response_metadata")
+            if isinstance(metadata, dict):
+                metadata.update(
+                    {
+                        "provider": "github-models",
+                        "model": model,
+                        "trace_id": "trace-123",
+                        "trace_url": "https://smith.langchain.com/r/trace-123",
+                    }
+                )
+            return "trace-enabled-response"
+
+    monkeypatch.setitem(session_module._PROVIDER_CLIENTS, "openai", _TraceProvider())
+    session = ChatSession(context=context, provider="openai", model=openai_model)
+
+    answer = session.ask("top exposures")
+
+    assert answer == "trace-enabled-response"
+    chat_log_dir = context.run_dir / _CHAT_LOG_DIR_NAME
+    chat_logs = sorted(chat_log_dir.glob("*.jsonl"))
+    assert len(chat_logs) == 1
+    lines = [line for line in chat_logs[0].read_text(encoding="utf-8").splitlines() if line]
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["provider"] == "github-models"
+    assert payload["model"] == openai_model
+    assert payload["trace_id"] == "trace-123"
+    assert payload["trace_url"] == "https://smith.langchain.com/r/trace-123"
+
+
+def test_chat_session_surfaces_chat_log_write_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = load_run_context(_write_minimal_run(tmp_path))
+    session = ChatSession(context=context, provider="local", model=_MODEL_KEY)
+
+    original_open = Path.open
+
+    def _failing_open(
+        self: Path,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> IO[Any]:
+        if self.suffix == ".jsonl" and "chat_logs" in str(self):
+            raise OSError("permission denied")
+        return original_open(
+            self,
+            mode=mode,
+            buffering=buffering,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+        )
+
+    monkeypatch.setattr(Path, "open", _failing_open)
+
+    with pytest.raises(RuntimeError, match="Failed to write chat log transcript"):
+        session.ask("top exposures")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #283

<!-- pr-preamble:end -->

## Scope
Adds durable run-folder chat transcripts with provider/model and LangSmith trace metadata so every chat turn is auditable and correlated to trace links when available.

## Tasks
- [x] Capture provider response metadata (`provider`, `model`, `trace_id`, `trace_url`) from LangChain-backed providers.
- [x] Append each chat turn to run-scoped JSONL transcript files under `chat_logs/`.
- [x] Extend run-context loading with chat log discovery (`load_chat_logs`) and include chat-turn counts in summaries.
- [x] Keep legacy per-interaction debug logging (`llm_logs`) optional while making transcript logging mandatory.
- [x] Add tests for JSONL transcript creation, trace metadata persistence, malformed-log handling, and log-write failure surfacing.
- [x] Document transcript location/fields and LangSmith correlation (`docs/chat_logging.md`, `README.md`).

## Acceptance Criteria
- [x] Every chat submission appends a JSONL transcript record with prompt/response, provider/model, timestamp, and trace metadata when available.
- [x] Run-context helpers can load and surface chat transcript records from the run folder.
- [x] Chat log write failures surface a clear runtime error (no silent drop).
- [x] Tests validate happy path + failure path behavior for transcript logging.

## Validation
- [x] `.venv/bin/ruff check src/counter_risk/chat/providers/base.py src/counter_risk/chat/session.py src/counter_risk/chat/context.py src/counter_risk/chat/__init__.py tests/test_chat_provider_clients.py tests/test_chat_session.py tests/test_chat_context.py`
- [x] `.venv/bin/mypy src tests`
- [x] `.venv/bin/pytest -q tests/test_chat_provider_clients.py tests/test_chat_session.py tests/test_chat_context.py tests/test_chat_ui.py`

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Issue #33 requires treating workbook text as untrusted and logging prompt/response interactions. Currently chat runs are ephemeral—no transcript storage, no LangSmith trace links, and no manifests capturing what was asked.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#33](https://github.com/stranske/Counter_Risk/issues/33)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Extend `ChatSession.ask()` to capture prompt payload, LangChain response metadata (trace/run IDs), and assistant output before returning.
- [ ] Add a logging sink (e.g., `run_dir/chat_logs/chat_log_<timestamp>.jsonl`) that appends each turn with fields: provider, model, sanitized prompt text, response text, LangSmith trace URL if present.
- [ ] Update `RunContext` to load chat logs (or at least provide a helper) so future UI features can display history.
- [ ] Surface trace links/errors to the user: include the LangSmith URL (when available) and instruct operators how to retrieve the transcript.
- [ ] Write documentation (`docs/AGENTS.md` or new `docs/chat_logging.md`) explaining retention policy, sensitive data handling, and how to review logs.
- [ ] Add tests ensuring logs are written, rotations occur per run, and LangSmith metadata is included/mocked when the provider returns it.

#### Acceptance criteria
- [ ] Every chat submission writes a JSONL record with prompt, response, provider/model, timestamp, and (when available) LangSmith trace URL.
- [ ] Operators can locate logs under the associated run folder and correlate them with LangSmith traces.
- [ ] Test suite validates logging behavior and ensures failures when the log directory is unwritable surface clear errors.
- [ ] Documentation covers how to enable/disable logging and how to review prompts for audit purposes.

**Head SHA:** 1799d9d92f47a303ddbc45824f559aa756b4baa0
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22529905724) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22529905725) |
<!-- auto-status-summary:end -->