### PR TITLE
[Agent] [M1] Close issue #216 canonicalization acceptance gaps

### DIFF
--- a/src/counter_risk/writers/pptx_screenshots.py
+++ b/src/counter_risk/writers/pptx_screenshots.py
@@ -10,6 +10,8 @@ from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.shapes.base import BaseShape
 from pptx.slide import Slide
 
+from counter_risk.normalize import canonicalize_name
+
 _SECTION_TITLE_SUBSTRINGS: dict[str, tuple[str, ...]] = {
     "allprograms": ("allprograms",),
     "extrend": ("extrend", "excludingtrend"),
@@ -24,7 +26,8 @@ _EXPECTED_PICTURE_GEOMETRY_BY_SECTION: dict[str, tuple[tuple[int, int, int, int]
 
 
 def _normalize_key(value: str) -> str:
-    return "".join(ch.lower() for ch in value if ch.isalnum())
+    canonical = canonicalize_name(value)
+    return "".join(ch.lower() for ch in canonical if ch.isalnum())
 
 
 def _slide_title(slide: Slide) -> str:

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1303,7 +1303,23 @@ def test_run_pipeline_writes_expected_outputs_and_manifest(
     assert manifest["missing_inputs"]["missing_required"] == []
     assert manifest["reconciliation_results"]["status"] in {"passed", "failed"}
     assert manifest["reconciliation_results"]["fail_policy"] in {"warn", "strict"}
-    assert isinstance(manifest["reconciliation_results"]["by_variant"], dict)
+    by_variant = manifest["reconciliation_results"]["by_variant"]
+    assert isinstance(by_variant, dict)
+    assert by_variant
+    for variant_result in by_variant.values():
+        by_sheet = variant_result["by_sheet"]
+        assert isinstance(by_sheet, dict)
+        assert by_sheet
+        for sheet_result in by_sheet.values():
+            canonical_key_by_series = sheet_result["canonical_key_by_series"]
+            assert isinstance(canonical_key_by_series, dict)
+            counterparties_in_data = sheet_result["counterparties_in_data"]
+            clearing_houses_in_data = sheet_result["clearing_houses_in_data"]
+            for series_label in set(counterparties_in_data).union(clearing_houses_in_data):
+                assert series_label in canonical_key_by_series
+                canonical_value = canonical_key_by_series[series_label]
+                assert isinstance(canonical_value, str)
+                assert canonical_value.strip()
 
     expected_hashes = {
         "mosers_all_programs_xlsx": _sha256(

--- a/tests/writers/test_pptx_screenshots.py
+++ b/tests/writers/test_pptx_screenshots.py
@@ -7,6 +7,7 @@ import pytest
 from pptx import Presentation
 from pptx.util import Inches
 
+from counter_risk.writers import pptx_screenshots as screenshots_module
 from counter_risk.writers.pptx_screenshots import replace_screenshot_pictures
 
 _RED_PNG = base64.b64decode(
@@ -129,3 +130,18 @@ def test_replace_screenshot_pictures_raises_when_section_not_found(tmp_path: Pat
             {"Missing Section": replacement},
             output,
         )
+
+
+def test_normalize_key_uses_canonicalize_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def _fake_canonicalize(value: str) -> str:
+        calls.append(value)
+        return "Ex Trend"
+
+    monkeypatch.setattr(screenshots_module, "canonicalize_name", _fake_canonicalize)
+
+    normalized = screenshots_module._normalize_key("Ex\u2014Trend")
+
+    assert normalized == "extrend"
+    assert calls == ["Ex\u2014Trend"]


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #216

<!-- pr-preamble:end -->

## Scope
Complete the remaining Issue #216 acceptance gaps by:
- asserting canonical series keys are present and non-empty in run manifest reconciliation payloads
- applying canonical name normalization in PPT title/section key matching logic before lookup operations

## Tasks
- [x] Tighten `test_run_pipeline_writes_expected_outputs_and_manifest` to require `reconciliation_results.by_variant.*.by_sheet.*.canonical_key_by_series` for matched labels.
- [x] Ensure PPT screenshot section-title matching normalizes titles via `canonicalize_name()` before key matching.
- [x] Add focused unit coverage proving PPT key normalization path uses canonicalization.

## Acceptance Criteria
- [x] Matching behavior remains stable with spacing/punctuation variants and canonicalization is used before title-key matching.
- [x] Run manifest contract now explicitly verifies canonical key coverage for each matched counterparty/series label.

## Validation
- [x] `ruff check src/counter_risk/writers/pptx_screenshots.py tests/writers/test_pptx_screenshots.py tests/pipeline/test_run_pipeline.py`
- [x] `pytest -q tests/writers/test_pptx_screenshots.py tests/pipeline/test_run_pipeline.py -k "writes_expected_outputs_and_manifest or normalize_key_uses_canonicalize_name"`

Closes #216

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
A single leading/trailing space or inconsistent punctuation can break series matching across Excel headers, PPT chart series, and parsed counterparty names.

#### Tasks
- [ ] Implement `canonicalize_name()`: strip leading/trailing whitespace collapse repeated spaces normalize apostrophes/hyphens where appropriate
- [ ] Add a “safe display name” function separate from “matching key”
- [ ] Apply canonicalization before all lookup/match operations
- [ ] Add tests with known tricky cases (spaces, punctuation, capitalization)

#### Acceptance criteria
- [ ] Matching behavior is stable even when headers have extra spaces
- [ ] A run manifest includes the canonical key used for each matched counterparty/series

**Head SHA:** a6cc8f9a39f090b5d491286e516b0ebe2415a194
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530334258) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530440034) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530440010) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530339223) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530336941) |
| Gate | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530336974) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22530336916) |
<!-- auto-status-summary:end -->