### PR TITLE
Issue #471: Track dual PPT deliverables

### DIFF
--- a/src/counter_risk/config.py
+++ b/src/counter_risk/config.py
@@ -108,6 +108,7 @@ class WorkflowConfig(BaseModel):
     input_discovery: InputDiscoveryConfig = Field(default_factory=InputDiscoveryConfig)
     reconciliation: ReconciliationConfig = Field(default_factory=ReconciliationConfig)
     distribution_static: bool = False
+    enable_distribution_output: bool = True
     export_pdf: bool = False
     enable_ppt_output: bool = True
     include_concentration_table_in_ppt: bool = False

--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -51,6 +51,7 @@ class ManifestBuilder:
         missing_inputs: dict[str, Any] | None = None,
         reconciliation_results: dict[str, Any] | None = None,
         ppt_status: str = "success",
+        ppt_outputs: dict[str, dict[str, str]] | None = None,
         concentration_metrics: list[dict[str, Any]] | None = None,
         limit_breach_summary: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -118,6 +119,7 @@ class ManifestBuilder:
         ppt_outputs = self._build_ppt_outputs(
             output_paths=normalized_output_paths,
             ppt_status=ppt_status,
+            explicit_outputs=ppt_outputs,
         )
         if ppt_outputs:
             manifest["ppt_outputs"] = ppt_outputs
@@ -154,10 +156,16 @@ class ManifestBuilder:
         output_paths.append(_DATA_QUALITY_SUMMARY_FILENAME)
 
     def _build_ppt_outputs(
-        self, *, output_paths: list[Path], ppt_status: str
+        self,
+        *,
+        output_paths: list[Path],
+        ppt_status: str,
+        explicit_outputs: dict[str, dict[str, str]] | None = None,
     ) -> dict[str, dict[str, str]]:
         if not self.config.ppt_output_enabled:
             return {}
+        if explicit_outputs is not None:
+            return explicit_outputs
 
         output_path_strings = {path.as_posix() for path in output_paths}
         output_names = resolve_ppt_output_names(self.as_of_date)

--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -13,6 +13,7 @@ from typing import Any
 from counter_risk.config import WorkflowConfig
 from counter_risk.dates import DateResolution
 from counter_risk.pipeline.data_quality import build_data_quality
+from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
 from counter_risk.pipeline.warnings import WarningsCollector
 
 __all__ = ["ManifestBuilder", "WarningsCollector"]
@@ -114,6 +115,12 @@ class ManifestBuilder:
             "missing_inputs": resolved_missing_inputs,
             "reconciliation_results": resolved_reconciliation_results,
         }
+        ppt_outputs = self._build_ppt_outputs(
+            output_paths=normalized_output_paths,
+            ppt_status=ppt_status,
+        )
+        if ppt_outputs:
+            manifest["ppt_outputs"] = ppt_outputs
         if concentration_metrics is not None:
             manifest["concentration_metrics"] = concentration_metrics
         if limit_breach_summary is not None:
@@ -145,6 +152,44 @@ class ManifestBuilder:
         if _DATA_QUALITY_SUMMARY_FILENAME in rendered_paths:
             return
         output_paths.append(_DATA_QUALITY_SUMMARY_FILENAME)
+
+    def _build_ppt_outputs(
+        self, *, output_paths: list[Path], ppt_status: str
+    ) -> dict[str, dict[str, str]]:
+        if not self.config.ppt_output_enabled:
+            return {}
+
+        output_path_strings = {path.as_posix() for path in output_paths}
+        output_names = resolve_ppt_output_names(self.as_of_date)
+        master_filename = output_names.master_filename
+        distribution_filename = output_names.distribution_filename
+        ppt_outputs: dict[str, dict[str, str]] = {}
+
+        if master_filename in output_path_strings:
+            ppt_outputs["master"] = {
+                "role": "maintainer_master",
+                "status": "failed" if ppt_status == "failed" else "success",
+                "path": master_filename,
+                "generation_step": "ppt_master",
+            }
+
+        if distribution_filename in output_path_strings:
+            ppt_outputs["distribution"] = {
+                "role": "distribution",
+                "status": "success",
+                "path": distribution_filename,
+                "generation_step": "ppt_distribution",
+            }
+        elif ppt_outputs.get("master", {}).get("status") == "success":
+            ppt_outputs["distribution"] = {
+                "role": "distribution",
+                "status": "skipped",
+                "path": distribution_filename,
+                "generation_step": "ppt_distribution",
+                "skipped_reason": "Distribution output disabled for this run.",
+            }
+
+        return ppt_outputs
 
     def _build_data_quality_summary(self, manifest: Mapping[str, Any]) -> str:
         data_quality = manifest.get("data_quality")

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -7,9 +7,13 @@ from typing import Any
 
 _PPT_OUTPUT_ENTRY_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "required": ["path"],
+    "required": ["role", "status", "path", "generation_step"],
     "properties": {
+        "role": {"type": "string", "enum": ["maintainer_master", "distribution"]},
+        "status": {"type": "string", "enum": ["success", "skipped", "failed"]},
         "path": {"type": "string", "minLength": 1},
+        "generation_step": {"type": "string", "minLength": 1},
+        "skipped_reason": {"type": "string", "minLength": 1},
     },
     "additionalProperties": False,
 }

--- a/src/counter_risk/pipeline/ppt_naming.py
+++ b/src/counter_risk/pipeline/ppt_naming.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 
 _MASTER_BASE_NAME = "Monthly Counterparty Exposure Report (Master)"
 _DISTRIBUTION_BASE_NAME = "Monthly Counterparty Exposure Report"
@@ -20,19 +20,30 @@ class PptOutputNames:
 def master_ppt_filename(as_of_date: date) -> str:
     """Return the canonical Master PPT filename for an as-of date."""
 
-    return f"{_MASTER_BASE_NAME} - {as_of_date.isoformat()}.pptx"
+    resolved_as_of_date = _coerce_as_of_date(as_of_date)
+    return f"{_MASTER_BASE_NAME} - {resolved_as_of_date.isoformat()}.pptx"
 
 
 def distribution_ppt_filename(as_of_date: date) -> str:
     """Return the canonical Distribution PPT filename for an as-of date."""
 
-    return f"{_DISTRIBUTION_BASE_NAME} - {as_of_date.isoformat()}.pptx"
+    resolved_as_of_date = _coerce_as_of_date(as_of_date)
+    return f"{_DISTRIBUTION_BASE_NAME} - {resolved_as_of_date.isoformat()}.pptx"
 
 
 def resolve_ppt_output_names(as_of_date: date) -> PptOutputNames:
     """Return deterministic PowerPoint output names for a pipeline run date."""
 
+    resolved_as_of_date = _coerce_as_of_date(as_of_date)
     return PptOutputNames(
-        master_filename=master_ppt_filename(as_of_date),
-        distribution_filename=distribution_ppt_filename(as_of_date),
+        master_filename=master_ppt_filename(resolved_as_of_date),
+        distribution_filename=distribution_ppt_filename(resolved_as_of_date),
     )
+
+
+def _coerce_as_of_date(as_of_date: date) -> date:
+    """Normalize date-like values to a date token used in output names."""
+
+    if isinstance(as_of_date, datetime):
+        return as_of_date.date()
+    return as_of_date

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2174,6 +2174,13 @@ def _write_outputs(
         )
         output_paths.extend(static_output_paths)
     if refresh_result.status == PptProcessingStatus.SUCCESS and config.enable_distribution_output:
+        distribution_pdf_path = run_dir / f"{target_distribution_ppt.stem}.pdf"
+        if distribution_pdf_path.exists():
+            readme_ppt_outputs = RunFolderReadmePptOutputs(
+                master=readme_ppt_outputs.master,
+                distribution=readme_ppt_outputs.distribution,
+                distribution_pdf=distribution_pdf_path.relative_to(run_dir),
+            )
         warning_banner = _build_limit_warning_banner_for_run_dir(run_dir)
         readme_path = run_dir / "README.txt"
         readme_path.write_text(

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -221,6 +221,7 @@ class PptProcessingResult:
 
     status: PptProcessingStatus
     error_detail: str | None = None
+    ppt_outputs: dict[str, dict[str, str]] | None = None
 
 
 @dataclass(frozen=True)
@@ -514,6 +515,7 @@ def run_pipeline(
             missing_inputs=missing_inputs,
             reconciliation_results=reconciliation_outcome.get("reconciliation_results"),
             ppt_status=ppt_result.status.value,
+            ppt_outputs=ppt_result.ppt_outputs,
             concentration_metrics=(
                 concentration_metrics_records if concentration_metrics_records else None
             ),
@@ -2047,6 +2049,14 @@ def _write_outputs(
         master=target_master_ppt.relative_to(run_dir),
         distribution=target_distribution_ppt.relative_to(run_dir),
     )
+    manifest_ppt_outputs: dict[str, dict[str, str]] = {
+        "master": {
+            "role": "maintainer_master",
+            "status": "success",
+            "path": target_master_ppt.relative_to(run_dir).as_posix(),
+            "generation_step": "ppt_master",
+        }
+    }
 
     refresh_generators = registry.load(
         output_generators=config.output_generators,
@@ -2080,16 +2090,32 @@ def _write_outputs(
             LOGGER.error("Master PPT link refresh failed: %s", exc)
 
     if refresh_result.status == PptProcessingStatus.FAILED:
+        manifest_ppt_outputs["master"]["status"] = "failed"
         LOGGER.warning(
             "Skipping distribution PPT derivation because Master PPT refresh failed: %s",
             target_master_ppt,
         )
     elif not config.enable_distribution_output:
+        if refresh_result.status == PptProcessingStatus.SKIPPED:
+            manifest_ppt_outputs["master"]["status"] = "skipped"
+            if refresh_result.error_detail:
+                manifest_ppt_outputs["master"]["skipped_reason"] = refresh_result.error_detail
+        manifest_ppt_outputs["distribution"] = {
+            "role": "distribution",
+            "status": "skipped",
+            "path": target_distribution_ppt.relative_to(run_dir).as_posix(),
+            "generation_step": "ppt_distribution",
+            "skipped_reason": "Distribution output disabled for this run.",
+        }
         LOGGER.info(
             "Skipping distribution PPT derivation because Distribution output is disabled: %s",
             target_distribution_ppt,
         )
     else:
+        if refresh_result.status == PptProcessingStatus.SKIPPED:
+            manifest_ppt_outputs["master"]["status"] = "skipped"
+            if refresh_result.error_detail:
+                manifest_ppt_outputs["master"]["skipped_reason"] = refresh_result.error_detail
         chart_replaced_ppt = run_dir / f"{target_master_ppt.stem}_chart_replaced.pptx"
         chart_replacement_applied = _apply_chart_replacement(
             master_pptx_path=target_master_ppt,
@@ -2122,6 +2148,12 @@ def _write_outputs(
                     f"external relationships in: {rel_parts}"
                 )
         output_paths.append(target_distribution_ppt)
+        manifest_ppt_outputs["distribution"] = {
+            "role": "distribution",
+            "status": "success",
+            "path": target_distribution_ppt.relative_to(run_dir).as_posix(),
+            "generation_step": "ppt_distribution",
+        }
         post_distribution_generators = registry.load(
             output_generators=config.output_generators,
             stage="ppt_post_distribution",
@@ -2155,7 +2187,11 @@ def _write_outputs(
         output_paths.append(readme_path)
 
     LOGGER.info("write_outputs_complete output_count=%s", len(output_paths))
-    return output_paths, refresh_result
+    return output_paths, PptProcessingResult(
+        status=refresh_result.status,
+        error_detail=refresh_result.error_detail,
+        ppt_outputs=manifest_ppt_outputs,
+    )
 
 
 def _apply_chart_replacement(

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2098,9 +2098,8 @@ def _write_outputs(
             static_mode=config.distribution_static,
             warnings=warnings,
         )
-        distribution_source = chart_replaced_ppt if chart_replacement_applied else target_master_ppt
         _derive_distribution_ppt(
-            master_pptx_path=distribution_source,
+            master_pptx_path=target_master_ppt,
             distribution_pptx_path=target_distribution_ppt,
         )
         try:

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2057,10 +2057,27 @@ def _write_outputs(
         ),
     )
     refresh_result = PptProcessingResult(status=PptProcessingStatus.SKIPPED)
+    ran_master_refresh = False
     for generator in refresh_generators:
         generator.generate(context=output_context)
         if generator.name == "ppt_link_refresh":
             refresh_result = _to_ppt_processing_result(getattr(generator, "last_result", None))
+            ran_master_refresh = True
+
+    if not ran_master_refresh:
+        try:
+            refresh_result = _refresh_ppt_links(target_master_ppt)
+        except Exception as exc:
+            refresh_result = PptProcessingResult(
+                status=PptProcessingStatus.FAILED,
+                error_detail=str(exc),
+            )
+            warnings.append(
+                "PPT links refresh failed; COM refresh encountered an error"
+                if not refresh_result.error_detail
+                else f"PPT links refresh failed; {refresh_result.error_detail}"
+            )
+            LOGGER.error("Master PPT link refresh failed: %s", exc)
 
     if refresh_result.status == PptProcessingStatus.FAILED:
         LOGGER.warning(

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2117,7 +2117,7 @@ def _write_outputs(
             if refresh_result.error_detail:
                 manifest_ppt_outputs["master"]["skipped_reason"] = refresh_result.error_detail
         chart_replaced_ppt = run_dir / f"{target_master_ppt.stem}_chart_replaced.pptx"
-        chart_replacement_applied = _apply_chart_replacement(
+        _apply_chart_replacement(
             master_pptx_path=target_master_ppt,
             output_path=chart_replaced_ppt,
             run_dir=run_dir,

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -108,7 +108,9 @@ def reconcile_series_coverage(
 ) -> dict[str, Any]:
     reconciliation_globals = _reconcile_series_coverage.__globals__
     original = reconciliation_globals.get("normalize_counterparty_with_source")
-    reconciliation_globals["normalize_counterparty_with_source"] = normalize_counterparty_with_source
+    reconciliation_globals["normalize_counterparty_with_source"] = (
+        normalize_counterparty_with_source
+    )
     try:
         return _reconcile_series_coverage(
             parsed_data_by_sheet=parsed_data_by_sheet,
@@ -119,6 +121,7 @@ def reconcile_series_coverage(
         )
     finally:
         reconciliation_globals["normalize_counterparty_with_source"] = original
+
 
 if TYPE_CHECKING:
     from counter_risk.outputs.ppt_link_refresh import PptLinkRefreshOutputGenerator
@@ -2064,6 +2067,11 @@ def _write_outputs(
             "Skipping distribution PPT derivation because Master PPT refresh failed: %s",
             target_master_ppt,
         )
+    elif not config.enable_distribution_output:
+        LOGGER.info(
+            "Skipping distribution PPT derivation because Distribution output is disabled: %s",
+            target_distribution_ppt,
+        )
     else:
         chart_replaced_ppt = run_dir / f"{target_master_ppt.stem}_chart_replaced.pptx"
         chart_replacement_applied = _apply_chart_replacement(
@@ -2109,14 +2117,15 @@ def _write_outputs(
         )
         for generator in post_distribution_generators:
             output_paths.extend(generator.generate(context=output_context))
-    static_output_paths = _create_static_distribution(
-        source_pptx=target_master_ppt,
-        run_dir=run_dir,
-        config=config,
-        warnings=warnings,
-    )
-    output_paths.extend(static_output_paths)
-    if refresh_result.status == PptProcessingStatus.SUCCESS:
+    if config.enable_distribution_output:
+        static_output_paths = _create_static_distribution(
+            source_pptx=target_master_ppt,
+            run_dir=run_dir,
+            config=config,
+            warnings=warnings,
+        )
+        output_paths.extend(static_output_paths)
+    if refresh_result.status == PptProcessingStatus.SUCCESS and config.enable_distribution_output:
         warning_banner = _build_limit_warning_banner_for_run_dir(run_dir)
         readme_path = run_dir / "README.txt"
         readme_path.write_text(

--- a/src/counter_risk/pipeline/run_folder_outputs.py
+++ b/src/counter_risk/pipeline/run_folder_outputs.py
@@ -40,9 +40,9 @@ def build_run_folder_readme_content(
         f"Master PPT: {master}",
         f"Distribution PPT: {distribution}",
         "",
-        "1. Open the Master PPT and verify linked chart values are refreshed for the as-of date.",
+        "1. Use the Master PPT only for maintainer edits and final checks inside this run folder.",
         f"2. Confirm the standalone Distribution PPT is present as '{distribution}'.",
-        "3. Send only the Distribution PPT to recipients and retain the Master PPT in the run folder.",
+        "3. Send only the Distribution PPT to recipients; keep the Master PPT maintainer-only.",
     ]
 
     if warning_banner is not None:

--- a/src/counter_risk/pipeline/run_folder_outputs.py
+++ b/src/counter_risk/pipeline/run_folder_outputs.py
@@ -13,6 +13,7 @@ class RunFolderReadmePptOutputs:
 
     master: Path
     distribution: Path
+    distribution_pdf: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -34,16 +35,30 @@ def build_run_folder_readme_content(
     _ = as_of_date
     master = str(ppt_outputs.master)
     distribution = str(ppt_outputs.distribution)
+    distribution_pdf = (
+        None if ppt_outputs.distribution_pdf is None else str(ppt_outputs.distribution_pdf)
+    )
+    send_line = (
+        f"2. Send this file to recipients: {distribution_pdf}."
+        if distribution_pdf is not None
+        else f"2. Send this file to recipients: {distribution}."
+    )
     lines = [
         "Counterparty Risk PPT Distribution Guide",
         "",
-        f"Master PPT: {master}",
-        f"Distribution PPT: {distribution}",
-        "",
-        "1. Use the Master PPT only for maintainer edits and final checks inside this run folder.",
-        f"2. Confirm the standalone Distribution PPT is present as '{distribution}'.",
-        "3. Send only the Distribution PPT to recipients; keep the Master PPT maintainer-only.",
+        f"Maintainer-only file (do not send): {master}",
+        f"Recipient file (safe to send): {distribution}",
     ]
+    if distribution_pdf is not None:
+        lines.append(f"Recipient PDF (preferred when available): {distribution_pdf}")
+    lines.extend(
+        [
+        "",
+        "1. Edit only the maintainer Master PPT and keep it inside this run folder.",
+        send_line,
+        "3. Do not send the Master PPT to recipients.",
+    ]
+    )
 
     if warning_banner is not None:
         lines.extend(

--- a/tests/pipeline/test_manifest_schema.py
+++ b/tests/pipeline/test_manifest_schema.py
@@ -11,7 +11,19 @@ def test_manifest_schema_defines_master_and_distribution_ppt_outputs() -> None:
     assert "master" in ppt_outputs["properties"]
     assert "distribution" in ppt_outputs["properties"]
 
+    assert ppt_outputs["properties"]["master"]["required"] == [
+        "role",
+        "status",
+        "path",
+        "generation_step",
+    ]
     assert ppt_outputs["properties"]["master"]["properties"]["path"]["type"] == "string"
+    assert ppt_outputs["properties"]["master"]["properties"]["status"]["enum"] == [
+        "success",
+        "skipped",
+        "failed",
+    ]
+    assert ppt_outputs["properties"]["master"]["properties"]["generation_step"]["type"] == "string"
     assert ppt_outputs["properties"]["distribution"]["properties"]["path"]["type"] == "string"
 
 

--- a/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
+++ b/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
@@ -130,6 +130,53 @@ def test_ppt_enabled_names_produce_exactly_two_expected_pptx_files(
     }
 
 
+def test_ppt_enabled_run_writes_readme_consistent_with_manifest_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, enable_ppt_output=True)
+    as_of_date = date(2025, 12, 31)
+    output_names = resolve_ppt_output_names(as_of_date)
+
+    monkeypatch.setattr(
+        run_module,
+        "_refresh_ppt_links",
+        lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
+    )
+
+    output_paths, ppt_result = run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=as_of_date,
+        warnings=[],
+    )
+
+    readme_path = run_dir / "README.txt"
+    assert readme_path.exists()
+    readme_content = readme_path.read_text(encoding="utf-8")
+    assert output_names.master_filename in readme_content
+    assert output_names.distribution_filename in readme_content
+
+    manifest = ManifestBuilder(
+        config=config,
+        as_of_date=as_of_date,
+        run_date=date(2026, 1, 2),
+    ).build(
+        run_dir=run_dir,
+        input_hashes={},
+        output_paths=output_paths,
+        top_exposures={},
+        top_changes_per_variant={},
+        warnings=[],
+        ppt_status=ppt_result.status.value,
+    )
+
+    assert "README.txt" in manifest["output_paths"]
+    assert manifest["ppt_outputs"]["master"]["path"] == output_names.master_filename
+    assert manifest["ppt_outputs"]["distribution"]["path"] == output_names.distribution_filename
+
+
 def test_master_refresh_failure_logs_error_and_skips_distribution_derivation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
+++ b/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
@@ -19,7 +19,9 @@ def _write_placeholder(path: Path, *, payload: bytes = b"fixture") -> None:
     path.write_bytes(payload)
 
 
-def _build_config(tmp_path: Path, *, enable_ppt_output: bool) -> WorkflowConfig:
+def _build_config(
+    tmp_path: Path, *, enable_ppt_output: bool, enable_distribution_output: bool = True
+) -> WorkflowConfig:
     inputs_dir = tmp_path / "inputs"
     files = {
         "all_programs": inputs_dir / "all_programs.xlsx",
@@ -43,6 +45,7 @@ def _build_config(tmp_path: Path, *, enable_ppt_output: bool) -> WorkflowConfig:
         output_root=tmp_path / "ignored-output-root",
         enable_screenshot_replacement=False,
         enable_ppt_output=enable_ppt_output,
+        enable_distribution_output=enable_distribution_output,
     )
 
 
@@ -85,7 +88,7 @@ def test_ppt_enabled_names_produce_exactly_two_expected_pptx_files(
         "_refresh_ppt_links",
         lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
     )
-    run_module._write_outputs(
+    output_paths, ppt_result = run_module._write_outputs(
         run_dir=run_dir,
         config=config,
         as_of_date=date(2025, 12, 31),
@@ -96,6 +99,34 @@ def test_ppt_enabled_names_produce_exactly_two_expected_pptx_files(
         "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx",
         "Monthly Counterparty Exposure Report - 2025-12-31.pptx",
     ]
+
+    manifest = ManifestBuilder(
+        config=config,
+        as_of_date=date(2025, 12, 31),
+        run_date=date(2026, 1, 2),
+    ).build(
+        run_dir=run_dir,
+        input_hashes={},
+        output_paths=output_paths,
+        top_exposures={},
+        top_changes_per_variant={},
+        warnings=[],
+        ppt_status=ppt_result.status.value,
+    )
+    assert manifest["ppt_outputs"] == {
+        "distribution": {
+            "generation_step": "ppt_distribution",
+            "path": "Monthly Counterparty Exposure Report - 2025-12-31.pptx",
+            "role": "distribution",
+            "status": "success",
+        },
+        "master": {
+            "generation_step": "ppt_master",
+            "path": "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx",
+            "role": "maintainer_master",
+            "status": "success",
+        },
+    }
 
 
 def test_master_refresh_failure_logs_error_and_skips_distribution_derivation(
@@ -191,6 +222,69 @@ def test_ppt_enabled_order_master_generated_before_distribution(
     assert call_order.count("distribution_derivation") == 1
 
 
+def test_distribution_disabled_keeps_master_and_records_skipped_manifest_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(
+        tmp_path,
+        enable_ppt_output=True,
+        enable_distribution_output=False,
+    )
+    as_of_date = date(2025, 12, 31)
+    output_names = run_module.resolve_ppt_output_names(as_of_date)
+    calls = {"distribution": 0}
+
+    monkeypatch.setattr(
+        run_module,
+        "_refresh_ppt_links",
+        lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
+    )
+
+    def _derive_distribution(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        calls["distribution"] += 1
+
+    monkeypatch.setattr(run_module, "_derive_distribution_ppt", _derive_distribution)
+
+    output_paths, ppt_result = run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=as_of_date,
+        warnings=[],
+    )
+
+    assert (run_dir / output_names.master_filename).exists()
+    assert not (run_dir / output_names.distribution_filename).exists()
+    assert not (run_dir / "README.txt").exists()
+    assert calls["distribution"] == 0
+    assert all(Path(path).name != output_names.distribution_filename for path in output_paths)
+
+    manifest = ManifestBuilder(
+        config=config,
+        as_of_date=as_of_date,
+        run_date=date(2026, 1, 2),
+    ).build(
+        run_dir=run_dir,
+        input_hashes={},
+        output_paths=output_paths,
+        top_exposures={},
+        top_changes_per_variant={},
+        warnings=[],
+        ppt_status=ppt_result.status.value,
+    )
+
+    assert manifest["ppt_outputs"]["master"]["status"] == "success"
+    assert manifest["ppt_outputs"]["distribution"] == {
+        "generation_step": "ppt_distribution",
+        "path": output_names.distribution_filename,
+        "role": "distribution",
+        "skipped_reason": "Distribution output disabled for this run.",
+        "status": "skipped",
+    }
+
+
 def test_no_distribution_without_master_when_master_generation_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -231,3 +325,9 @@ def test_no_distribution_without_master_when_master_generation_fails(
     assert all(Path(path).name != distribution_name for path in manifest["output_paths"])
     assert all(Path(path).name != "README.txt" for path in manifest["output_paths"])
     assert "distribution" not in manifest.get("ppt_outputs", {})
+    assert manifest["ppt_outputs"]["master"] == {
+        "generation_step": "ppt_master",
+        "path": "Monthly Counterparty Exposure Report (Master) - 2025-12-31.pptx",
+        "role": "maintainer_master",
+        "status": "failed",
+    }

--- a/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
+++ b/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
@@ -285,6 +285,61 @@ def test_distribution_disabled_keeps_master_and_records_skipped_manifest_entry(
     }
 
 
+def test_master_refresh_skipped_records_master_skipped_and_distribution_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, enable_ppt_output=True)
+    as_of_date = date(2025, 12, 31)
+    output_names = run_module.resolve_ppt_output_names(as_of_date)
+
+    monkeypatch.setattr(
+        run_module,
+        "_refresh_ppt_links",
+        lambda _path: run_module.PptProcessingResult(
+            status=run_module.PptProcessingStatus.SKIPPED,
+            error_detail="unsupported platform",
+        ),
+    )
+
+    output_paths, ppt_result = run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=as_of_date,
+        warnings=[],
+    )
+
+    manifest = ManifestBuilder(
+        config=config,
+        as_of_date=as_of_date,
+        run_date=date(2026, 1, 2),
+    ).build(
+        run_dir=run_dir,
+        input_hashes={},
+        output_paths=output_paths,
+        top_exposures={},
+        top_changes_per_variant={},
+        warnings=[],
+        ppt_status=ppt_result.status.value,
+        ppt_outputs=ppt_result.ppt_outputs,
+    )
+
+    assert manifest["ppt_outputs"]["master"] == {
+        "generation_step": "ppt_master",
+        "path": output_names.master_filename,
+        "role": "maintainer_master",
+        "skipped_reason": "unsupported platform",
+        "status": "skipped",
+    }
+    assert manifest["ppt_outputs"]["distribution"] == {
+        "generation_step": "ppt_distribution",
+        "path": output_names.distribution_filename,
+        "role": "distribution",
+        "status": "success",
+    }
+
+
 def test_no_distribution_without_master_when_master_generation_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
+++ b/tests/pipeline/test_monthly_pipeline_ppt_outputs.py
@@ -11,6 +11,7 @@ import pytest
 import counter_risk.pipeline.run as run_module
 from counter_risk.config import WorkflowConfig
 from counter_risk.pipeline.manifest import ManifestBuilder
+from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
 from counter_risk.pipeline.ppt_validation import PptStandaloneValidationResult
 
 
@@ -233,7 +234,7 @@ def test_distribution_disabled_keeps_master_and_records_skipped_manifest_entry(
         enable_distribution_output=False,
     )
     as_of_date = date(2025, 12, 31)
-    output_names = run_module.resolve_ppt_output_names(as_of_date)
+    output_names = resolve_ppt_output_names(as_of_date)
     calls = {"distribution": 0}
 
     monkeypatch.setattr(
@@ -292,7 +293,7 @@ def test_master_refresh_skipped_records_master_skipped_and_distribution_success(
     run_dir.mkdir(parents=True)
     config = _build_config(tmp_path, enable_ppt_output=True)
     as_of_date = date(2025, 12, 31)
-    output_names = run_module.resolve_ppt_output_names(as_of_date)
+    output_names = resolve_ppt_output_names(as_of_date)
 
     monkeypatch.setattr(
         run_module,

--- a/tests/pipeline/test_run_folder_outputs.py
+++ b/tests/pipeline/test_run_folder_outputs.py
@@ -27,6 +27,9 @@ def test_build_run_folder_readme_content_includes_expected_filenames_and_steps()
     assert "\n1. " in content
     assert "\n2. " in content
     assert "\n3. " in content
+    assert "Maintainer-only file (do not send):" in content
+    assert "Recipient file (safe to send):" in content
+    assert "Do not send the Master PPT to recipients." in content
 
 
 def test_build_run_folder_readme_content_has_numbered_steps_in_order() -> None:
@@ -68,3 +71,19 @@ def test_build_run_folder_readme_content_includes_limit_warning_banner_when_prov
     assert "WARNING: Limit Breaches Detected (2)" in content
     assert "Warning banner: 2 configured limit breaches were detected." in content
     assert "Review breach details: limit_breaches.csv" in content
+
+
+def test_build_run_folder_readme_content_prefers_distribution_pdf_when_available() -> None:
+    output_names = resolve_ppt_output_names(date(2026, 1, 31))
+    distribution_pdf = Path(output_names.distribution_filename.replace(".pptx", ".pdf"))
+    content = build_run_folder_readme_content(
+        date(2026, 1, 31),
+        RunFolderReadmePptOutputs(
+            master=Path(output_names.master_filename),
+            distribution=Path(output_names.distribution_filename),
+            distribution_pdf=distribution_pdf,
+        ),
+    )
+
+    assert f"Recipient PDF (preferred when available): {distribution_pdf}" in content
+    assert f"Send this file to recipients: {distribution_pdf}." in content

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -329,7 +329,7 @@ def test_write_outputs_raises_when_distribution_standalone_validation_fails(
     assert called["validate_distribution"] == 1
 
 
-def test_write_outputs_skips_disabled_refresh_generator(
+def test_write_outputs_runs_master_refresh_even_when_refresh_generator_is_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run_dir = tmp_path / "run"
@@ -361,7 +361,7 @@ def test_write_outputs_skips_disabled_refresh_generator(
     )
 
     output_names = resolve_ppt_output_names(date(2025, 12, 31))
-    assert called["refresh"] == 0
+    assert called["refresh"] == 1
     assert (run_dir / output_names.master_filename) in output_paths
     assert (run_dir / output_names.distribution_filename) in output_paths
 

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -366,6 +366,52 @@ def test_write_outputs_runs_master_refresh_even_when_refresh_generator_is_disabl
     assert (run_dir / output_names.distribution_filename) in output_paths
 
 
+def test_write_outputs_derives_distribution_from_resolved_master_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, screenshot_inputs={}).model_copy(
+        update={"enable_screenshot_replacement": False}
+    )
+    as_of_date = date(2025, 12, 31)
+    output_names = resolve_ppt_output_names(as_of_date)
+    expected_master_path = run_dir / output_names.master_filename
+    observed: dict[str, Path] = {}
+
+    monkeypatch.setattr(
+        run_module,
+        "_refresh_ppt_links",
+        lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
+    )
+    monkeypatch.setattr(run_module, "_apply_chart_replacement", lambda **_kwargs: True)
+
+    def _capture_derive(*, master_pptx_path: Path, distribution_pptx_path: Path) -> None:
+        observed["master_pptx_path"] = master_pptx_path
+        distribution_pptx_path.write_bytes(b"distribution")
+
+    monkeypatch.setattr(run_module, "_derive_distribution_ppt", _capture_derive)
+    monkeypatch.setattr(
+        run_module,
+        "validate_distribution_ppt_standalone",
+        lambda _path: PptStandaloneValidationResult(
+            is_valid=True,
+            external_relationship_count=0,
+            relationship_parts_scanned=(),
+            external_relationship_parts=(),
+        ),
+    )
+
+    run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=as_of_date,
+        warnings=[],
+    )
+
+    assert observed["master_pptx_path"] == expected_master_path
+
+
 def test_write_outputs_runs_config_registered_generator_without_pipeline_changes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_pipeline_run_outputs.py
+++ b/tests/test_pipeline_run_outputs.py
@@ -211,6 +211,60 @@ def test_write_outputs_skips_all_ppt_generation_when_disabled(
     assert list(run_dir.glob("*.pptx")) == []
 
 
+@pytest.mark.parametrize(
+    ("enable_distribution_output", "expected_distribution_count"),
+    ((True, 1), (False, 0)),
+)
+def test_write_outputs_successful_run_writes_master_and_optional_distribution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    enable_distribution_output: bool,
+    expected_distribution_count: int,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    config = _build_config(tmp_path, screenshot_inputs={}).model_copy(
+        update={
+            "enable_screenshot_replacement": False,
+            "enable_distribution_output": enable_distribution_output,
+        }
+    )
+    as_of_date = date(2025, 12, 31)
+    output_names = resolve_ppt_output_names(as_of_date)
+    master_ppt = run_dir / output_names.master_filename
+    distribution_ppt = run_dir / output_names.distribution_filename
+
+    monkeypatch.setattr(
+        run_module,
+        "_refresh_ppt_links",
+        lambda _path: run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SUCCESS),
+    )
+    monkeypatch.setattr(run_module, "_apply_chart_replacement", lambda **_kwargs: True)
+    monkeypatch.setattr(
+        run_module,
+        "validate_distribution_ppt_standalone",
+        lambda _path: PptStandaloneValidationResult(
+            is_valid=True,
+            external_relationship_count=0,
+            relationship_parts_scanned=(),
+            external_relationship_parts=(),
+        ),
+    )
+
+    output_paths, ppt_result = run_module._write_outputs(
+        run_dir=run_dir,
+        config=config,
+        as_of_date=as_of_date,
+        warnings=[],
+    )
+
+    assert ppt_result.status == run_module.PptProcessingStatus.SUCCESS
+    assert master_ppt in output_paths
+    assert master_ppt.exists()
+    assert int(distribution_ppt in output_paths) == expected_distribution_count
+    assert int(distribution_ppt.exists()) == expected_distribution_count
+
+
 def test_write_outputs_skips_distribution_when_master_refresh_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_ppt_naming.py
+++ b/tests/unit/test_ppt_naming.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
 from counter_risk.pipeline.ppt_naming import (
     distribution_ppt_filename,
@@ -39,3 +39,14 @@ def test_resolve_ppt_output_names_is_deterministic_for_same_date() -> None:
     second = resolve_ppt_output_names(as_of_date)
 
     assert first == second
+
+
+def test_ppt_filenames_normalize_datetime_inputs_to_date_only_suffix() -> None:
+    as_of_datetime = datetime(2026, 1, 31, 14, 22, 7)
+
+    names = resolve_ppt_output_names(as_of_datetime)
+
+    assert (
+        names.master_filename == "Monthly Counterparty Exposure Report (Master) - 2026-01-31.pptx"
+    )
+    assert names.distribution_filename == "Monthly Counterparty Exposure Report - 2026-01-31.pptx"

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,9 +1,10 @@
 # Counter_Risk Workloop State
 
-## 2026-05-01T14:12Z - opener PR in progress for issue #471
+## 2026-05-01T14:12Z - opener PR opened for issue #471
 
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Selected lane: https://github.com/stranske/Counter_Risk/issues/471 (`priority:normal`, `repo-review-approved`).
+- Draft PR: https://github.com/stranske/Counter_Risk/pull/523 (`agent:codex`, branch `codex/issue-471-dual-ppt-deliverables`).
 - Branch: `codex/issue-471-dual-ppt-deliverables` from `origin/main` (`1fde16c`).
 - Selection rationale:
   - ACTION A succeeded; sentinel active slot was closer-owned trip-planner #1057/#1044 verifier state and treated as informational.
@@ -22,7 +23,9 @@
   - `python -m pytest tests/test_ppt_status_reporting.py tests/pipeline/test_run_pipeline.py -k 'ppt or PPT or distribution or manifest' --no-cov` -> 19 passed, 81 deselected.
   - `python -m ruff check src/counter_risk/config.py src/counter_risk/pipeline/run.py src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/manifest_schema.py src/counter_risk/pipeline/run_folder_outputs.py tests/pipeline/test_monthly_pipeline_ppt_outputs.py tests/pipeline/test_manifest_schema.py` -> pass.
   - `python -m black --target-version py312 --check src/counter_risk/config.py src/counter_risk/pipeline/run.py src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/manifest_schema.py src/counter_risk/pipeline/run_folder_outputs.py tests/pipeline/test_monthly_pipeline_ppt_outputs.py tests/pipeline/test_manifest_schema.py` -> pass.
-- Next action: commit, push, open draft PR with `agent:codex`, then emit `pr_opened`; keepalive owns follow-up after PR creation.
+- Relay: emitted `pr_opened active.source_repo=stranske/Counter_Risk active.source_issue=471 active.source_pr=523 active.next_action=wait_for_keepalive`.
+- Cap state post-PR: 5/5 opener-owned issue-linked PRs (`Counter_Risk#521`, `Counter_Risk#522`, `Counter_Risk#523`, `Travel-Plan-Permission#1008`, `trip-planner#1061`). Next opener round will be cap-blocked unless closer drains.
+- Next action: keepalive owns PR #523; opener should move to the next eligible issue only after the cap drops below 5.
 
 ## 2026-05-01T08:05:33Z - opener PR opened for issue #468
 - Automation: `pd-workloop-resume` (codex opener lane).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,29 @@
 # Counter_Risk Workloop State
 
+## 2026-05-01T14:12Z - opener PR in progress for issue #471
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Selected lane: https://github.com/stranske/Counter_Risk/issues/471 (`priority:normal`, `repo-review-approved`).
+- Branch: `codex/issue-471-dual-ppt-deliverables` from `origin/main` (`1fde16c`).
+- Selection rationale:
+  - ACTION A succeeded; sentinel active slot was closer-owned trip-planner #1057/#1044 verifier state and treated as informational.
+  - Approved queue inputs remain inactive/stale (`approved-issue-queue.json` has `issues=[]`, `feedback_status=stale`; `repo_review_feedback.json` is dated `2026-04-26`).
+  - Required priority discovery found high-priority implementation issues already linked to open PRs (`Travel-Plan-Permission#1000 -> #1008`, `trip-planner#1048 -> #1061`) and skipped the Workflows auth-expiring ops alert.
+  - Opener cap check found 4/5 live opener-owned issue-linked PRs after closer merged trip-planner #1057: `Counter_Risk#521`, `Counter_Risk#522`, `Travel-Plan-Permission#1008`, and `trip-planner#1061`.
+  - Oldest unlinked supported normal-priority issue was Counter_Risk #471.
+- Implementation:
+  - Added `enable_distribution_output` so runs can intentionally produce only the editable Master deck without deriving Distribution artifacts.
+  - Manifest building now emits `ppt_outputs.master` / `ppt_outputs.distribution` entries with role, status, path, generation step, and skipped reason when Distribution is disabled.
+  - Master refresh failure still suppresses Distribution derivation and omits the Distribution manifest entry.
+  - Run-folder README text now states the maintainer-only vs send-to-recipients distinction in operator language.
+  - Manifest schema and focused tests cover successful both-deliverable runs, Distribution-disabled runs, Master-refresh failure, and PPT output schema fields.
+- Validation:
+  - `python -m pytest tests/pipeline/test_monthly_pipeline_ppt_outputs.py tests/pipeline/test_run_manifest_ppt_entries.py tests/pipeline/test_run_folder_readme.py tests/pipeline/test_manifest_schema.py tests/unit/test_ppt_naming.py --no-cov` -> 24 passed.
+  - `python -m pytest tests/test_ppt_status_reporting.py tests/pipeline/test_run_pipeline.py -k 'ppt or PPT or distribution or manifest' --no-cov` -> 19 passed, 81 deselected.
+  - `python -m ruff check src/counter_risk/config.py src/counter_risk/pipeline/run.py src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/manifest_schema.py src/counter_risk/pipeline/run_folder_outputs.py tests/pipeline/test_monthly_pipeline_ppt_outputs.py tests/pipeline/test_manifest_schema.py` -> pass.
+  - `python -m black --target-version py312 --check src/counter_risk/config.py src/counter_risk/pipeline/run.py src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/manifest_schema.py src/counter_risk/pipeline/run_folder_outputs.py tests/pipeline/test_monthly_pipeline_ppt_outputs.py tests/pipeline/test_manifest_schema.py` -> pass.
+- Next action: commit, push, open draft PR with `agent:codex`, then emit `pr_opened`; keepalive owns follow-up after PR creation.
+
 ## 2026-05-01T08:05:33Z - opener PR opened for issue #468
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Selected lane: `https://github.com/stranske/Counter_Risk/issues/468` (`priority:normal`, repo-review-approved).


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:471 -->
> **Source:** Issue #471

Closes #471

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Maintainers need an editable linked deck, while operators and recipients need a safe static deck. The pipeline should write both artifacts with predictable names and manifest entries so users know which file to edit and which file to send.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#467](https://github.com/stranske/Counter_Risk/issues/467)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define Master and Distribution naming in `src/counter_risk/pipeline/ppt_naming.py`, using the resolved `as_of_date` consistently.
- [x] Ensure the pipeline writes the linked Master deck first through the existing PPT refresh path.
- [x] Derive the Distribution deck from the resolved Master output path through the static/scrubbed path when enabled.
- [x] Register both artifacts, generation status, skipped reasons, and file paths in `manifest.json`.
- [x] Write a short run-folder README that tells operators which PPT/PDF file to send and which file remains maintainer-only.
- [x] Add tests covering both-enabled, Distribution-disabled, Master-failure, and manifest/README consistency cases.

#### Acceptance criteria
- [x] A successful PPT-enabled run produces a Master artifact and a Distribution artifact unless Distribution is explicitly disabled.
- [x] Distribution generation never runs from an unresolved, missing, or failed Master output.
- [x] `manifest.json` names both deliverables with status, path, and generation step.
- [x] The run-folder README explains the send-versus-edit distinction in non-technical operator language.
- [x] Tests prove no Distribution artifact or manifest entry is written when Master generation fails.

<!-- auto-status-summary:end -->