### PR TITLE
Issue #470: Make static distribution output canonical

### DIFF
--- a/src/counter_risk/chat/providers/base.py
+++ b/src/counter_risk/chat/providers/base.py
@@ -105,6 +105,7 @@ class LangChainProviderClient:
         slot_catalog = get_provider_model_catalog()
         missing_dependency_names: set[str] = set()
         runtime_ready_provider_seen = False
+        attempted_provider_without_client = False
 
         for provider_name in self._provider_chain:
             provider_models = slot_catalog.get(provider_name, set())
@@ -112,6 +113,7 @@ class LangChainProviderClient:
                 continue
             client_info = build_chat_client(provider=provider_name, model=model)
             if client_info is None:
+                attempted_provider_without_client = True
                 missing_dependencies = missing_provider_dependencies(provider_name)
                 if missing_dependencies:
                     missing_dependency_names.update(missing_dependencies)
@@ -157,6 +159,13 @@ class LangChainProviderClient:
             raise RuntimeError(
                 "LangChain provider dependencies are missing for the selected provider/model. "
                 f"Install required packages: {missing_rendered}."
+            )
+
+        if self._required_env_keys and attempted_provider_without_client:
+            missing_env = ", ".join(self._required_env_keys)
+            raise RuntimeError(
+                "No provider credentials/configured clients available. "
+                f"Set one of: {missing_env}."
             )
 
         chain = ", ".join(self._provider_chain)

--- a/src/counter_risk/chat/providers/base.py
+++ b/src/counter_risk/chat/providers/base.py
@@ -145,9 +145,8 @@ class LangChainProviderClient:
         if last_error is not None:
             raise RuntimeError(f"Provider request failed: {last_error}") from last_error
 
-        if self._required_env_keys and not any(
-            os.environ.get(key) for key in self._required_env_keys
-        ):
+        required_env_available = any(os.environ.get(key) for key in self._required_env_keys)
+        if self._required_env_keys and not required_env_available:
             missing_env = ", ".join(self._required_env_keys)
             raise RuntimeError(
                 "No provider credentials/configured clients available. "
@@ -162,6 +161,12 @@ class LangChainProviderClient:
             )
 
         if self._required_env_keys and attempted_provider_without_client:
+            if required_env_available:
+                chain = ", ".join(self._provider_chain)
+                raise RuntimeError(
+                    "Provider credentials are present but no LangChain client could be "
+                    f"initialized for model {model!r} via provider chain: {chain}."
+                )
             missing_env = ", ".join(self._required_env_keys)
             raise RuntimeError(
                 "No provider credentials/configured clients available. "

--- a/src/counter_risk/outputs/ppt_screenshot.py
+++ b/src/counter_risk/outputs/ppt_screenshot.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import shutil
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 from counter_risk.config import WorkflowConfig
 from counter_risk.outputs.base import OutputContext, OutputGenerator
@@ -22,6 +24,35 @@ _PptCopier = Callable[[str | Path, str | Path], str]
 
 def _copy_ppt(source: str | Path, destination: str | Path) -> str:
     return shutil.copy2(str(source), str(destination))
+
+
+def export_ppt_slides_as_png_via_com(*, source_pptx: Path, slide_images_dir: Path) -> list[Path]:
+    """Export one PNG image per slide via PowerPoint COM automation."""
+    from counter_risk.integrations.powerpoint_com import initialize_powerpoint_application
+
+    app: Any | None = None
+    presentation: Any | None = None
+    slide_images: list[Path] = []
+    try:
+        app = initialize_powerpoint_application()
+        with suppress(Exception):
+            app.Visible = 0
+        presentation = app.Presentations.Open(str(source_pptx), False, True, False)
+
+        slide_images_dir.mkdir(parents=True, exist_ok=True)
+        slide_count = int(presentation.Slides.Count)
+        for slide_idx in range(1, slide_count + 1):
+            image_path = slide_images_dir / f"slide_{slide_idx:04d}.png"
+            presentation.Slides[slide_idx].Export(str(image_path), "PNG")
+            slide_images.append(image_path)
+    finally:
+        if presentation is not None:
+            with suppress(Exception):
+                presentation.Close()
+        if app is not None:
+            with suppress(Exception):
+                app.Quit()
+    return slide_images
 
 
 @dataclass(frozen=True)

--- a/src/counter_risk/outputs/ppt_screenshot.py
+++ b/src/counter_risk/outputs/ppt_screenshot.py
@@ -43,7 +43,13 @@ def export_ppt_slides_as_png_via_com(*, source_pptx: Path, slide_images_dir: Pat
         slide_count = int(presentation.Slides.Count)
         for slide_idx in range(1, slide_count + 1):
             image_path = slide_images_dir / f"slide_{slide_idx:04d}.png"
-            presentation.Slides[slide_idx].Export(str(image_path), "PNG")
+            try:
+                presentation.Slides[slide_idx].Export(str(image_path), "PNG")
+            except Exception as exc:
+                raise RuntimeError(
+                    "PowerPoint slide PNG export failed "
+                    f"for slide {slide_idx} to '{image_path}': {exc}"
+                ) from exc
             slide_images.append(image_path)
     finally:
         if presentation is not None:

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -42,6 +42,7 @@ from counter_risk.normalize import (
     normalize_counterparty_with_source,
 )
 from counter_risk.outputs.base import OutputContext, OutputGenerator
+from counter_risk.outputs.ppt_screenshot import export_ppt_slides_as_png_via_com
 from counter_risk.outputs.registry import OutputGeneratorRegistry, OutputGeneratorRegistryContext
 from counter_risk.parsers import parse_fcm_totals, parse_futures_detail
 from counter_risk.parsers.daily_holdings_pdf import parse_daily_holdings_pdf
@@ -2443,20 +2444,10 @@ def _create_static_distribution(
     output_paths: list[Path] = []
     slide_images_dir = run_dir / "_distribution_slides"
     static_pptx_path = output_path or run_dir / f"{source_pptx.stem}_distribution_static.pptx"
-    app = None
-    presentation = None
     try:
-        app = win32com.client.DispatchEx("PowerPoint.Application")
-        app.Visible = False
-        presentation = app.Presentations.Open(str(source_pptx), WithWindow=False)
-
-        # Preferred: export each slide as a PNG and rebuild the entire deck as
-        # one picture per slide, removing all live chart/OLE objects.
-        slide_images_dir.mkdir(parents=True, exist_ok=True)
-        slide_images = _export_slides_as_images(
-            com_presentation=presentation,
+        slide_images = export_ppt_slides_as_png_via_com(
+            source_pptx=source_pptx,
             slide_images_dir=slide_images_dir,
-            warnings=warnings,
         )
         _rebuild_pptx_from_slide_images(
             source_pptx=source_pptx,
@@ -2473,13 +2464,6 @@ def _create_static_distribution(
     except Exception as exc:
         warnings.append(f"distribution_static generation failed: {exc}")
         LOGGER.exception("distribution_static_failed")
-    finally:
-        if presentation is not None:
-            with contextlib.suppress(Exception):
-                presentation.Close()
-        if app is not None:
-            with contextlib.suppress(Exception):
-                app.Quit()
 
     return output_paths
 
@@ -2517,29 +2501,6 @@ def _export_pptx_to_pdf(*, source_pptx: Path, pdf_path: Path) -> None:
     from counter_risk.outputs.pdf_export import export_pptx_to_pdf_via_com
 
     export_pptx_to_pdf_via_com(source_pptx=source_pptx, pdf_path=pdf_path)
-
-
-def _export_slides_as_images(
-    *,
-    com_presentation: Any,
-    slide_images_dir: Path,
-    warnings: list[str],
-) -> list[Path]:
-    """Export each slide in the COM presentation as a PNG image."""
-    slide_images: list[Path] = []
-    slide_count = int(com_presentation.Slides.Count)
-    for slide_idx in range(1, slide_count + 1):
-        image_path = slide_images_dir / f"slide_{slide_idx:04d}.png"
-        try:
-            com_presentation.Slides[slide_idx].Export(str(image_path), "PNG")
-            slide_images.append(image_path)
-        except Exception as exc:
-            warnings.append(f"distribution_static slide export failed (slide {slide_idx}): {exc}")
-            LOGGER.warning(
-                "distribution_static_slide_export_failed slide=%d exc=%s", slide_idx, exc
-            )
-            raise
-    return slide_images
 
 
 def _export_chart_shapes_as_images(

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import csv
 import hashlib
+import importlib.util
 import inspect
 import logging
 import math
@@ -2431,9 +2432,7 @@ def _create_static_distribution(
         LOGGER.info("distribution_static_skipped reason=non_windows")
         return []
 
-    try:
-        import win32com.client
-    except ImportError:
+    if importlib.util.find_spec("win32com.client") is None:
         warnings.append(
             "distribution_static requested but win32com is not installed; "
             "no static distribution produced"

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -12,6 +12,7 @@ import math
 import os
 import platform
 import shutil
+import sys
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -2432,7 +2433,12 @@ def _create_static_distribution(
         LOGGER.info("distribution_static_skipped reason=non_windows")
         return []
 
-    if importlib.util.find_spec("win32com.client") is None:
+    try:
+        win32com_available = importlib.util.find_spec("win32com.client") is not None
+    except (ImportError, ValueError):
+        win32com_available = "win32com.client" in sys.modules
+
+    if not win32com_available:
         warnings.append(
             "distribution_static requested but win32com is not installed; "
             "no static distribution produced"

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -108,7 +108,9 @@ def reconcile_series_coverage(
 ) -> dict[str, Any]:
     reconciliation_globals = _reconcile_series_coverage.__globals__
     original = reconciliation_globals.get("normalize_counterparty_with_source")
-    reconciliation_globals["normalize_counterparty_with_source"] = normalize_counterparty_with_source
+    reconciliation_globals["normalize_counterparty_with_source"] = (
+        normalize_counterparty_with_source
+    )
     try:
         return _reconcile_series_coverage(
             parsed_data_by_sheet=parsed_data_by_sheet,
@@ -119,6 +121,7 @@ def reconcile_series_coverage(
         )
     finally:
         reconciliation_globals["normalize_counterparty_with_source"] = original
+
 
 if TYPE_CHECKING:
     from counter_risk.outputs.ppt_link_refresh import PptLinkRefreshOutputGenerator
@@ -2078,6 +2081,13 @@ def _write_outputs(
             master_pptx_path=distribution_source,
             distribution_pptx_path=target_distribution_ppt,
         )
+        static_output_paths = _create_static_distribution(
+            source_pptx=target_master_ppt,
+            run_dir=run_dir,
+            config=config,
+            warnings=warnings,
+            output_path=target_distribution_ppt,
+        )
         try:
             distribution_validation = validate_distribution_ppt_standalone(target_distribution_ppt)
         except RuntimeError as exc:
@@ -2098,6 +2108,9 @@ def _write_outputs(
                     f"external relationships in: {rel_parts}"
                 )
         output_paths.append(target_distribution_ppt)
+        for static_output_path in static_output_paths:
+            if static_output_path not in output_paths:
+                output_paths.append(static_output_path)
         post_distribution_generators = registry.load(
             output_generators=config.output_generators,
             stage="ppt_post_distribution",
@@ -2109,13 +2122,6 @@ def _write_outputs(
         )
         for generator in post_distribution_generators:
             output_paths.extend(generator.generate(context=output_context))
-    static_output_paths = _create_static_distribution(
-        source_pptx=target_master_ppt,
-        run_dir=run_dir,
-        config=config,
-        warnings=warnings,
-    )
-    output_paths.extend(static_output_paths)
     if refresh_result.status == PptProcessingStatus.SUCCESS:
         warning_banner = _build_limit_warning_banner_for_run_dir(run_dir)
         readme_path = run_dir / "README.txt"
@@ -2401,6 +2407,7 @@ def _create_static_distribution(
     run_dir: Path,
     config: WorkflowConfig,
     warnings: list[str],
+    output_path: Path | None = None,
 ) -> list[Path]:
     """Produce a static distribution copy of the presentation.
 
@@ -2435,7 +2442,7 @@ def _create_static_distribution(
 
     output_paths: list[Path] = []
     slide_images_dir = run_dir / "_distribution_slides"
-    static_pptx_path = run_dir / f"{source_pptx.stem}_distribution_static.pptx"
+    static_pptx_path = output_path or run_dir / f"{source_pptx.stem}_distribution_static.pptx"
     app = None
     presentation = None
     try:
@@ -2455,6 +2462,10 @@ def _create_static_distribution(
             source_pptx=source_pptx,
             output_path=static_pptx_path,
             slide_images=slide_images,
+        )
+        scrub_external_relationships_from_pptx(
+            static_pptx_path,
+            scrubbed_pptx_path=static_pptx_path,
         )
         output_paths.append(static_pptx_path)
         LOGGER.info("distribution_static_pptx_complete path=%s", static_pptx_path)

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2120,19 +2120,22 @@ def _write_outputs(
             if refresh_result.error_detail:
                 manifest_ppt_outputs["master"]["skipped_reason"] = refresh_result.error_detail
         chart_replaced_ppt = run_dir / f"{target_master_ppt.stem}_chart_replaced.pptx"
-        _apply_chart_replacement(
+        chart_replacement_applied = _apply_chart_replacement(
             master_pptx_path=target_master_ppt,
             output_path=chart_replaced_ppt,
             run_dir=run_dir,
             static_mode=config.distribution_static,
             warnings=warnings,
         )
+        distribution_source_ppt = (
+            chart_replaced_ppt if chart_replacement_applied else target_master_ppt
+        )
         _derive_distribution_ppt(
-            master_pptx_path=target_master_ppt,
+            master_pptx_path=distribution_source_ppt,
             distribution_pptx_path=target_distribution_ppt,
         )
         static_output_paths = _create_static_distribution(
-            source_pptx=target_master_ppt,
+            source_pptx=distribution_source_ppt,
             run_dir=run_dir,
             config=config,
             warnings=warnings,

--- a/src/counter_risk/ppt/pptx_postprocess.py
+++ b/src/counter_risk/ppt/pptx_postprocess.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import tempfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import cast
@@ -27,17 +28,38 @@ def scrub_external_relationships_from_pptx(
             f"{source_pptx_path.stem}_scrubbed{source_pptx_path.suffix}"
         )
     )
+    in_place = source_pptx_path.resolve() == destination.resolve()
+    write_destination = destination
+    temp_path: Path | None = None
+    if in_place:
+        with tempfile.NamedTemporaryFile(
+            prefix=f"{source_pptx_path.stem}-scrubbed-",
+            suffix=source_pptx_path.suffix,
+            dir=source_pptx_path.parent,
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+        write_destination = temp_path
 
-    destination.parent.mkdir(parents=True, exist_ok=True)
+    write_destination.parent.mkdir(parents=True, exist_ok=True)
 
-    with ZipFile(source_pptx_path) as source_archive, ZipFile(destination, "w") as output_archive:
-        for item in source_archive.infolist():
-            xml_bytes = source_archive.read(item.filename)
-            if not _is_ppt_relationship_part(item.filename):
-                output_archive.writestr(item, xml_bytes)
-                continue
+    try:
+        with (
+            ZipFile(source_pptx_path) as source_archive,
+            ZipFile(write_destination, "w") as output_archive,
+        ):
+            for item in source_archive.infolist():
+                xml_bytes = source_archive.read(item.filename)
+                if not _is_ppt_relationship_part(item.filename):
+                    output_archive.writestr(item, xml_bytes)
+                    continue
 
-            output_archive.writestr(item, _remove_external_relationship_targets(xml_bytes))
+                output_archive.writestr(item, _remove_external_relationship_targets(xml_bytes))
+        if temp_path is not None:
+            temp_path.replace(destination)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
 
     return destination
 

--- a/src/counter_risk/ppt/pptx_static.py
+++ b/src/counter_risk/ppt/pptx_static.py
@@ -9,6 +9,10 @@ class PngValidationError(ValueError):
     """Raised when a slide PNG fails static rebuild validation."""
 
 
+class SlideImageCountMismatchError(ValueError):
+    """Raised when the number of slide images does not match source slides."""
+
+
 def _validate_slide_png(png_path: Path) -> None:
     """Validate a slide PNG before inserting it into a rebuilt PPTX."""
 
@@ -47,6 +51,13 @@ def _rebuild_pptx_from_slide_images(
     assert source_prs.slide_height is not None, "source PPT has no slide height"
     slide_width = source_prs.slide_width
     slide_height = source_prs.slide_height
+    source_slide_count = len(source_prs.slides)
+
+    if len(slide_images) != source_slide_count:
+        raise SlideImageCountMismatchError(
+            "Static rebuild image count mismatch for "
+            f"'{source_pptx}': expected {source_slide_count} images, got {len(slide_images)}"
+        )
 
     new_prs = Presentation()
     new_prs.slide_width = slide_width

--- a/tests/outputs/test_ppt_screenshot.py
+++ b/tests/outputs/test_ppt_screenshot.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 from datetime import date
 from pathlib import Path
 
+import pytest
+
 from counter_risk.config import WorkflowConfig
 from counter_risk.outputs import OutputContext, PptScreenshotOutputGenerator
 from counter_risk.outputs.ppt_screenshot import export_ppt_slides_as_png_via_com
@@ -121,7 +123,9 @@ def test_ppt_screenshot_generator_copies_source_when_replacement_disabled(tmp_pa
     ]
 
 
-def test_export_ppt_slides_as_png_via_com_exports_all_slides(tmp_path: Path, monkeypatch) -> None:
+def test_export_ppt_slides_as_png_via_com_exports_all_slides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     source_pptx = tmp_path / "source.pptx"
     source_pptx.write_bytes(b"pptx")
     slide_images_dir = tmp_path / "slides"

--- a/tests/outputs/test_ppt_screenshot.py
+++ b/tests/outputs/test_ppt_screenshot.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from counter_risk.config import WorkflowConfig
 from counter_risk.outputs import OutputContext, PptScreenshotOutputGenerator
+from counter_risk.outputs.ppt_screenshot import export_ppt_slides_as_png_via_com
 from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
 
 
@@ -118,3 +119,63 @@ def test_ppt_screenshot_generator_copies_source_when_replacement_disabled(tmp_pa
     assert warnings == [
         "PPT screenshots replacement disabled; copied source deck to Master unchanged"
     ]
+
+
+def test_export_ppt_slides_as_png_via_com_exports_all_slides(tmp_path: Path, monkeypatch) -> None:
+    source_pptx = tmp_path / "source.pptx"
+    source_pptx.write_bytes(b"pptx")
+    slide_images_dir = tmp_path / "slides"
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\rIDATx\x9cc\xf8\xcf\xc0\xf0\x1f\x00\x05\x00\x01\xff\x89\x99=\x1d"
+        b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+
+    class _FakeSlide:
+        def __init__(self, index: int) -> None:
+            self.index = index
+
+        def Export(self, path: str, fmt: str) -> None:  # noqa: N802
+            assert fmt == "PNG"
+            Path(path).write_bytes(png_bytes + bytes(str(self.index), encoding="ascii"))
+
+    class _FakeSlides:
+        def __init__(self) -> None:
+            self.Count = 2
+
+        def __getitem__(self, idx: int) -> _FakeSlide:
+            return _FakeSlide(idx)
+
+    class _FakePresentation:
+        def __init__(self) -> None:
+            self.Slides = _FakeSlides()
+
+        def Close(self) -> None:  # noqa: N802
+            return None
+
+    class _FakePowerPointApplication:
+        def __init__(self) -> None:
+            self.Visible = 1
+            self.Presentations = type(
+                "_Presentations",
+                (),
+                {"Open": staticmethod(lambda *_args, **_kwargs: _FakePresentation())},
+            )
+
+        def Quit(self) -> None:  # noqa: N802
+            return None
+
+    monkeypatch.setattr(
+        "counter_risk.integrations.powerpoint_com.initialize_powerpoint_application",
+        lambda: _FakePowerPointApplication(),
+    )
+
+    exported = export_ppt_slides_as_png_via_com(
+        source_pptx=source_pptx,
+        slide_images_dir=slide_images_dir,
+    )
+
+    assert exported == [slide_images_dir / "slide_0001.png", slide_images_dir / "slide_0002.png"]
+    assert all(path.exists() for path in exported)

--- a/tests/outputs/test_ppt_screenshot.py
+++ b/tests/outputs/test_ppt_screenshot.py
@@ -183,3 +183,48 @@ def test_export_ppt_slides_as_png_via_com_exports_all_slides(
 
     assert exported == [slide_images_dir / "slide_0001.png", slide_images_dir / "slide_0002.png"]
     assert all(path.exists() for path in exported)
+
+
+def test_export_ppt_slides_as_png_via_com_reports_slide_export_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_pptx = tmp_path / "source.pptx"
+    source_pptx.write_bytes(b"pptx")
+    slide_images_dir = tmp_path / "slides"
+
+    class _FailingSlide:
+        def Export(self, _path: str, _fmt: str) -> None:  # noqa: N802
+            raise OSError("COM export failed")
+
+    class _FakeSlides:
+        Count = 1
+
+        def __getitem__(self, _idx: int) -> _FailingSlide:
+            return _FailingSlide()
+
+    class _FakePresentation:
+        Slides = _FakeSlides()
+
+        def Close(self) -> None:  # noqa: N802
+            return None
+
+    class _FakePowerPointApplication:
+        Presentations = type(
+            "_Presentations",
+            (),
+            {"Open": staticmethod(lambda *_args, **_kwargs: _FakePresentation())},
+        )
+
+        def Quit(self) -> None:  # noqa: N802
+            return None
+
+    monkeypatch.setattr(
+        "counter_risk.integrations.powerpoint_com.initialize_powerpoint_application",
+        lambda: _FakePowerPointApplication(),
+    )
+
+    with pytest.raises(RuntimeError, match=r"slide 1.*slide_0001\.png.*COM export failed"):
+        export_ppt_slides_as_png_via_com(
+            source_pptx=source_pptx,
+            slide_images_dir=slide_images_dir,
+        )

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -3453,50 +3453,22 @@ def test_create_static_distribution_rebuilds_from_slide_images(
         b"\x00\x00\x00\x00IEND\xaeB`\x82"
     )
 
-    class _FakeSlide:
-        def __init__(self, slide_idx: int) -> None:
-            self._slide_idx = slide_idx
-
-        def Export(self, path: str, fmt: str) -> None:  # noqa: N802
-            assert fmt == "PNG"
-            Path(path).write_bytes(png_bytes)
-
-    class _FakeSlides:
-        def __init__(self, count: int) -> None:
-            self.Count = count
-            self._slides = {idx: _FakeSlide(idx) for idx in range(1, count + 1)}
-
-        def __getitem__(self, idx: int) -> _FakeSlide:
-            return self._slides[idx]
-
-    class _FakePresentation:
-        def __init__(self) -> None:
-            self.Slides = _FakeSlides(2)
-
-        def ExportAsFixedFormat(self, path: str, fmt: int) -> None:  # noqa: N802
-            assert fmt == 2
-            Path(path).write_bytes(b"%PDF-1.4\n")
-
-        def Close(self) -> None:  # noqa: N802
-            return None
-
-    class _FakePowerPointApplication:
-        def __init__(self) -> None:
-            self.Visible = False
-            self.Presentations = types.SimpleNamespace(
-                Open=lambda *_args, **_kwargs: _FakePresentation()
-            )
-
-        def Quit(self) -> None:  # noqa: N802
-            return None
-
-    fake_client = types.SimpleNamespace(
-        DispatchEx=lambda *_args, **_kwargs: _FakePowerPointApplication()
-    )
+    fake_client = types.SimpleNamespace(DispatchEx=lambda *_args, **_kwargs: object())
     fake_win32com = types.ModuleType("win32com")
     cast(Any, fake_win32com).client = fake_client
     monkeypatch.setitem(sys.modules, "win32com", fake_win32com)
     monkeypatch.setitem(sys.modules, "win32com.client", fake_client)
+    monkeypatch.setattr(
+        run_module,
+        "export_ppt_slides_as_png_via_com",
+        lambda *, source_pptx, slide_images_dir: [
+            slide_images_dir / "slide_0001.png",
+            slide_images_dir / "slide_0002.png",
+        ],
+    )
+    (run_dir / "_distribution_slides").mkdir(parents=True, exist_ok=True)
+    (run_dir / "_distribution_slides" / "slide_0001.png").write_bytes(png_bytes)
+    (run_dir / "_distribution_slides" / "slide_0002.png").write_bytes(png_bytes)
 
     output = run_module._create_static_distribution(
         source_pptx=source_pptx,
@@ -3541,41 +3513,18 @@ def test_create_static_distribution_can_overwrite_canonical_distribution(
         b"\x00\x00\x00\x00IEND\xaeB`\x82"
     )
 
-    class _FakeSlide:
-        def Export(self, path: str, fmt: str) -> None:  # noqa: N802
-            assert fmt == "PNG"
-            Path(path).write_bytes(png_bytes)
-
-    class _FakeSlides:
-        Count = 1
-
-        def __getitem__(self, idx: int) -> _FakeSlide:
-            assert idx == 1
-            return _FakeSlide()
-
-    class _FakePresentation:
-        Slides = _FakeSlides()
-
-        def Close(self) -> None:  # noqa: N802
-            return None
-
-    class _FakePowerPointApplication:
-        def __init__(self) -> None:
-            self.Visible = False
-            self.Presentations = types.SimpleNamespace(
-                Open=lambda *_args, **_kwargs: _FakePresentation()
-            )
-
-        def Quit(self) -> None:  # noqa: N802
-            return None
-
-    fake_client = types.SimpleNamespace(
-        DispatchEx=lambda *_args, **_kwargs: _FakePowerPointApplication()
-    )
+    fake_client = types.SimpleNamespace(DispatchEx=lambda *_args, **_kwargs: object())
     fake_win32com = types.ModuleType("win32com")
     cast(Any, fake_win32com).client = fake_client
     monkeypatch.setitem(sys.modules, "win32com", fake_win32com)
     monkeypatch.setitem(sys.modules, "win32com.client", fake_client)
+    monkeypatch.setattr(
+        run_module,
+        "export_ppt_slides_as_png_via_com",
+        lambda *, source_pptx, slide_images_dir: [slide_images_dir / "slide_0001.png"],
+    )
+    (run_dir / "_distribution_slides").mkdir(parents=True, exist_ok=True)
+    (run_dir / "_distribution_slides" / "slide_0001.png").write_bytes(png_bytes)
 
     output = run_module._create_static_distribution(
         source_pptx=source_pptx,

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -3593,6 +3593,47 @@ def test_run_pipeline_manifest_includes_distribution_static_warning(
     assert manifest["config_snapshot"]["distribution_static"] is True
 
 
+def test_run_pipeline_manifest_includes_pdf_skip_warning_when_com_unavailable(
+    tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Full pipeline: export_pdf=True on non-Windows emits manifest warning and still succeeds."""
+    fixtures = Path("tests/fixtures")
+    output_root = tmp_path / "runs"
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "as_of_date: 2025-12-31",
+                f"mosers_all_programs_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - All Programs.xlsx'}",
+                f"mosers_ex_trend_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - Ex Trend.xlsx'}",
+                f"mosers_trend_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - Trend.xlsx'}",
+                f"hist_all_programs_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx'}",
+                f"hist_ex_llc_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - ex LLC 3 Year.xlsx'}",
+                f"hist_llc_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - LLC 3 Year.xlsx'}",
+                f"monthly_pptx: {fixtures / 'Monthly Counterparty Exposure Report.pptx'}",
+                f"output_root: {output_root}",
+                "export_pdf: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("counter_risk.pipeline.run.platform.system", lambda: "Linux")
+
+    run_dir = run_pipeline(config_path)
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+
+    assert (run_dir / "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx").exists()
+    assert (run_dir / "Monthly Counterparty Exposure Report - 2025-12-31.pptx").exists()
+    assert not (run_dir / "Monthly Counterparty Exposure Report - 2025-12-31.pdf").exists()
+    assert (
+        "distribution_pdf requested but PowerPoint COM is unavailable; skipping PDF generation"
+        in manifest["warnings"]
+    )
+
+
 # ---------------------------------------------------------------------------
 # _export_chart_shapes_as_images tests
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -3513,6 +3513,84 @@ def test_create_static_distribution_rebuilds_from_slide_images(
     assert len(output_prs.slides) == 2
 
 
+def test_create_static_distribution_can_overwrite_canonical_distribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pptx import Presentation
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    source_pptx = tmp_path / "source.pptx"
+    source_prs = Presentation()
+    blank_layout = source_prs.slide_layouts[6]
+    source_prs.slides.add_slide(blank_layout)
+    source_prs.save(str(source_pptx))
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    output_path = run_dir / "Monthly Counterparty Exposure Report - 2025-12-31.pptx"
+    output_path.write_bytes(b"old-distribution")
+    config = _make_minimal_config(tmp_path / "cfg", distribution_static=True)
+    warnings: list[str] = []
+
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\rIDATx\x9cc\xf8\xcf\xc0\xf0\x1f\x00\x05\x00\x01\xff\x89\x99=\x1d"
+        b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+
+    class _FakeSlide:
+        def Export(self, path: str, fmt: str) -> None:  # noqa: N802
+            assert fmt == "PNG"
+            Path(path).write_bytes(png_bytes)
+
+    class _FakeSlides:
+        Count = 1
+
+        def __getitem__(self, idx: int) -> _FakeSlide:
+            assert idx == 1
+            return _FakeSlide()
+
+    class _FakePresentation:
+        Slides = _FakeSlides()
+
+        def Close(self) -> None:  # noqa: N802
+            return None
+
+    class _FakePowerPointApplication:
+        def __init__(self) -> None:
+            self.Visible = False
+            self.Presentations = types.SimpleNamespace(
+                Open=lambda *_args, **_kwargs: _FakePresentation()
+            )
+
+        def Quit(self) -> None:  # noqa: N802
+            return None
+
+    fake_client = types.SimpleNamespace(
+        DispatchEx=lambda *_args, **_kwargs: _FakePowerPointApplication()
+    )
+    fake_win32com = types.ModuleType("win32com")
+    cast(Any, fake_win32com).client = fake_client
+    monkeypatch.setitem(sys.modules, "win32com", fake_win32com)
+    monkeypatch.setitem(sys.modules, "win32com.client", fake_client)
+
+    output = run_module._create_static_distribution(
+        source_pptx=source_pptx,
+        run_dir=run_dir,
+        config=config,
+        warnings=warnings,
+        output_path=output_path,
+    )
+
+    assert output == [output_path]
+    assert warnings == []
+    assert not (run_dir / f"{source_pptx.stem}_distribution_static.pptx").exists()
+    assert len(Presentation(str(output_path)).slides) == 1
+
+
 def test_run_pipeline_manifest_includes_distribution_static_warning(
     tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_chat_provider_clients.py
+++ b/tests/test_chat_provider_clients.py
@@ -276,3 +276,31 @@ def test_langchain_provider_client_reports_missing_dependencies_for_provider_cha
 
     with pytest.raises(RuntimeError, match="Install required packages: langchain-openai"):
         client.generate(messages=[{"role": "user", "content": "hello"}], model="gpt-5.2")
+
+
+def test_langchain_provider_client_reports_client_init_failure_when_credentials_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        provider_base,
+        "get_provider_model_catalog",
+        lambda: {
+            "github-models": {"gpt-5.2"},
+            "openai": {"gpt-5.2"},
+            "anthropic": set(),
+        },
+    )
+    monkeypatch.setattr(provider_base, "missing_provider_dependencies", lambda _provider: ())
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr(provider_base, "build_chat_client", lambda **_: None)
+
+    client = provider_base.LangChainProviderClient(
+        provider_chain=("github-models", "openai"),
+        required_env_keys=("GITHUB_TOKEN", "OPENAI_API_KEY"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="credentials are present but no LangChain client could be initialized",
+    ):
+        client.generate(messages=[{"role": "user", "content": "hello"}], model="gpt-5.2")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -319,6 +319,31 @@ def test_load_config_accepts_export_pdf_flag(tmp_path: Path) -> None:
     assert config.export_pdf is True
 
 
+def test_load_config_accepts_distribution_static_flag(tmp_path: Path) -> None:
+    config_path = tmp_path / "with_distribution_static.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "as_of_date: 2025-12-31",
+                "mosers_all_programs_xlsx: docs/N__A Data/MOSERS Counterparty Risk Summary 12-31-2025 - All Programs.xlsx",
+                "mosers_ex_trend_xlsx: docs/N__A Data/MOSERS Counterparty Risk Summary 12-31-2025 - Ex Trend.xlsx",
+                "mosers_trend_xlsx: docs/N__A Data/MOSERS Counterparty Risk Summary 12-31-2025 - Trend.xlsx",
+                "hist_all_programs_3yr_xlsx: docs/Ratings Instructiosns/Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx",
+                "hist_ex_llc_3yr_xlsx: docs/Ratings Instructiosns/Historical Counterparty Risk Graphs - ex LLC 3 Year.xlsx",
+                "hist_llc_3yr_xlsx: docs/Ratings Instructiosns/Historical Counterparty Risk Graphs - LLC 3 Year.xlsx",
+                "monthly_pptx: docs/Ratings Instructiosns/Monthly Counterparty Exposure Report.pptx",
+                "output_root: runs/test",
+                "distribution_static: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+    assert config.distribution_static is True
+
+
 def test_load_config_raises_for_invalid_screenshot_implementation(tmp_path: Path) -> None:
     bad_config = tmp_path / "invalid_screenshot_impl.yml"
     bad_config.write_text(

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -399,3 +399,43 @@ def test_write_outputs_runs_config_registered_generator_without_pipeline_changes
     custom_output = run_dir / "config-registered-output.txt"
     assert custom_output in output_paths
     assert custom_output.read_text(encoding="utf-8") == "ok"
+
+
+def test_write_outputs_passes_distribution_static_to_chart_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, screenshot_inputs={}).model_copy(
+        update={"enable_screenshot_replacement": False, "distribution_static": True}
+    )
+    observed: dict[str, bool] = {}
+
+    monkeypatch.setattr(run_module, "_refresh_ppt_links", lambda _path: True)
+    monkeypatch.setattr(run_module, "_derive_distribution_ppt", lambda **_kwargs: None)
+    monkeypatch.setattr(run_module, "_create_static_distribution", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        run_module,
+        "validate_distribution_ppt_standalone",
+        lambda _path: PptStandaloneValidationResult(
+            is_valid=True,
+            relationship_parts_scanned=(),
+            external_relationship_count=0,
+            external_relationship_parts=(),
+        ),
+    )
+
+    def _capture_chart_replacement(*, static_mode: bool, **_kwargs: object) -> bool:
+        observed["static_mode"] = static_mode
+        return False
+
+    monkeypatch.setattr(run_module, "_apply_chart_replacement", _capture_chart_replacement)
+
+    run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=date(2025, 12, 31),
+        warnings=[],
+    )
+
+    assert observed["static_mode"] is True

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -239,7 +239,7 @@ def test_write_outputs_successful_run_writes_master_and_optional_distribution(
         "_refresh_ppt_links",
         lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
     )
-    monkeypatch.setattr(run_module, "_apply_chart_replacement", lambda **_kwargs: True)
+    monkeypatch.setattr(run_module, "_apply_chart_replacement", lambda **_kwargs: False)
     monkeypatch.setattr(
         run_module,
         "validate_distribution_ppt_standalone",
@@ -420,7 +420,7 @@ def test_write_outputs_runs_master_refresh_even_when_refresh_generator_is_disabl
     assert (run_dir / output_names.distribution_filename) in output_paths
 
 
-def test_write_outputs_derives_distribution_from_resolved_master_path(
+def test_write_outputs_derives_distribution_from_chart_replaced_path_when_available(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run_dir = tmp_path / "run"
@@ -431,6 +431,7 @@ def test_write_outputs_derives_distribution_from_resolved_master_path(
     as_of_date = date(2025, 12, 31)
     output_names = resolve_ppt_output_names(as_of_date)
     expected_master_path = run_dir / output_names.master_filename
+    expected_chart_replaced_path = run_dir / f"{expected_master_path.stem}_chart_replaced.pptx"
     observed: dict[str, Path] = {}
 
     monkeypatch.setattr(
@@ -438,7 +439,12 @@ def test_write_outputs_derives_distribution_from_resolved_master_path(
         "_refresh_ppt_links",
         lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
     )
-    monkeypatch.setattr(run_module, "_apply_chart_replacement", lambda **_kwargs: True)
+
+    def _apply_chart_replacement(*, output_path: Path, **_kwargs: object) -> bool:
+        output_path.write_bytes(b"chart-replaced")
+        return True
+
+    monkeypatch.setattr(run_module, "_apply_chart_replacement", _apply_chart_replacement)
 
     def _capture_derive(*, master_pptx_path: Path, distribution_pptx_path: Path) -> None:
         observed["master_pptx_path"] = master_pptx_path
@@ -463,7 +469,7 @@ def test_write_outputs_derives_distribution_from_resolved_master_path(
         warnings=[],
     )
 
-    assert observed["master_pptx_path"] == expected_master_path
+    assert observed["master_pptx_path"] == expected_chart_replaced_path
 
 
 def test_write_outputs_runs_config_registered_generator_without_pipeline_changes(

--- a/tests/test_pptx_postprocess.py
+++ b/tests/test_pptx_postprocess.py
@@ -97,6 +97,31 @@ def test_scrub_external_relationships_from_pptx_returns_new_default_scrubbed_cop
     assert list_external_relationship_targets(scrubbed) == set()
 
 
+def test_scrub_external_relationships_from_pptx_supports_in_place_scrub(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.pptx"
+
+    with ZipFile(source, "w") as archive:
+        archive.writestr(
+            "ppt/_rels/presentation.xml.rels",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">
+  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\"https://example.com\" TargetMode=\"External\"/>
+</Relationships>
+""",
+        )
+        archive.writestr("ppt/presentation.xml", b"<presentation/>")
+
+    scrubbed = scrub_external_relationships_from_pptx(source, scrubbed_pptx_path=source)
+
+    assert scrubbed == source
+    assert source.exists()
+    assert list_external_relationship_targets(source) == set()
+    with ZipFile(source) as archive:
+        assert archive.read("ppt/presentation.xml") == b"<presentation/>"
+
+
 def test_scrub_external_relationships_from_pptx_accepts_str_paths_and_creates_parent_dirs(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pptx_static.py
+++ b/tests/test_pptx_static.py
@@ -17,7 +17,10 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency in some en
         allow_module_level=True,
     )
 
-from counter_risk.ppt.pptx_static import _rebuild_pptx_from_slide_images
+from counter_risk.ppt.pptx_static import (
+    SlideImageCountMismatchError,
+    _rebuild_pptx_from_slide_images,
+)
 
 
 def _write_png(path: Path) -> None:
@@ -68,6 +71,9 @@ def test_rebuild_pptx_from_slide_images_outputs_picture_only_slides(tmp_path: Pa
 
     rebuilt = Presentation(str(output))
     assert len(rebuilt.slides) == 2
+    source_prs = Presentation(str(source))
+    assert rebuilt.slide_width == source_prs.slide_width
+    assert rebuilt.slide_height == source_prs.slide_height
     for slide in rebuilt.slides:
         picture_shapes = [
             shape for shape in slide.shapes if shape.shape_type == MSO_SHAPE_TYPE.PICTURE
@@ -75,3 +81,24 @@ def test_rebuild_pptx_from_slide_images_outputs_picture_only_slides(tmp_path: Pa
         chart_shapes = [shape for shape in slide.shapes if shape.shape_type == MSO_SHAPE_TYPE.CHART]
         assert len(picture_shapes) == 1
         assert chart_shapes == []
+
+
+def test_rebuild_pptx_from_slide_images_fails_when_slide_count_mismatch(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "rebuilt.pptx"
+
+    source_img = tmp_path / "source.png"
+    _write_png(source_img)
+    _make_source_with_chart(source, source_img)
+
+    slide_image_1 = tmp_path / "slide_0001.png"
+    _write_png(slide_image_1)
+
+    with pytest.raises(SlideImageCountMismatchError, match="image count mismatch"):
+        _rebuild_pptx_from_slide_images(
+            source_pptx=source,
+            slide_images=[slide_image_1],
+            output_path=output,
+        )
+
+    assert not output.exists()

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,6 @@
 # Counter_Risk Workloop State
 
-## 2026-05-01T13:09Z - opener branch ready for issue #470
+## 2026-05-01T13:09Z - opener PR opened for issue #470
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Selected lane: `https://github.com/stranske/Counter_Risk/issues/470` (`priority:normal`, `repo-review-approved`).
 - Branch: `codex/issue-470-distribution-static` from `origin/main` (`1fde16c`).
@@ -13,8 +13,10 @@
   - `python -m pytest tests/test_pptx_postprocess.py tests/pipeline/test_run_pipeline.py -k 'static_distribution or scrub_external_relationships or distribution_static' --no-cov` -> 11 passed.
   - `python -m ruff check src/counter_risk/pipeline/run.py src/counter_risk/ppt/pptx_postprocess.py tests/pipeline/test_run_pipeline.py tests/test_pptx_postprocess.py` -> pass.
   - `python -m black --target-version py312 --check src/counter_risk/pipeline/run.py src/counter_risk/ppt/pptx_postprocess.py tests/pipeline/test_run_pipeline.py tests/test_pptx_postprocess.py` -> pass.
-- Draft PR: pending creation; apply `agent:codex` at PR creation.
-- Next action: push branch, open draft PR, emit `pr_opened`, then keepalive owns the PR.
+- Draft PR: `https://github.com/stranske/Counter_Risk/pull/522` (`agent:codex`, branch `codex/issue-470-distribution-static`).
+- Relay: emitted `pr_opened active.source_repo=stranske/Counter_Risk active.source_issue=470 active.source_pr=522 active.next_action=wait_for_keepalive`.
+- Cap state post-PR: 5/5 opener-owned issue-linked PRs (Counter_Risk #521/#522; TPP #1008; trip-planner #1057/#1061). Next opener round will hit cap unless closer drains.
+- Next action: keepalive owns PR #522.
 
 ## 2026-05-01T08:05:33Z - opener PR opened for issue #468
 - Automation: `pd-workloop-resume` (codex opener lane).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,21 @@
 # Counter_Risk Workloop State
 
+## 2026-05-01T13:09Z - opener branch ready for issue #470
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Selected lane: `https://github.com/stranske/Counter_Risk/issues/470` (`priority:normal`, `repo-review-approved`).
+- Branch: `codex/issue-470-distribution-static` from `origin/main` (`1fde16c`).
+- Selection rationale: ACTION A succeeded and full opener discovery ran. High-priority implementation issues were already linked to open opener PRs, while Workflows #1976 is an operational auth-expiring alert and was skipped. Cap check found 4/5 active opener-owned issue-linked PRs after Counter_Risk #520 merged, leaving one opener slot. The oldest unlinked supported normal-priority implementation issue was Counter_Risk #470.
+- Implementation:
+  - Static distribution mode now rebuilds the canonical Distribution PPT path before post-distribution generators run, so PDF export receives the final static deck when COM export succeeds.
+  - Static rebuild output is scrubbed through `pptx_postprocess` after image-only deck creation.
+  - `scrub_external_relationships_from_pptx` now supports safe in-place scrubbing via a temporary archive.
+- Validation:
+  - `python -m pytest tests/test_pptx_postprocess.py tests/pipeline/test_run_pipeline.py -k 'static_distribution or scrub_external_relationships or distribution_static' --no-cov` -> 11 passed.
+  - `python -m ruff check src/counter_risk/pipeline/run.py src/counter_risk/ppt/pptx_postprocess.py tests/pipeline/test_run_pipeline.py tests/test_pptx_postprocess.py` -> pass.
+  - `python -m black --target-version py312 --check src/counter_risk/pipeline/run.py src/counter_risk/ppt/pptx_postprocess.py tests/pipeline/test_run_pipeline.py tests/test_pptx_postprocess.py` -> pass.
+- Draft PR: pending creation; apply `agent:codex` at PR creation.
+- Next action: push branch, open draft PR, emit `pr_opened`, then keepalive owns the PR.
+
 ## 2026-05-01T08:05:33Z - opener PR opened for issue #468
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Selected lane: `https://github.com/stranske/Counter_Risk/issues/468` (`priority:normal`, repo-review-approved).


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:470 -->
> **Source:** Issue #470

Closes #470

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Recipients should not see Office link-update prompts or need access to linked workbooks. The pipeline needs a static Distribution deck, and optionally a PDF, while keeping the editable Master deck available for maintainers.

#### Tasks
- [x] Add or verify a `distribution_static` pipeline option in config parsing and output-generation code.
- [x] Use `src/counter_risk/ppt/pptx_static.py` to rebuild a static Distribution deck from validated slide images while preserving slide count and page size.
- [x] Use `src/counter_risk/ppt/pptx_postprocess.py` to scrub external relationships from the final Distribution `.pptx`.
- [x] Integrate COM-based screenshot/PDF export through `src/counter_risk/outputs/ppt_screenshot.py` and `src/counter_risk/outputs/pdf_export.py` when COM is available.
- [x] Record skipped static/PDF work as manifest warnings when COM is unavailable rather than failing unrelated Master generation.
- [ ] Add tests for no external relationships, slide count preservation, corrupted image rejection, COM-unavailable fallback warnings, and optional PDF registration.

#### Acceptance criteria
- [ ] Distribution PPT output contains no external OLE or hyperlink relationships that trigger link-update prompts.
- [x] Distribution PPT preserves slide count and basic page dimensions from the Master/source deck.
- [x] Static image inputs are validated before the deck is written, and corrupt images fail with a clear path-specific error.
- [ ] PDF export is produced when enabled and COM is available; otherwise the manifest records a clear skipped-PDF warning.
- [ ] Existing linked Master generation still works when Distribution static mode is disabled.

<!-- auto-status-summary:end -->