### PR TITLE
[Agent] [Chat] Restrict local stub provider to offline mode (#282)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ LANGCHAIN_SLOT3_MODEL=
 
 LANGSMITH_API_KEY=
 LANGCHAIN_PROJECT=counter-risk-chat
+
+# Offline/local chat stub mode (tests/dev only)
+# Leave unset in normal environments so only real providers are available.
+COUNTER_RISK_CHAT_OFFLINE_MODE=

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The run-context chat assistant now uses LangChain-backed providers (instead of s
   - `GITHUB_TOKEN` (used for OpenAI-compatible GitHub Models path)
   - `OPENAI_API_KEY` (direct OpenAI path)
   - `CLAUDE_API_STRANSKE` (Anthropic path)
+- The deterministic local stub provider is disabled by default and only available when
+  `COUNTER_RISK_CHAT_OFFLINE_MODE=1` (intended for offline tests/dev only).
 - Optional routing/model overrides are also documented in `.env.example` (`LANGCHAIN_PROVIDER`,
   `LANGCHAIN_MODEL`, slot overrides, timeout/retry settings).
 

--- a/src/counter_risk/chat/providers/base.py
+++ b/src/counter_risk/chat/providers/base.py
@@ -40,7 +40,9 @@ class ProviderModelRegistry:
     provider_model_required_env_keys: dict[str, dict[str, tuple[str, ...]]]
 
 
-def build_provider_model_registry(*, local_model: str) -> ProviderModelRegistry:
+def build_provider_model_registry(
+    *, local_model: str, include_local: bool = True
+) -> ProviderModelRegistry:
     """Build provider model allowlists from shared slot configuration."""
 
     slot_catalog = get_provider_model_catalog()
@@ -67,17 +69,21 @@ def build_provider_model_registry(*, local_model: str) -> ProviderModelRegistry:
 
     anthropic_model_requirements = dict.fromkeys(sorted(anthropic_models), _ANTHROPIC_ENV_KEYS)
 
+    provider_models: dict[str, set[str]] = {
+        "openai": openai_models,
+        "anthropic": anthropic_models,
+    }
+    provider_model_required_env_keys: dict[str, dict[str, tuple[str, ...]]] = {
+        "openai": openai_model_requirements,
+        "anthropic": anthropic_model_requirements,
+    }
+    if include_local:
+        provider_models["local"] = {local_model}
+        provider_model_required_env_keys["local"] = {local_model: ()}
+
     return ProviderModelRegistry(
-        provider_models={
-            "local": {local_model},
-            "openai": openai_models,
-            "anthropic": anthropic_models,
-        },
-        provider_model_required_env_keys={
-            "local": {local_model: ()},
-            "openai": openai_model_requirements,
-            "anthropic": anthropic_model_requirements,
-        },
+        provider_models=provider_models,
+        provider_model_required_env_keys=provider_model_required_env_keys,
     )
 
 

--- a/src/counter_risk/chat/session.py
+++ b/src/counter_risk/chat/session.py
@@ -24,11 +24,48 @@ from counter_risk.chat.utils import cmp_with_tol, is_close
 _LOGGER = logging.getLogger(__name__)
 
 _PLACEHOLDER_MODEL: Final[str] = "chat-model-placeholder"
+_OFFLINE_MODE_ENV: Final[str] = "COUNTER_RISK_CHAT_OFFLINE_MODE"
 _PROVIDER_MODEL_REGISTRY = build_provider_model_registry(local_model=_PLACEHOLDER_MODEL)
 _PROVIDER_MODELS: Final[dict[str, set[str]]] = _PROVIDER_MODEL_REGISTRY.provider_models
 _PROVIDER_MODEL_REQUIRED_ENV_KEYS: Final[dict[str, dict[str, tuple[str, ...]]]] = (
     _PROVIDER_MODEL_REGISTRY.provider_model_required_env_keys
 )
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().casefold() in {"1", "true", "yes", "on"}
+
+
+def _offline_mode_enabled() -> bool:
+    return _is_truthy(os.environ.get(_OFFLINE_MODE_ENV))
+
+
+def _visible_provider_models() -> dict[str, set[str]]:
+    if _offline_mode_enabled():
+        return _PROVIDER_MODELS
+    return {
+        provider: models
+        for provider, models in _PROVIDER_MODELS.items()
+        if provider != "local"
+    }
+
+
+def _default_provider_key() -> str:
+    visible = _visible_provider_models()
+    for provider in ("openai", "anthropic", "local"):
+        if provider in visible:
+            return provider
+    return "openai"
+
+
+def _default_model_key() -> str:
+    provider = _default_provider_key()
+    models = tuple(sorted(_visible_provider_models().get(provider, ())))
+    if models:
+        return models[0]
+    return _PLACEHOLDER_MODEL
 
 _INJECTION_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
     re.compile(r"ignore\s+(all\s+)?(previous|prior)\s+instructions", re.IGNORECASE),
@@ -145,8 +182,8 @@ class ChatSession:
     """In-memory chat session with provider/model validation and guarded prompting."""
 
     context: RunContext
-    provider: str = "local"
-    model: str = _PLACEHOLDER_MODEL
+    provider: str = field(default_factory=_default_provider_key)
+    model: str = field(default_factory=_default_model_key)
     history: list[ChatMessage] = field(default_factory=list)
     enable_llm_logging: bool = False
     _interaction_counter: int = field(default=0, init=False, repr=False)
@@ -155,6 +192,11 @@ class ChatSession:
         self.provider = self.provider.strip().lower()
         self.model = self.model.strip()
 
+        if self.provider == "local" and not _offline_mode_enabled():
+            raise ChatSessionError(
+                "Provider 'local' is only available in offline test mode "
+                f"({_OFFLINE_MODE_ENV}=1)."
+            )
         if self.provider != "local" and not provider_env_available(self.provider):
             raise ChatSessionError(
                 f"Provider '{self.provider}' is not configured in the environment."
@@ -186,6 +228,11 @@ class ChatSession:
         selected_provider = (provider_key or self.provider).strip().lower()
         selected_model = (model_key or self.model).strip()
 
+        if selected_provider == "local" and not _offline_mode_enabled():
+            raise ChatSessionError(
+                "Provider 'local' is only available in offline test mode "
+                f"({_OFFLINE_MODE_ENV}=1)."
+            )
         if selected_provider != "local" and not provider_env_available(selected_provider):
             raise ChatSessionError(
                 f"Provider '{selected_provider}' is not configured in the environment."
@@ -254,6 +301,8 @@ def is_provider_model_supported(provider: str, model: str) -> bool:
     """Return True when provider/model selection is allowed."""
 
     provider_key = provider.strip().lower()
+    if provider_key == "local" and not _offline_mode_enabled():
+        return False
     model_key = model.strip()
     available_models = _PROVIDER_MODELS.get(provider_key)
     if available_models is None:
@@ -267,7 +316,10 @@ def is_provider_model_supported(provider: str, model: str) -> bool:
 def get_provider_models() -> dict[str, tuple[str, ...]]:
     """Return provider/model catalog for UI and validation surfaces."""
 
-    return {provider: tuple(sorted(models)) for provider, models in _PROVIDER_MODELS.items()}
+    return {
+        provider: tuple(sorted(models))
+        for provider, models in _visible_provider_models().items()
+    }
 
 
 # Safeguards reduce injection risk but do not replace model-side safety systems.

--- a/src/counter_risk/chat/session.py
+++ b/src/counter_risk/chat/session.py
@@ -52,10 +52,25 @@ def _visible_provider_models() -> dict[str, set[str]]:
     }
 
 
+def _model_credentials_available(provider: str, model: str) -> bool:
+    required_env_keys = _PROVIDER_MODEL_REQUIRED_ENV_KEYS.get(provider, {}).get(model, ())
+    if not required_env_keys:
+        return True
+    return any(os.environ.get(env_key) for env_key in required_env_keys)
+
+
 def _default_provider_key() -> str:
     visible = _visible_provider_models()
     for provider in ("openai", "anthropic", "local"):
-        if provider in visible:
+        provider_models = visible.get(provider)
+        if not provider_models:
+            continue
+        if provider != "local" and not provider_env_available(provider):
+            continue
+        if any(_model_credentials_available(provider, model) for model in provider_models):
+            return provider
+    for provider, provider_models in visible.items():
+        if any(_model_credentials_available(provider, model) for model in provider_models):
             return provider
     return "openai"
 
@@ -63,6 +78,9 @@ def _default_provider_key() -> str:
 def _default_model_key() -> str:
     provider = _default_provider_key()
     models = tuple(sorted(_visible_provider_models().get(provider, ())))
+    for model in models:
+        if _model_credentials_available(provider, model):
+            return model
     if models:
         return models[0]
     return _PLACEHOLDER_MODEL

--- a/tests/test_chat_provider_clients.py
+++ b/tests/test_chat_provider_clients.py
@@ -19,6 +19,16 @@ def test_build_provider_model_registry_uses_real_model_ids() -> None:
     assert registry.provider_models["anthropic"]
 
 
+def test_build_provider_model_registry_can_exclude_local_stub_model() -> None:
+    registry = provider_base.build_provider_model_registry(
+        local_model="chat-model-placeholder",
+        include_local=False,
+    )
+
+    assert "local" not in registry.provider_models
+    assert "local" not in registry.provider_model_required_env_keys
+
+
 def test_build_provider_model_registry_tracks_credential_requirements_per_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -30,6 +30,7 @@ _MODEL_KEY = "chat-model-placeholder"
 def _provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_TOKEN", "test-token")
     monkeypatch.setenv("CLAUDE_API_STRANSKE", "test-token")
+    monkeypatch.setenv("COUNTER_RISK_CHAT_OFFLINE_MODE", "1")
 
 
 def _provider_model(provider: str) -> str:
@@ -100,6 +101,29 @@ def test_chat_session_returns_manifest_top_exposure(tmp_path: Path) -> None:
     assert "all_programs: A (10.00)" in answer
     assert answer.index("all_programs: B (20.00)") < answer.index("all_programs: A (10.00)")
     assert len(session.history) == 2
+
+
+def test_chat_session_rejects_local_provider_when_offline_mode_is_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COUNTER_RISK_CHAT_OFFLINE_MODE", raising=False)
+    context = load_run_context(_write_minimal_run(tmp_path))
+
+    with pytest.raises(ChatSessionError, match="offline test mode"):
+        ChatSession(context=context, provider="local", model=_MODEL_KEY)
+
+
+def test_get_provider_models_hides_local_provider_when_offline_mode_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COUNTER_RISK_CHAT_OFFLINE_MODE", raising=False)
+
+    provider_models = get_provider_models()
+
+    assert "local" not in provider_models
+    assert "openai" in provider_models
+    assert "anthropic" in provider_models
 
 
 def test_chat_session_provider_is_deterministic_for_same_prompt(

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -126,6 +126,53 @@ def test_get_provider_models_hides_local_provider_when_offline_mode_is_disabled(
     assert "anthropic" in provider_models
 
 
+def test_chat_session_default_provider_prefers_available_provider_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COUNTER_RISK_CHAT_OFFLINE_MODE", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CLAUDE_API_STRANSKE", "anthropic-test-token")
+    context = load_run_context(_write_minimal_run(tmp_path))
+
+    session = ChatSession(context=context)
+
+    assert session.provider == "anthropic"
+    assert session.model in session_module.get_provider_models()["anthropic"]
+
+
+def test_chat_session_default_model_uses_credential_compatible_option(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COUNTER_RISK_CHAT_OFFLINE_MODE", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_API_STRANSKE", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-token")
+    monkeypatch.setattr(
+        session_module,
+        "_PROVIDER_MODELS",
+        {"openai": {"github-only-model", "openai-only-model"}},
+    )
+    monkeypatch.setattr(
+        session_module,
+        "_PROVIDER_MODEL_REQUIRED_ENV_KEYS",
+        {
+            "openai": {
+                "github-only-model": ("GITHUB_TOKEN",),
+                "openai-only-model": ("OPENAI_API_KEY",),
+            }
+        },
+    )
+    context = load_run_context(_write_minimal_run(tmp_path))
+
+    session = ChatSession(context=context)
+
+    assert session.provider == "openai"
+    assert session.model == "openai-only-model"
+
+
 def test_chat_session_provider_is_deterministic_for_same_prompt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #282

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The current chat workflow only talks to deterministic stub classes (`openai_stub`, `anthropic_stub`). Operators cannot query actual GPT or Claude models, and Issue #33’s “LLM interaction layer” remains unfulfilled.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#33](https://github.com/stranske/Counter_Risk/issues/33)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Update `src/counter_risk/chat/providers/base.py` to define a concrete `LangChainProviderClient` wrapper that calls `tools.llm_provider.get_llm_provider()` with selected provider/model.
- [ ] Replace `_PROVIDER_CLIENTS` and `_PROVIDER_MODELS` definitions in `src/counter_risk/chat/session.py` with data sourced from `tools.llm_provider` (real model names + availability checks).
- [ ] Implement provider adapters that call LangChain’s `ChatOpenAI` / `ChatAnthropic` / GitHub Models endpoints (using the shared helper) and return assistant text + optional trace metadata.
- [ ] Add environment/config plumbing so provider API keys and base URLs are loaded from the same mechanism used by repo automation (docs + `.env.example` update).
- [ ] Expand unit tests (`tests/test_chat_session.py`) to cover real provider selection (mocking LangChain client responses) and invalid model errors.

#### Acceptance criteria
- [ ] Chat UI/session code can call at least two real providers (OpenAI via GitHub Models + Anthropic) when credentials are configured.
- [ ] Provider/model dropdowns list actual model IDs returned by the LangChain helper instead of placeholder text.
- [ ] When a provider call fails (rate limit, invalid key), `SubmitResult` returns a clear error string and no assistant message.
- [ ] Tests cover provider/model validation and ensure stubs are only used in offline test mode.

**Head SHA:** 80522ef198d8e9f15e61a375744ceb8a711356a9
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530032951) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530148391) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530148404) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530033398) |
| Gate | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530033524) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530033480) |
<!-- auto-status-summary:end -->