### PR TITLE
[Agent] [Chat] Add configurable chat logging modes (#304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ The run-context chat assistant now uses LangChain-backed providers (instead of s
   `COUNTER_RISK_CHAT_OFFLINE_MODE=1` (intended for offline tests/dev only).
 - Optional routing/model overrides are also documented in `.env.example` (`LANGCHAIN_PROVIDER`,
   `LANGCHAIN_MODEL`, slot overrides, timeout/retry settings).
-- Chat transcripts are written per run under `runs/<...>/chat_logs/`; see
-  [docs/chat_logging.md](docs/chat_logging.md) for payload fields and LangSmith trace linkage.
-- Transcript logging is always on for audits; optional legacy `llm_logs` artifacts can be
-  enabled by code paths that set `ChatSession(enable_llm_logging=True)`.
+- Chat logging mode defaults to `transcript`; override with `COUNTER_RISK_CHAT_LOG_MODE`
+  (`transcript`, `full`, `off`).
+- See [docs/chat_logging.md](docs/chat_logging.md) for mode behavior, payload fields, and
+  LangSmith trace linkage.
 
 ## Workflow Run Command
 

--- a/docs/chat_logging.md
+++ b/docs/chat_logging.md
@@ -4,10 +4,13 @@ Counter_Risk persists each chat interaction to the active run folder for auditab
 
 ## Logging Controls
 
-- Transcript logging (`chat_logs/*.jsonl`) is always enabled by design for run-level auditability.
-- There is no runtime toggle to disable transcript logging.
-- Legacy debug prompt/response artifacts (`llm_logs/*.json`) are optional and only written when
-  `ChatSession(enable_llm_logging=True)` is used by the caller.
+- Logging mode is controlled by `ChatSession(log_mode=...)` or `COUNTER_RISK_CHAT_LOG_MODE`.
+- Supported modes:
+  - `transcript` (default): write `chat_logs/*.jsonl` only
+  - `full`: write `chat_logs/*.jsonl` and `llm_logs/*.json`
+  - `off`: write no chat artifacts
+- Legacy debug flag `ChatSession(enable_llm_logging=True)` still forces `llm_logs/*.json`
+  regardless of mode for backward compatibility.
 
 ## Log Location
 

--- a/src/counter_risk/chat/session.py
+++ b/src/counter_risk/chat/session.py
@@ -25,6 +25,15 @@ _LOGGER = logging.getLogger(__name__)
 
 _PLACEHOLDER_MODEL: Final[str] = "chat-model-placeholder"
 _OFFLINE_MODE_ENV: Final[str] = "COUNTER_RISK_CHAT_OFFLINE_MODE"
+_CHAT_LOG_MODE_ENV: Final[str] = "COUNTER_RISK_CHAT_LOG_MODE"
+_CHAT_LOG_MODE_TRANSCRIPT: Final[str] = "transcript"
+_CHAT_LOG_MODE_FULL: Final[str] = "full"
+_CHAT_LOG_MODE_OFF: Final[str] = "off"
+_VALID_CHAT_LOG_MODES: Final[set[str]] = {
+    _CHAT_LOG_MODE_TRANSCRIPT,
+    _CHAT_LOG_MODE_FULL,
+    _CHAT_LOG_MODE_OFF,
+}
 _PROVIDER_MODEL_REGISTRY = build_provider_model_registry(local_model=_PLACEHOLDER_MODEL)
 _PROVIDER_MODELS: Final[dict[str, set[str]]] = _PROVIDER_MODEL_REGISTRY.provider_models
 _PROVIDER_MODEL_REQUIRED_ENV_KEYS: Final[dict[str, dict[str, tuple[str, ...]]]] = (
@@ -82,6 +91,17 @@ def _default_model_key() -> str:
     if models:
         return models[0]
     return _PLACEHOLDER_MODEL
+
+
+def _resolve_chat_log_mode(log_mode: str | None) -> str:
+    raw_mode = log_mode if log_mode is not None else os.environ.get(_CHAT_LOG_MODE_ENV)
+    normalized = _CHAT_LOG_MODE_TRANSCRIPT if raw_mode is None else raw_mode.strip().lower()
+    if normalized not in _VALID_CHAT_LOG_MODES:
+        valid_modes = ", ".join(sorted(_VALID_CHAT_LOG_MODES))
+        raise ChatSessionError(
+            f"Unsupported chat log mode '{normalized}'. Valid modes: {valid_modes}."
+        )
+    return normalized
 
 
 _INJECTION_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
@@ -203,11 +223,13 @@ class ChatSession:
     model: str = field(default_factory=_default_model_key)
     history: list[ChatMessage] = field(default_factory=list)
     enable_llm_logging: bool = False
+    log_mode: str | None = None
     _interaction_counter: int = field(default=0, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.provider = self.provider.strip().lower()
         self.model = self.model.strip()
+        self.log_mode = _resolve_chat_log_mode(self.log_mode)
 
         if self.provider == "local" and not _offline_mode_enabled():
             raise ChatSessionError(
@@ -274,6 +296,7 @@ class ChatSession:
         self.history.append(ChatMessage(role="assistant", content=answer))
         self._interaction_counter += 1
         _LOGGER.debug("Built guarded prompt of %s characters", len(prompt))
+        resolved_log_mode = _resolve_chat_log_mode(self.log_mode)
 
         resolved_provider = str(provider_response_metadata.get("provider") or selected_provider)
         resolved_model = str(provider_response_metadata.get("model") or selected_model)
@@ -282,21 +305,30 @@ class ChatSession:
         trace_id = None if trace_id_raw in (None, "") else str(trace_id_raw)
         trace_url = None if trace_url_raw in (None, "") else str(trace_url_raw)
 
-        _append_chat_turn_log(
-            run_dir=self.context.run_dir,
-            interaction_number=self._interaction_counter,
-            question=clean_question,
-            prompt=prompt,
-            response=answer,
-            selected_provider=selected_provider,
-            selected_model=selected_model,
-            resolved_provider=resolved_provider,
-            resolved_model=resolved_model,
-            trace_id=trace_id,
-            trace_url=trace_url,
+        should_write_transcript = resolved_log_mode in {
+            _CHAT_LOG_MODE_TRANSCRIPT,
+            _CHAT_LOG_MODE_FULL,
+        }
+        should_write_llm_artifact = self.enable_llm_logging or (
+            resolved_log_mode == _CHAT_LOG_MODE_FULL
         )
 
-        if self.enable_llm_logging:
+        if should_write_transcript:
+            _append_chat_turn_log(
+                run_dir=self.context.run_dir,
+                interaction_number=self._interaction_counter,
+                question=clean_question,
+                prompt=prompt,
+                response=answer,
+                selected_provider=selected_provider,
+                selected_model=selected_model,
+                resolved_provider=resolved_provider,
+                resolved_model=resolved_model,
+                trace_id=trace_id,
+                trace_url=trace_url,
+            )
+
+        if should_write_llm_artifact:
             _write_llm_log(
                 run_dir=self.context.run_dir,
                 interaction_number=self._interaction_counter,

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -453,6 +453,50 @@ def test_llm_logging_disabled_writes_no_artifacts(tmp_path: Path) -> None:
     assert len(chat_logs) == 1
 
 
+def test_chat_log_mode_off_writes_no_chat_or_llm_artifacts(tmp_path: Path) -> None:
+    context = load_run_context(_write_minimal_run(tmp_path))
+    session = ChatSession(context=context, provider="local", model=_MODEL_KEY, log_mode="off")
+
+    session.ask("top exposures")
+
+    assert not (context.run_dir / _CHAT_LOG_DIR_NAME).exists()
+    assert not (context.run_dir / _LLM_LOG_DIR_NAME).exists()
+
+
+def test_chat_log_mode_full_writes_chat_and_llm_artifacts_without_legacy_flag(
+    tmp_path: Path,
+) -> None:
+    context = load_run_context(_write_minimal_run(tmp_path))
+    session = ChatSession(context=context, provider="local", model=_MODEL_KEY, log_mode="full")
+
+    session.ask("top exposures")
+
+    chat_logs = sorted((context.run_dir / _CHAT_LOG_DIR_NAME).glob("*.jsonl"))
+    llm_logs = sorted((context.run_dir / _LLM_LOG_DIR_NAME).glob("*.json"))
+    assert len(chat_logs) == 1
+    assert len(llm_logs) == 1
+
+
+def test_chat_session_rejects_invalid_log_mode(tmp_path: Path) -> None:
+    context = load_run_context(_write_minimal_run(tmp_path))
+
+    with pytest.raises(ChatSessionError, match="Unsupported chat log mode"):
+        ChatSession(context=context, provider="local", model=_MODEL_KEY, log_mode="invalid")
+
+
+def test_chat_log_mode_can_be_configured_via_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COUNTER_RISK_CHAT_LOG_MODE", "off")
+    context = load_run_context(_write_minimal_run(tmp_path))
+    session = ChatSession(context=context, provider="local", model=_MODEL_KEY)
+
+    session.ask("top exposures")
+
+    assert not (context.run_dir / _CHAT_LOG_DIR_NAME).exists()
+
+
 def test_chat_session_writes_jsonl_chat_log_with_trace_metadata(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #304

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Issue #33 acceptance criteria call for optional/configurable prompt-response logging. Current behavior logs `chat_logs` transcripts unconditionally, while only legacy `llm_logs` are optional. We need a clear, policy-driven logging contract for operations/compliance.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#33](https://github.com/stranske/Counter_Risk/issues/33)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Define logging modes (for example: audit-only transcript, transcript+prompt-response, disabled where policy allows) and default mode.
- [ ] Add config/runtime controls for logging mode selection.
- [ ] Implement mode handling in chat session logging paths.
- [ ] Add tests covering each logging mode and failure behavior.
- [ ] Update docs to align behavior with policy and acceptance criteria language.

#### Acceptance criteria
- [ ] Logging behavior is configurable via documented settings.
- [ ] Selected logging mode deterministically controls which artifacts are written (`chat_logs`, `llm_logs`, both, or restricted mode per policy).
- [ ] Tests verify mode behavior and prevent regressions.
- [ ] Documentation clearly states defaults, toggles, and compliance rationale.

**Head SHA:** 01a79a1d2eef225149453b04779b124ae6ef6319
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22533549198) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22533673625) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22533673619) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22533549692) |
| Gate | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22533549974) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/22533549914) |
<!-- auto-status-summary:end -->