### PR TITLE
Issue #472: machine-readable macro spec + parity harness

### DIFF
--- a/docs/macro_spec.md
+++ b/docs/macro_spec.md
@@ -121,7 +121,8 @@ Required inputs (sheet names, columns):
 Output expectations (ranges affected, invariants):
 - Writes status text to `Runner!B7` and result text to `Runner!B8`
 - Writes data quality status (text + fill color) to `Runner!B9` when a
-  `DATA_QUALITY_SUMMARY.txt` is produced; cell stays empty if no summary file
+  `DATA_QUALITY_SUMMARY.txt` is produced; if no summary file is present, the VBA
+  does not modify the existing `Runner!B9` value
 - Uses All Programs config for pipeline invocation
 - Generated workbook includes `CPRS - CH`
 - `CPRS - CH!B5` matches parsed lead counterparty from source

--- a/docs/macro_spec.md
+++ b/docs/macro_spec.md
@@ -1,54 +1,127 @@
 # Macro Specification
 
 This document captures the current VBA macro behavior that must be preserved as the
-pipeline replaces spreadsheet automation.
+pipeline replaces spreadsheet automation. It is the machine-readable parity harness
+referenced by the macro-equivalent test suite: each section is anchored by a stable
+Spec ID (`MS-*`) so a failed parity test can point straight at the section it
+protects.
 
 ## Scope
 
-- VBA module: `assets/vba/RunnerLaunch.bas`
-- Workbook surface: `Runner.xlsm` and `assets/templates/counter_risk_template.xlsm`
-- User-facing sheet: `Runner`
+- VBA module sources: `assets/vba/*.bas` (canonical: `assets/vba/RunnerLaunch.bas`).
+- Macro-enabled workbook fixtures (the source of truth for embedded module names):
+  - `Runner.xlsm`
+  - `assets/templates/counter_risk_template.xlsm`
+- User-facing sheet: `Runner` (constant `RUNNER_SHEET_NAME`).
+- Generated outputs: MOSERS workbooks per run mode (`All Programs`, `Ex Trend`,
+  `Trend`); MOSERS structural invariants are documented per macro below and asserted
+  in `tests/test_mosers_*_output_structure.py`.
+
+## Runner Sheet Cell Layout
+
+Spec ID: `MS-RUNNER-CELLS`
+
+The Runner sheet uses a small set of named cells that every click handler reads or
+writes. These are the source-of-truth constants in `RunnerLaunch.bas`; any drift
+between the spec section and the `.bas` constants is a parity failure (see
+`tests/test_macro_spec_parity.py`).
+
+| Purpose                     | Cell | `.bas` constant            |
+|-----------------------------|------|----------------------------|
+| Selected as-of month input  | `B3` | (read by `ReadSelectedDate`) |
+| Status output               | `B7` | `STATUS_CELL`              |
+| Result output               | `B8` | `RESULT_CELL`              |
+| Data quality status         | `B9` | `DQ_STATUS_CELL`           |
+
+The selected-month cell `B3` accepts any value Excel parses as a date; macros
+internally normalize to the last day of the parsed month before invoking the
+pipeline.
 
 ## Macro Intent (Plain Language)
 
 ### `RunAll_Click`
 
+Spec ID: `MS-RUN-ALL`
+
 Runs the counter-risk pipeline in **All Programs** mode for the month selected on the
-`Runner` sheet. It updates status/result cells so an operator can see whether execution
-completed successfully.
+`Runner` sheet. It updates status/result cells so an operator can see whether
+execution completed successfully.
 
 ### `RunExTrend_Click`
 
+Spec ID: `MS-RUN-EX-TREND`
+
 Runs the counter-risk pipeline in **Ex Trend** mode for the month selected on the
-`Runner` sheet. It follows the same launch flow as `RunAll_Click`, but uses the Ex Trend
-configuration.
+`Runner` sheet. It follows the same launch flow as `RunAll_Click`, but uses the Ex
+Trend configuration.
 
 ### `RunTrend_Click`
 
-Runs the counter-risk pipeline in **Trend** mode for the month selected on the `Runner`
-sheet. It follows the same launch flow as the other run macros, but uses the Trend
-configuration.
+Spec ID: `MS-RUN-TREND`
+
+Runs the counter-risk pipeline in **Trend** mode for the month selected on the
+`Runner` sheet. It follows the same launch flow as the other run macros, but uses
+the Trend configuration.
 
 ### `OpenOutputFolder_Click`
 
-Opens the output directory for the currently selected reporting month so operators can
-inspect generated artifacts. If the folder does not exist, it reports an error instead of
-silently succeeding.
+Spec ID: `MS-OPEN-OUTPUT`
+
+Opens the run output directory for the currently selected reporting month so
+operators can inspect generated artifacts. If the folder does not exist, it reports
+an error instead of silently succeeding.
+
+### `OpenSummary_Click`
+
+Spec ID: `MS-OPEN-SUMMARY`
+
+Opens the data-quality summary file (`DATA_QUALITY_SUMMARY.txt`) inside the run
+output directory for the selected reporting month. If the summary file is missing,
+it reports an error in the result cell instead of silently succeeding.
+
+### `OpenManifest_Click`
+
+Spec ID: `MS-OPEN-MANIFEST`
+
+Opens the run manifest (`manifest.json`) inside the run output directory for the
+selected reporting month. If the manifest is missing, it reports an error in the
+result cell instead of silently succeeding.
+
+### `OpenPPTFolder_Click`
+
+Spec ID: `MS-OPEN-PPT`
+
+Opens the static PPT deliverable directory (`distribution_static/`) inside the run
+output directory for the selected reporting month. If the directory is missing, it
+reports an error in the result cell instead of silently succeeding.
 
 ## Per-Macro Requirements
 
 ### `RunAll_Click`
 
+Spec ID: `MS-RUN-ALL`
+
+Fixture sources:
+- VBA module fixture: `assets/vba/RunnerLaunch.bas`
+  (extracted from `Runner.xlsm` and `assets/templates/counter_risk_template.xlsm`)
+- Pipeline input workbook fixture: `tests/fixtures/NISA Monthly All Programs - Raw.xlsx`
+- Generated workbook fixture under test: produced by
+  `counter_risk.mosers.workbook_generation.generate_mosers_workbook_all_programs`
+  (asserted in `tests/test_mosers_all_programs_output_structure.py`)
+
 Required inputs (sheet names, columns):
 - Sheet `Runner`
 - Cell `B3` with selected month text (`MM/YYYY`)
-- Cell `B11` status output target
-- Cell `B12` result output target
+- Cell `B7` status output target (constant `STATUS_CELL`)
+- Cell `B8` result output target (constant `RESULT_CELL`)
+- Cell `B9` data quality status target (constant `DQ_STATUS_CELL`)
 - Pipeline input workbook `tests/fixtures/NISA Monthly All Programs - Raw.xlsx`
 - Parsed source fields from CPRS-CH totals rows: annualized volatility and notional
 
 Output expectations (ranges affected, invariants):
-- Writes status/result text to `Runner!B11:B12`
+- Writes status text to `Runner!B7` and result text to `Runner!B8`
+- Writes data quality status (text + fill color) to `Runner!B9` when a
+  `DATA_QUALITY_SUMMARY.txt` is produced; cell stays empty if no summary file
 - Uses All Programs config for pipeline invocation
 - Generated workbook includes `CPRS - CH`
 - `CPRS - CH!B5` matches parsed lead counterparty from source
@@ -62,16 +135,28 @@ Output expectations (ranges affected, invariants):
 
 ### `RunExTrend_Click`
 
+Spec ID: `MS-RUN-EX-TREND`
+
+Fixture sources:
+- VBA module fixture: `assets/vba/RunnerLaunch.bas`
+- Pipeline input workbook fixture: `tests/fixtures/NISA Monthly Ex Trend - Raw.xlsx`
+- Generated workbook fixture under test: produced by
+  `counter_risk.mosers.workbook_generation.generate_mosers_workbook_ex_trend`
+  (asserted in `tests/test_mosers_ex_trend_output_structure.py`)
+
 Required inputs (sheet names, columns):
 - Sheet `Runner`
 - Cell `B3` with selected month text (`MM/YYYY`)
-- Cell `B11` status output target
-- Cell `B12` result output target
+- Cell `B7` status output target (constant `STATUS_CELL`)
+- Cell `B8` result output target (constant `RESULT_CELL`)
+- Cell `B9` data quality status target (constant `DQ_STATUS_CELL`)
 - Pipeline input workbook `tests/fixtures/NISA Monthly Ex Trend - Raw.xlsx`
 - Parsed source fields from CPRS-CH totals rows: annualized volatility and notional
 
 Output expectations (ranges affected, invariants):
-- Writes status/result text to `Runner!B11:B12`
+- Writes status text to `Runner!B7` and result text to `Runner!B8`
+- Writes data quality status (text + fill color) to `Runner!B9` when a
+  `DATA_QUALITY_SUMMARY.txt` is produced
 - Uses Ex Trend config for pipeline invocation
 - Generated workbook includes `CPRS - CH`
 - `CPRS - CH!B5` matches parsed lead counterparty from source
@@ -85,16 +170,28 @@ Output expectations (ranges affected, invariants):
 
 ### `RunTrend_Click`
 
+Spec ID: `MS-RUN-TREND`
+
+Fixture sources:
+- VBA module fixture: `assets/vba/RunnerLaunch.bas`
+- Pipeline input workbook fixture: `tests/fixtures/NISA Monthly Trend - Raw.xlsx`
+- Generated workbook fixture under test: produced by
+  `counter_risk.mosers.workbook_generation.generate_mosers_workbook_trend`
+  (asserted in `tests/test_mosers_trend_output_structure.py`)
+
 Required inputs (sheet names, columns):
 - Sheet `Runner`
 - Cell `B3` with selected month text (`MM/YYYY`)
-- Cell `B11` status output target
-- Cell `B12` result output target
+- Cell `B7` status output target (constant `STATUS_CELL`)
+- Cell `B8` result output target (constant `RESULT_CELL`)
+- Cell `B9` data quality status target (constant `DQ_STATUS_CELL`)
 - Pipeline input workbook `tests/fixtures/NISA Monthly Trend - Raw.xlsx`
 - Parsed source fields from CPRS-CH totals rows: annualized volatility and notional
 
 Output expectations (ranges affected, invariants):
-- Writes status/result text to `Runner!B11:B12`
+- Writes status text to `Runner!B7` and result text to `Runner!B8`
+- Writes data quality status (text + fill color) to `Runner!B9` when a
+  `DATA_QUALITY_SUMMARY.txt` is produced
 - Uses Trend config for pipeline invocation
 - Generated workbook includes `CPRS - CH`
 - `CPRS - CH!B5` matches parsed lead counterparty from source
@@ -108,17 +205,83 @@ Output expectations (ranges affected, invariants):
 
 ### `OpenOutputFolder_Click`
 
+Spec ID: `MS-OPEN-OUTPUT`
+
+Fixture sources:
+- VBA module fixture: `assets/vba/RunnerLaunch.bas`
+- Path resolution exercised against the run output directory under
+  `<OutputRoot>/<yyyy-mm-dd_hhnnss>` per `ResolveOutputDir`
+
 Required inputs (sheet names, columns):
 - Sheet `Runner`
 - Cell `B3` selected month text (`MM/YYYY`) for output folder resolution
 
 Output expectations (ranges affected, invariants):
 - Resolves output path using selected month and repository root
-- Attempts to open folder path
-- If path missing, reports an error status instead of silent success
+- Attempts to open the folder path
+- If path missing, writes an error to `Runner!B8` instead of silent success
+- Does not mutate MOSERS workbook ranges
+
+### `OpenSummary_Click`
+
+Spec ID: `MS-OPEN-SUMMARY`
+
+Fixture sources:
+- VBA module fixture: `assets/vba/RunnerLaunch.bas`
+- Path resolution exercised against `<run-output-dir>/DATA_QUALITY_SUMMARY.txt`
+  per `ResolveDataQualitySummaryPath`
+
+Required inputs (sheet names, columns):
+- Sheet `Runner`
+- Cell `B3` selected month text (`MM/YYYY`) for summary path resolution
+
+Output expectations (ranges affected, invariants):
+- Resolves summary file path using selected month and repository root
+- Attempts to open the file
+- If file missing, writes an error to `Runner!B8` instead of silent success
+- Does not mutate MOSERS workbook ranges
+
+### `OpenManifest_Click`
+
+Spec ID: `MS-OPEN-MANIFEST`
+
+Fixture sources:
+- VBA module fixture: `assets/vba/RunnerLaunch.bas`
+- Path resolution exercised against `<run-output-dir>/manifest.json` per
+  `ResolveManifestPath`
+
+Required inputs (sheet names, columns):
+- Sheet `Runner`
+- Cell `B3` selected month text (`MM/YYYY`) for manifest path resolution
+
+Output expectations (ranges affected, invariants):
+- Resolves manifest file path using selected month and repository root
+- Attempts to open the file
+- If file missing, writes an error to `Runner!B8` instead of silent success
+- Does not mutate MOSERS workbook ranges
+
+### `OpenPPTFolder_Click`
+
+Spec ID: `MS-OPEN-PPT`
+
+Fixture sources:
+- VBA module fixture: `assets/vba/RunnerLaunch.bas`
+- Path resolution exercised against `<run-output-dir>/distribution_static` per
+  `ResolvePPTOutputDir`
+
+Required inputs (sheet names, columns):
+- Sheet `Runner`
+- Cell `B3` selected month text (`MM/YYYY`) for PPT folder resolution
+
+Output expectations (ranges affected, invariants):
+- Resolves PPT output folder path using selected month and repository root
+- Attempts to open the folder
+- If folder missing, writes an error to `Runner!B8` instead of silent success
 - Does not mutate MOSERS workbook ranges
 
 ## Known-Acceptable Drift
+
+Spec ID: `MS-DRIFT`
 
 - Floating-point comparisons for transformed numeric values use tolerance
   `rel_tol=1e-12` and `abs_tol=1e-12`.
@@ -127,3 +290,6 @@ Output expectations (ranges affected, invariants):
 - Empty tail slots after available rows are accepted as blanks (`None`) in range-level
   checks, but invariant checks require non-blank values in the enforced core numeric
   ranges.
+- Cosmetic-only differences (cell fill color tints, font weight, column widths) are
+  out of scope for parity tests; only structural and numeric invariants documented
+  above are enforced.

--- a/tests/spec/test_macro_spec_doc.py
+++ b/tests/spec/test_macro_spec_doc.py
@@ -51,7 +51,8 @@ def test_macro_spec_doc_lists_required_inputs_and_output_expectations_per_macro(
         )
 
     required_terms = (
-        "Runner!B11:B12",
+        "Runner!B7",
+        "Runner!B8",
         "CPRS - CH!D10:D20",
         "CPRS - CH!E10:E20",
         "CPRS - CH!C10:C20",
@@ -59,7 +60,9 @@ def test_macro_spec_doc_lists_required_inputs_and_output_expectations_per_macro(
     for term in required_terms:
         assert term in content, (
             "docs/macro_spec.md must include range-level output expectations and invariants; "
-            f"missing {term}."
+            f"missing {term}. Cell references must match the constants in "
+            "assets/vba/RunnerLaunch.bas (STATUS_CELL/RESULT_CELL/DQ_STATUS_CELL); "
+            "see section [MS-RUNNER-CELLS]."
         )
 
 

--- a/tests/test_macro_spec_parity.py
+++ b/tests/test_macro_spec_parity.py
@@ -1,0 +1,196 @@
+"""Macro parity harness.
+
+Bidirectional checks that ``docs/macro_spec.md`` stays aligned with the source-of-
+truth constants and public click handlers in ``assets/vba/RunnerLaunch.bas``. Each
+assertion failure points at the Spec ID section in ``macro_spec.md`` that protects
+the invariant, so a maintainer can update the spec or the macro deliberately.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+VBA_MODULE_PATH = Path("assets/vba/RunnerLaunch.bas")
+MACRO_SPEC_PATH = Path("docs/macro_spec.md")
+
+# Constants in the .bas file we expect to find documented in macro_spec.md.
+# (constant_name, expected_address, spec_section_id)
+RUNNER_CELL_CONSTANTS: tuple[tuple[str, str, str], ...] = (
+    ("STATUS_CELL", "B7", "MS-RUNNER-CELLS"),
+    ("RESULT_CELL", "B8", "MS-RUNNER-CELLS"),
+    ("DQ_STATUS_CELL", "B9", "MS-RUNNER-CELLS"),
+)
+
+# Public click handlers (Sub <Name>_Click) every spec must document with a Spec ID.
+EXPECTED_CLICK_HANDLERS: tuple[tuple[str, str], ...] = (
+    ("RunAll_Click", "MS-RUN-ALL"),
+    ("RunExTrend_Click", "MS-RUN-EX-TREND"),
+    ("RunTrend_Click", "MS-RUN-TREND"),
+    ("OpenOutputFolder_Click", "MS-OPEN-OUTPUT"),
+    ("OpenSummary_Click", "MS-OPEN-SUMMARY"),
+    ("OpenManifest_Click", "MS-OPEN-MANIFEST"),
+    ("OpenPPTFolder_Click", "MS-OPEN-PPT"),
+)
+
+CLICK_HANDLER_PATTERN = re.compile(r"^Public Sub ([A-Za-z0-9_]+_Click)\(\)", re.MULTILINE)
+CONSTANT_PATTERN = re.compile(
+    r'^Private Const\s+([A-Z0-9_]+)\s+As String\s*=\s*"([^"]+)"', re.MULTILINE
+)
+
+
+def _read_module_source() -> str:
+    assert VBA_MODULE_PATH.is_file(), (
+        f"Expected VBA source at {VBA_MODULE_PATH}; macro parity harness cannot run "
+        f"without it. See docs/macro_spec.md section 'Scope'."
+    )
+    return VBA_MODULE_PATH.read_text(encoding="utf-8")
+
+
+def _read_spec_text() -> str:
+    assert MACRO_SPEC_PATH.is_file(), (
+        f"Expected macro spec at {MACRO_SPEC_PATH}; the parity harness has nothing "
+        f"to compare against."
+    )
+    return MACRO_SPEC_PATH.read_text(encoding="utf-8")
+
+
+def _bas_constants(module_source: str) -> dict[str, str]:
+    return {match.group(1): match.group(2) for match in CONSTANT_PATTERN.finditer(module_source)}
+
+
+def _click_handlers(module_source: str) -> set[str]:
+    return set(CLICK_HANDLER_PATTERN.findall(module_source))
+
+
+def test_runner_cell_constants_match_bas_source() -> None:
+    """The expected cell-name table must match the live ``.bas`` constants.
+
+    If a constant was renamed or its address changed in ``RunnerLaunch.bas``, update
+    section ``MS-RUNNER-CELLS`` in ``docs/macro_spec.md`` (and the per-macro
+    ``Required inputs`` / ``Output expectations`` lists for `MS-RUN-*`) before
+    relaxing this assertion.
+    """
+
+    constants = _bas_constants(_read_module_source())
+    for constant_name, expected_address, spec_section_id in RUNNER_CELL_CONSTANTS:
+        assert constant_name in constants, (
+            f"VBA constant {constant_name!r} is missing from {VBA_MODULE_PATH}. "
+            f"Update macro_spec.md section [{spec_section_id}] or restore the "
+            f"constant — they must agree."
+        )
+        actual_address = constants[constant_name]
+        assert actual_address == expected_address, (
+            f"VBA constant {constant_name} = {actual_address!r} but macro_spec.md "
+            f"section [{spec_section_id}] documents {expected_address!r}. "
+            f"Update either the constant or the spec section so they agree."
+        )
+
+
+def test_macro_spec_documents_each_runner_cell_constant() -> None:
+    """``MS-RUNNER-CELLS`` must mention each cell constant + address pair.
+
+    A failed assertion means a Runner-sheet cell constant exists in
+    ``RunnerLaunch.bas`` but is not documented in ``docs/macro_spec.md``. Add the
+    constant to the cell-layout table under section ``MS-RUNNER-CELLS``.
+    """
+
+    spec_text = _read_spec_text()
+    for constant_name, expected_address, spec_section_id in RUNNER_CELL_CONSTANTS:
+        assert constant_name in spec_text, (
+            f"macro_spec.md is missing reference to VBA constant {constant_name!r}. "
+            f"Add it to section [{spec_section_id}] in {MACRO_SPEC_PATH}."
+        )
+        assert f"`{expected_address}`" in spec_text, (
+            f"macro_spec.md does not mention cell address {expected_address!r}, "
+            f"which is bound to {constant_name!r} in {VBA_MODULE_PATH}. "
+            f"Update section [{spec_section_id}]."
+        )
+
+
+def test_every_public_click_handler_has_spec_section() -> None:
+    """Every ``*_Click`` macro in the source module must appear in ``macro_spec.md``.
+
+    Each handler must show up by name AND have its expected Spec ID present in the
+    spec doc. If a new click handler is added in ``RunnerLaunch.bas``, extend
+    ``EXPECTED_CLICK_HANDLERS`` here AND add a corresponding section to
+    ``docs/macro_spec.md`` with a fresh ``MS-*`` Spec ID.
+    """
+
+    module_source = _read_module_source()
+    spec_text = _read_spec_text()
+    handlers_in_source = _click_handlers(module_source)
+    expected_handler_names = {name for name, _ in EXPECTED_CLICK_HANDLERS}
+
+    extra_in_source = sorted(handlers_in_source - expected_handler_names)
+    assert not extra_in_source, (
+        "RunnerLaunch.bas exposes click handlers that the macro parity harness does "
+        "not know about: "
+        + ", ".join(extra_in_source)
+        + ". Add a Spec ID section to docs/macro_spec.md and extend "
+        "EXPECTED_CLICK_HANDLERS in tests/test_macro_spec_parity.py."
+    )
+
+    missing_in_source = sorted(expected_handler_names - handlers_in_source)
+    assert not missing_in_source, (
+        "Expected click handlers not found in RunnerLaunch.bas: "
+        + ", ".join(missing_in_source)
+        + ". Restore the handler or remove its section from docs/macro_spec.md."
+    )
+
+    for handler_name, spec_section_id in EXPECTED_CLICK_HANDLERS:
+        assert handler_name in spec_text, (
+            f"macro_spec.md does not document click handler {handler_name!r}. "
+            f"Add a section with Spec ID [{spec_section_id}]."
+        )
+        assert f"Spec ID: `{spec_section_id}`" in spec_text, (
+            f"macro_spec.md is missing Spec ID anchor [{spec_section_id}] for "
+            f"{handler_name!r}. Add a 'Spec ID: `{spec_section_id}`' line under the "
+            f"section heading so failed parity assertions can be cross-referenced."
+        )
+
+
+def test_macro_spec_lists_pipeline_input_fixtures_per_run_mode() -> None:
+    """Each ``MS-RUN-*`` spec section must name its concrete input-workbook fixture.
+
+    Acceptance criterion: ``docs/macro_spec.md`` maps every covered macro to its
+    fixture, affected ranges, and invariants. This test enforces the fixture
+    mapping for the three pipeline-invoking handlers; the per-macro ``Required
+    inputs`` block must mention the corresponding ``tests/fixtures/NISA Monthly *
+    - Raw.xlsx`` workbook.
+    """
+
+    spec_text = _read_spec_text()
+    expected_fixtures: tuple[tuple[str, str], ...] = (
+        ("MS-RUN-ALL", "tests/fixtures/NISA Monthly All Programs - Raw.xlsx"),
+        ("MS-RUN-EX-TREND", "tests/fixtures/NISA Monthly Ex Trend - Raw.xlsx"),
+        ("MS-RUN-TREND", "tests/fixtures/NISA Monthly Trend - Raw.xlsx"),
+    )
+    for spec_section_id, fixture_path in expected_fixtures:
+        assert spec_section_id in spec_text, (
+            f"Spec ID [{spec_section_id}] is missing from macro_spec.md; cannot "
+            f"verify fixture mapping for {fixture_path!r}."
+        )
+        assert fixture_path in spec_text, (
+            f"macro_spec.md section [{spec_section_id}] does not reference its "
+            f"required pipeline input fixture {fixture_path!r}. Add it to the "
+            f"'Fixture sources' list for that macro."
+        )
+
+
+def test_macro_spec_documents_macro_enabled_workbook_fixtures() -> None:
+    """Both macro-enabled workbook fixtures must be named in the spec scope.
+
+    These fixtures are the inventory source for ``assets/vba/*.bas`` and are
+    enforced by ``tests/test_vba_module_inventory.py``. Keeping them in the spec
+    means a maintainer who breaks inventory parity gets a pointer to both surfaces.
+    """
+
+    spec_text = _read_spec_text()
+    for workbook_path in ("Runner.xlsm", "assets/templates/counter_risk_template.xlsm"):
+        assert workbook_path in spec_text, (
+            f"macro_spec.md does not name macro-enabled workbook fixture "
+            f"{workbook_path!r}. Add it to the 'Scope' section so VBA inventory "
+            f"failures (test_vba_module_inventory.py) and macro parity failures "
+            f"share a single source of truth."
+        )

--- a/tests/test_vba_module_inventory.py
+++ b/tests/test_vba_module_inventory.py
@@ -23,38 +23,55 @@ def _extract_module_names(workbook_path: Path) -> set[str]:
 
 
 def test_assets_vba_directory_exists() -> None:
-    assert VBA_SOURCE_DIR.is_dir(), "Expected VBA source directory at assets/vba."
+    assert VBA_SOURCE_DIR.is_dir(), (
+        "Expected VBA source directory at assets/vba. "
+        "See docs/macro_spec.md section 'Scope' for the inventory contract."
+    )
 
 
 def test_vba_inventory_scope_is_explicit() -> None:
     """Define verification scope for VBA inventory parity checks."""
 
-    assert WORKBOOKS_WITH_VBA, "Scope must name at least one workbook with embedded VBA."
+    assert WORKBOOKS_WITH_VBA, (
+        "Scope must name at least one workbook with embedded VBA. "
+        "See docs/macro_spec.md section 'Scope'."
+    )
     for workbook_path in WORKBOOKS_WITH_VBA:
-        assert (
-            workbook_path.suffix.lower() == ".xlsm"
-        ), f"VBA inventory scope only includes macro-enabled workbook sources: {workbook_path}"
+        assert workbook_path.suffix.lower() == ".xlsm", (
+            f"VBA inventory scope only includes macro-enabled workbook sources: "
+            f"{workbook_path}. See docs/macro_spec.md section 'Scope'."
+        )
     assert MODULE_SOURCE_EXTENSION == ".bas", "VBA module sources must be stored as .bas files."
     for file_name in ALLOWED_NON_MODULE_FILES:
-        assert (
-            VBA_SOURCE_DIR / file_name
-        ).is_file(), (
-            f"Allowed non-module VBA artifact missing from scope: {VBA_SOURCE_DIR / file_name}"
+        assert (VBA_SOURCE_DIR / file_name).is_file(), (
+            f"Allowed non-module VBA artifact missing from scope: "
+            f"{VBA_SOURCE_DIR / file_name}. See docs/macro_spec.md section 'Scope'."
         )
 
 
 def test_all_embedded_vba_modules_have_bas_sources() -> None:
     discovered_modules: set[str] = set()
     for workbook_path in WORKBOOKS_WITH_VBA:
-        assert workbook_path.is_file(), f"Expected workbook fixture to exist: {workbook_path}"
+        assert workbook_path.is_file(), (
+            f"Expected workbook fixture to exist: {workbook_path}. "
+            "See docs/macro_spec.md section 'Scope' for the macro-enabled "
+            "workbook inventory."
+        )
         discovered_modules.update(_extract_module_names(workbook_path))
 
-    assert discovered_modules, "No VBA modules were discovered in workbook fixtures."
+    assert discovered_modules, (
+        "No VBA modules were discovered in workbook fixtures. "
+        "Re-run scripts/extract_vba_modules.py and update docs/macro_spec.md "
+        "section 'Scope' if the inventory has intentionally changed."
+    )
 
     bas_module_names = {path.stem for path in VBA_SOURCE_DIR.glob(f"*{MODULE_SOURCE_EXTENSION}")}
     missing_modules = sorted(discovered_modules - bas_module_names)
-    assert not missing_modules, "Missing VBA module source files in assets/vba: " + ", ".join(
-        f"{name}{MODULE_SOURCE_EXTENSION}" for name in missing_modules
+    assert not missing_modules, (
+        "Missing VBA module source files in assets/vba: "
+        + ", ".join(f"{name}{MODULE_SOURCE_EXTENSION}" for name in missing_modules)
+        + ". Run `python scripts/extract_vba_modules.py` to regenerate them, then "
+        "review docs/macro_spec.md to confirm the inventory change is intentional."
     )
 
     wrong_extension_files = sorted(
@@ -67,6 +84,7 @@ def test_all_embedded_vba_modules_have_bas_sources() -> None:
     assert not wrong_extension_files, (
         f"VBA modules must be committed with {MODULE_SOURCE_EXTENSION} extensions only: "
         + ", ".join(wrong_extension_files)
+        + ". See docs/macro_spec.md section 'Scope'."
     )
 
     unexpected_non_module_files = sorted(
@@ -76,15 +94,18 @@ def test_all_embedded_vba_modules_have_bas_sources() -> None:
         and path.stem not in discovered_modules
         and path.name not in ALLOWED_NON_MODULE_FILES
     )
-    assert (
-        not unexpected_non_module_files
-    ), "assets/vba contains files outside module inventory scope: " + ", ".join(
-        unexpected_non_module_files
+    assert not unexpected_non_module_files, (
+        "assets/vba contains files outside module inventory scope: "
+        + ", ".join(unexpected_non_module_files)
+        + ". Either remove them or extend ALLOWED_NON_MODULE_FILES "
+        "(and document the addition under docs/macro_spec.md section 'Scope')."
     )
 
     for module_name in sorted(discovered_modules):
         module_path = VBA_SOURCE_DIR / f"{module_name}{MODULE_SOURCE_EXTENSION}"
         source = module_path.read_text(encoding="utf-8")
-        assert (
-            f'Attribute VB_Name = "{module_name}"' in source
-        ), f"{module_path} does not declare the expected VB module name {module_name}."
+        assert f'Attribute VB_Name = "{module_name}"' in source, (
+            f"{module_path} does not declare the expected VB module name {module_name}. "
+            "Re-run scripts/extract_vba_modules.py to refresh, then update "
+            "docs/macro_spec.md if a module was renamed deliberately."
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:472 -->
> **Source:** Issue #472

Closes #472

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The existing VBA macros encode report requirements. A machine-readable macro parity harness lets agents replace or refactor macro behavior without guessing which workbook ranges, layout transformations, and plug-value rules matter.

#### Tasks
- [ ] Verify `assets/vba/*.bas` contains the VBA module sources extracted from macro-enabled workbook fixtures.
- [ ] Extend `docs/macro_spec.md` with each macro's purpose, required input sheets/columns, affected output ranges, invariants, and acceptable drift/tolerance.
- [ ] Add or update inventory tests that compare workbook embedded module names against committed `.bas` sources.
- [ ] Add spec tests for generated MOSERS-format outputs that check headers, required ranges, no blank numeric cells where values are required, and stable sheet naming.
- [ ] Add fixture documentation that names the workbook/template source used for each macro-equivalent spec check.
- [ ] Add clear failure messages that point from a failed spec test back to the macro/spec section it protects.

#### Acceptance criteria
- [ ] A maintainer can run the macro parity tests without Excel automation and see exactly which macro behaviors are covered.
- [ ] `docs/macro_spec.md` maps every covered macro to its fixture, affected ranges, and invariants.
- [ ] Tests fail if committed VBA sources drift from the workbook fixtures without an intentional spec update.
- [ ] Spec tests fail if Python-generated MOSERS-format outputs violate documented macro-equivalent structural or numeric invariants.
- [ ] Any tolerated cosmetic or rounding drift is explicitly documented rather than hidden in assertions.

<!-- auto-status-summary:end -->