### PR TITLE
feat: record repo cash source metadata in manifest (#474)

### DIFF
--- a/src/counter_risk/parsers/__init__.py
+++ b/src/counter_risk/parsers/__init__.py
@@ -13,6 +13,8 @@ from counter_risk.parsers.nisa import parse_nisa_all_programs
 from counter_risk.parsers.nisa_ex_trend import parse_nisa_ex_trend
 from counter_risk.parsers.nisa_trend import parse_nisa_trend
 from counter_risk.parsers.repo_cash_sources import (
+    find_duplicate_counterparty_names,
+    load_cash_by_counterparty,
     load_repo_cash_overrides_csv,
     load_repo_cash_structured_source,
 )
@@ -23,6 +25,8 @@ __all__ = [
     "parse_futures_detail",
     "parse_exposure_maturity_schedule",
     "parse_daily_holdings_pdf",
+    "find_duplicate_counterparty_names",
+    "load_cash_by_counterparty",
     "load_repo_cash_overrides_csv",
     "load_repo_cash_structured_source",
     "parse_nisa_all_programs",

--- a/src/counter_risk/parsers/repo_cash_sources.py
+++ b/src/counter_risk/parsers/repo_cash_sources.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import csv
 from collections.abc import Callable
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
 from counter_risk.normalize import normalize_counterparty
 

--- a/src/counter_risk/parsers/repo_cash_sources.py
+++ b/src/counter_risk/parsers/repo_cash_sources.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Callable
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from counter_risk.normalize import normalize_counterparty
 
@@ -63,6 +64,100 @@ def load_repo_cash_overrides_csv(path: Path | str) -> tuple[dict[str, float], li
             }
         )
     return overrides, audit_rows
+
+
+def load_cash_by_counterparty(
+    *,
+    source_type: Literal["csv", "xlsx", "pdf", "none"] | None,
+    source_path: Path | str | None,
+    overrides_path: Path | str | None = None,
+    pdf_parser: Callable[[Path], dict[str, float]] | None = None,
+) -> tuple[dict[str, float], list[dict[str, str]], str, list[str]]:
+    """Load repo cash indexed by canonical counterparty name.
+
+    Precedence (highest to lowest):
+    - Override file values are applied per-counterparty on top of the base source.
+    - Structured source (CSV/XLSX) or PDF parser provides the base values.
+
+    Returns a 4-tuple:
+      cash_by_counterparty   – final mapping after overrides are applied
+      override_audit_rows    – audit records for each applied override row
+      source_label           – description of the base source used (e.g. ``"csv:/path/file.csv"``)
+      duplicate_counterparty_names – canonical names that appeared >1 time in the base source
+    """
+    resolved_type = (source_type or "").strip().casefold()
+    resolved_source = Path(source_path) if source_path is not None else None
+
+    if resolved_type == "none" or resolved_source is None:
+        return {}, [], "none", []
+
+    effective_type = resolved_type
+    if effective_type not in {"pdf", "csv", "xlsx"}:
+        suffix = resolved_source.suffix.lower()
+        if suffix == ".csv":
+            effective_type = "csv"
+        elif suffix in {".xlsx", ".xlsm"}:
+            effective_type = "xlsx"
+        elif suffix == ".pdf":
+            effective_type = "pdf"
+        else:
+            raise ValueError(f"Cannot determine cash source type for '{resolved_source}'.")
+
+    duplicate_names: list[str] = []
+    if effective_type == "pdf":
+        if pdf_parser is None:
+            from counter_risk.parsers.daily_holdings_pdf import parse_daily_holdings_pdf
+
+            pdf_parser = parse_daily_holdings_pdf
+        repo_cash: dict[str, float] = pdf_parser(resolved_source)
+    else:
+        rows = (
+            _load_csv_rows(resolved_source)
+            if effective_type == "csv"
+            else _load_xlsx_rows(resolved_source)
+        )
+        duplicate_names = _find_duplicate_counterparty_names_in_rows(rows)
+        repo_cash = _rows_to_repo_cash_mapping(rows, path=resolved_source)
+
+    source_label = f"{effective_type}:{resolved_source}"
+    audit_rows: list[dict[str, str]] = []
+
+    if overrides_path is not None:
+        resolved_overrides = Path(overrides_path)
+        overrides, override_audit_rows = load_repo_cash_overrides_csv(resolved_overrides)
+        if overrides:
+            repo_cash.update(overrides)
+            audit_rows = override_audit_rows
+
+    return repo_cash, audit_rows, source_label, duplicate_names
+
+
+def find_duplicate_counterparty_names(
+    path: Path | str,
+    *,
+    source_type: Literal["csv", "xlsx"] | None = None,
+) -> list[str]:
+    """Return canonical counterparty names that appear more than once in a structured source file."""
+    source_path = Path(path)
+    resolved_type = _resolve_source_type(source_path, source_type)
+    rows = _load_csv_rows(source_path) if resolved_type == "csv" else _load_xlsx_rows(source_path)
+    return _find_duplicate_counterparty_names_in_rows(rows)
+
+
+def _find_duplicate_counterparty_names_in_rows(rows: list[dict[str, str]]) -> list[str]:
+    normalized_rows = [{_normalize_header(k): v for k, v in row.items()} for row in rows]
+    header_names = {k for row in normalized_rows for k in row}
+    counterparty_header = _first_matching_header(header_names, _COUNTERPARTY_HEADER_ALIASES)
+    if counterparty_header is None:
+        return []
+    seen: dict[str, int] = {}
+    for row in normalized_rows:
+        raw = str(row.get(counterparty_header, "")).strip()
+        if not raw:
+            continue
+        canonical = normalize_counterparty(raw)
+        seen[canonical] = seen.get(canonical, 0) + 1
+    return sorted(name for name, count in seen.items() if count > 1)
 
 
 def _resolve_source_type(

--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -55,6 +55,7 @@ class ManifestBuilder:
         concentration_metrics: list[dict[str, Any]] | None = None,
         risk_proxy_summary: dict[str, Any] | None = None,
         limit_breach_summary: dict[str, Any] | None = None,
+        repo_cash_summary: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         valid_ppt_statuses = {"success", "skipped", "failed"}
         if ppt_status not in valid_ppt_statuses:
@@ -130,6 +131,8 @@ class ManifestBuilder:
             manifest["risk_proxy_summary"] = risk_proxy_summary
         if limit_breach_summary is not None:
             manifest["limit_breach_summary"] = limit_breach_summary
+        if repo_cash_summary is not None:
+            manifest["repo_cash_summary"] = repo_cash_summary
         return manifest
 
     def write(self, *, run_dir: Path, manifest: dict[str, Any]) -> Path:

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -93,6 +93,69 @@ _DATA_QUALITY_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+_REPO_CASH_FINDING_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["code", "severity", "message"],
+    "properties": {
+        "code": {"type": "string", "minLength": 1},
+        "severity": _DATA_QUALITY_SEVERITY_SCHEMA,
+        "message": {"type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+_REPO_CASH_OVERRIDE_ROW_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["counterparty", "raw_counterparty", "cash_value", "note"],
+    "properties": {
+        "counterparty": {"type": "string", "minLength": 1},
+        "raw_counterparty": {"type": "string", "minLength": 1},
+        "cash_value": {"type": "string", "minLength": 1},
+        "note": {"type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+_REPO_CASH_SUMMARY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "source_type",
+        "source_path",
+        "skipped_reason",
+        "overrides_path",
+        "applied_override_count",
+        "raw_override_row_count",
+        "override_audit_rows",
+        "duplicate_counterparty_names",
+        "orphan_override_counterparties",
+        "counterparty_count",
+        "total_cash",
+        "required_counterparties",
+        "missing_required_counterparties",
+        "reconciliation_findings",
+        "fail_policy",
+    ],
+    "properties": {
+        "source_type": {"type": "string"},
+        "source_path": {"type": ["string", "null"]},
+        "skipped_reason": {"type": ["string", "null"]},
+        "overrides_path": {"type": ["string", "null"]},
+        "applied_override_count": {"type": "integer", "minimum": 0},
+        "raw_override_row_count": {"type": "integer", "minimum": 0},
+        "override_audit_rows": {"type": "array", "items": _REPO_CASH_OVERRIDE_ROW_SCHEMA},
+        "duplicate_counterparty_names": {"type": "array", "items": {"type": "string"}},
+        "orphan_override_counterparties": {"type": "array", "items": {"type": "string"}},
+        "counterparty_count": {"type": "integer", "minimum": 0},
+        "total_cash": {"type": "number"},
+        "required_counterparties": {"type": "array", "items": {"type": "string"}},
+        "missing_required_counterparties": {"type": "array", "items": {"type": "string"}},
+        "reconciliation_findings": {"type": "array", "items": _REPO_CASH_FINDING_SCHEMA},
+        "fail_policy": {"type": "string"},
+        "applied_to_totals": {"type": "boolean"},
+    },
+    "additionalProperties": False,
+}
+
 
 def manifest_schema() -> dict[str, Any]:
     """Return the run manifest schema used by pipeline validation."""
@@ -197,6 +260,7 @@ def manifest_schema() -> dict[str, Any]:
                 },
                 "additionalProperties": False,
             },
+            "repo_cash_summary": _REPO_CASH_SUMMARY_SCHEMA,
         },
         "additionalProperties": False,
     }

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -50,6 +50,7 @@ from counter_risk.outputs.registry import OutputGeneratorRegistry, OutputGenerat
 from counter_risk.parsers import parse_fcm_totals, parse_futures_detail
 from counter_risk.parsers.daily_holdings_pdf import parse_daily_holdings_pdf
 from counter_risk.parsers.repo_cash_sources import (
+    find_duplicate_counterparty_names,
     load_repo_cash_overrides_csv,
     load_repo_cash_structured_source,
 )
@@ -841,9 +842,12 @@ def _load_repo_cash_by_counterparty(
     summary: dict[str, Any] = {
         "source_type": source_type,
         "source_path": str(source_path) if source_path is not None else None,
+        "skipped_reason": None,
         "overrides_path": None,
         "applied_override_count": 0,
         "override_audit_rows": [],
+        "duplicate_counterparty_names": [],
+        "orphan_override_counterparties": [],
         "counterparty_count": 0,
         "total_cash": 0.0,
         "required_counterparties": [],
@@ -853,12 +857,35 @@ def _load_repo_cash_by_counterparty(
     }
 
     if source_type == "none" or source_path is None:
-        warnings.append("Repo Cash source is not configured (cash_source_type=none).")
+        skipped_reason = "Repo Cash source is not configured (cash_source_type=none)."
+        summary["skipped_reason"] = skipped_reason
+        warnings.append(skipped_reason)
         return {}, "none", summary
 
     if source_type == "pdf":
         repo_cash_by_counterparty = parse_daily_holdings_pdf(source_path)
     else:
+        duplicate_names = find_duplicate_counterparty_names(
+            source_path, source_type=cast(Literal["csv", "xlsx"], source_type)
+        )
+        if duplicate_names:
+            summary["duplicate_counterparty_names"] = duplicate_names
+            finding_message = (
+                "Repo Cash source has duplicate counterparty names after normalization: "
+                f"{', '.join(duplicate_names)}."
+            )
+            summary["reconciliation_findings"].append(
+                {
+                    "code": "duplicate_counterparty_names",
+                    "severity": "fail" if fail_policy == "strict" else "warn",
+                    "message": finding_message,
+                }
+            )
+            _handle_repo_cash_condition(
+                finding_message,
+                warnings=warnings,
+                fail_policy=fail_policy,
+            )
         repo_cash_by_counterparty = load_repo_cash_structured_source(
             source_path,
             source_type=cast(Literal["csv", "xlsx"], source_type),
@@ -873,8 +900,24 @@ def _load_repo_cash_by_counterparty(
     )
     if overrides_path is not None:
         summary["overrides_path"] = str(overrides_path)
+        base_counterparties = set(repo_cash_by_counterparty.keys())
         overrides, audit_rows = load_repo_cash_overrides_csv(overrides_path)
         if overrides:
+            orphan_overrides = sorted(k for k in overrides if k not in base_counterparties)
+            if orphan_overrides:
+                summary["orphan_override_counterparties"] = orphan_overrides
+                finding_message = (
+                    "Override file contains counterparties not found in base source: "
+                    f"{', '.join(orphan_overrides)}."
+                )
+                summary["reconciliation_findings"].append(
+                    {
+                        "code": "orphan_override_counterparties",
+                        "severity": "warn",
+                        "message": finding_message,
+                    }
+                )
+                warnings.append(finding_message)
             repo_cash_by_counterparty.update(overrides)
             summary["applied_override_count"] = len(audit_rows)
             summary["override_audit_rows"] = audit_rows

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -361,7 +361,7 @@ def run_pipeline(
             warnings=warnings,
         )
         parsed_by_variant = _parse_inputs(_resolve_input_paths(runtime_config))
-        _apply_daily_holdings_repo_cash(
+        repo_cash_summary = _apply_daily_holdings_repo_cash(
             config=runtime_config,
             parsed_by_variant=parsed_by_variant,
             warnings=warnings,
@@ -530,6 +530,7 @@ def run_pipeline(
             ),
             risk_proxy_summary=risk_proxy_summary,
             limit_breach_summary=limit_breach_summary,
+            repo_cash_summary=repo_cash_summary,
         )
         manifest_path = manifest_builder.write(run_dir=run_dir, manifest=manifest)
     except Exception as exc:
@@ -797,15 +798,16 @@ def _apply_daily_holdings_repo_cash(
     warnings: list[str],
     as_of_date: date | None = None,
     config_dir: Path | None = None,
-) -> None:
-    repo_cash_by_counterparty, source_label = _load_repo_cash_by_counterparty(
+) -> dict[str, Any]:
+    repo_cash_by_counterparty, source_label, summary = _load_repo_cash_by_counterparty(
         config=config,
         warnings=warnings,
         as_of_date=as_of_date,
         config_dir=config_dir,
     )
     if not repo_cash_by_counterparty:
-        return
+        summary["applied_to_totals"] = False
+        return summary
 
     all_programs_sections = parsed_by_variant.get("all_programs")
     if not isinstance(all_programs_sections, dict) or "totals" not in all_programs_sections:
@@ -822,6 +824,8 @@ def _apply_daily_holdings_repo_cash(
         "Applied Repo Cash values to all_programs totals "
         f"for {len(repo_cash_by_counterparty)} counterparties using {source_label}"
     )
+    summary["applied_to_totals"] = True
+    return summary
 
 
 def _load_repo_cash_by_counterparty(
@@ -830,14 +834,27 @@ def _load_repo_cash_by_counterparty(
     warnings: list[str],
     as_of_date: date | None,
     config_dir: Path | None = None,
-) -> tuple[dict[str, float], str]:
+) -> tuple[dict[str, float], str, dict[str, Any]]:
     fail_policy = config.reconciliation.fail_policy
     source_type, source_path = _resolve_repo_cash_source(config)
     source_label = source_type
+    summary: dict[str, Any] = {
+        "source_type": source_type,
+        "source_path": str(source_path) if source_path is not None else None,
+        "overrides_path": None,
+        "applied_override_count": 0,
+        "override_audit_rows": [],
+        "counterparty_count": 0,
+        "total_cash": 0.0,
+        "required_counterparties": [],
+        "missing_required_counterparties": [],
+        "reconciliation_findings": [],
+        "fail_policy": fail_policy,
+    }
 
     if source_type == "none" or source_path is None:
         warnings.append("Repo Cash source is not configured (cash_source_type=none).")
-        return {}, "none"
+        return {}, "none", summary
 
     if source_type == "pdf":
         repo_cash_by_counterparty = parse_daily_holdings_pdf(source_path)
@@ -855,9 +872,12 @@ def _load_repo_cash_by_counterparty(
         config_dir=config_dir,
     )
     if overrides_path is not None:
+        summary["overrides_path"] = str(overrides_path)
         overrides, audit_rows = load_repo_cash_overrides_csv(overrides_path)
         if overrides:
             repo_cash_by_counterparty.update(overrides)
+            summary["applied_override_count"] = len(audit_rows)
+            summary["override_audit_rows"] = audit_rows
             warnings.append(
                 "Repo Cash overrides applied from "
                 f"{overrides_path} ({len(audit_rows)} override rows)"
@@ -873,40 +893,86 @@ def _load_repo_cash_by_counterparty(
         },
         key=str.casefold,
     )
+    summary["required_counterparties"] = list(required_counterparties)
     missing_required = [
         counterparty
         for counterparty in required_counterparties
         if counterparty not in repo_cash_by_counterparty
     ]
+    summary["missing_required_counterparties"] = list(missing_required)
     if missing_required:
-        _handle_repo_cash_condition(
+        finding_message = (
             "Repo Cash source is missing required counterparties: "
-            f"{', '.join(missing_required)}.",
+            f"{', '.join(missing_required)}."
+        )
+        summary["reconciliation_findings"].append(
+            {
+                "code": "missing_required_counterparties",
+                "severity": "fail" if fail_policy == "strict" else "warn",
+                "message": finding_message,
+            }
+        )
+        _handle_repo_cash_condition(
+            finding_message,
             warnings=warnings,
             fail_policy=fail_policy,
         )
 
     total_cash = sum(repo_cash_by_counterparty.values())
+    summary["total_cash"] = float(total_cash)
+    summary["counterparty_count"] = len(repo_cash_by_counterparty)
     if config.cash_total_min is not None and total_cash < config.cash_total_min:
+        finding_message = (
+            f"Repo Cash total {total_cash:.2f} is below configured minimum "
+            f"{config.cash_total_min:.2f}."
+        )
+        summary["reconciliation_findings"].append(
+            {
+                "code": "cash_total_below_minimum",
+                "severity": "fail" if fail_policy == "strict" else "warn",
+                "message": finding_message,
+            }
+        )
         _handle_repo_cash_condition(
-            f"Repo Cash total {total_cash:.2f} is below configured minimum {config.cash_total_min:.2f}.",
+            finding_message,
             warnings=warnings,
             fail_policy=fail_policy,
         )
     if config.cash_total_max is not None and total_cash > config.cash_total_max:
+        finding_message = (
+            f"Repo Cash total {total_cash:.2f} exceeds configured maximum "
+            f"{config.cash_total_max:.2f}."
+        )
+        summary["reconciliation_findings"].append(
+            {
+                "code": "cash_total_above_maximum",
+                "severity": "fail" if fail_policy == "strict" else "warn",
+                "message": finding_message,
+            }
+        )
         _handle_repo_cash_condition(
-            f"Repo Cash total {total_cash:.2f} exceeds configured maximum {config.cash_total_max:.2f}.",
+            finding_message,
             warnings=warnings,
             fail_policy=fail_policy,
         )
 
     if not repo_cash_by_counterparty:
+        finding_message = (
+            f"Repo Cash source '{source_label}' did not yield any counterparty values."
+        )
+        summary["reconciliation_findings"].append(
+            {
+                "code": "empty_cash_source",
+                "severity": "fail" if fail_policy == "strict" else "warn",
+                "message": finding_message,
+            }
+        )
         _handle_repo_cash_condition(
-            f"Repo Cash source '{source_label}' did not yield any counterparty values.",
+            finding_message,
             warnings=warnings,
             fail_policy=fail_policy,
         )
-    return repo_cash_by_counterparty, source_label
+    return repo_cash_by_counterparty, source_label, summary
 
 
 def _resolve_repo_cash_source(config: WorkflowConfig) -> tuple[str, Path | None]:

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -845,6 +845,7 @@ def _load_repo_cash_by_counterparty(
         "skipped_reason": None,
         "overrides_path": None,
         "applied_override_count": 0,
+        "raw_override_row_count": 0,
         "override_audit_rows": [],
         "duplicate_counterparty_names": [],
         "orphan_override_counterparties": [],
@@ -919,7 +920,8 @@ def _load_repo_cash_by_counterparty(
                 )
                 warnings.append(finding_message)
             repo_cash_by_counterparty.update(overrides)
-            summary["applied_override_count"] = len(audit_rows)
+            summary["applied_override_count"] = len(overrides)
+            summary["raw_override_row_count"] = len(audit_rows)
             summary["override_audit_rows"] = audit_rows
             warnings.append(
                 "Repo Cash overrides applied from "

--- a/tests/parsers/test_repo_cash_sources.py
+++ b/tests/parsers/test_repo_cash_sources.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 
 from counter_risk.parsers.repo_cash_sources import (
+    find_duplicate_counterparty_names,
+    load_cash_by_counterparty,
     load_repo_cash_overrides_csv,
     load_repo_cash_structured_source,
 )
@@ -78,3 +80,188 @@ def test_load_repo_cash_structured_source_raises_for_source_type_extension_misma
 
     with pytest.raises(ValueError, match="cash_source_type=csv requires a .csv file path"):
         load_repo_cash_structured_source(source_path, source_type="csv")
+
+
+# ---------------------------------------------------------------------------
+# load_cash_by_counterparty tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_cash_by_counterparty_from_csv(tmp_path: Path) -> None:
+    source_path = tmp_path / "repo_cash.csv"
+    source_path.write_text(
+        "counterparty,cash_value\nCIBC,5.0\nASL,2.5\n",
+        encoding="utf-8",
+    )
+
+    cash, audit_rows, source_label, duplicates = load_cash_by_counterparty(
+        source_type="csv",
+        source_path=source_path,
+    )
+
+    assert cash["CIBC"] == 5.0
+    assert cash["ASL"] == 2.5
+    assert audit_rows == []
+    assert "csv:" in source_label
+    assert duplicates == []
+
+
+def test_load_cash_by_counterparty_from_xlsx(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+    source_path = tmp_path / "repo_cash.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.append(["counterparty", "cash_value"])
+    sheet.append(["CIBC", 7.0])
+    sheet.append(["ASL", 1.5])
+    workbook.save(source_path)
+
+    cash, audit_rows, source_label, duplicates = load_cash_by_counterparty(
+        source_type="xlsx",
+        source_path=source_path,
+    )
+
+    assert cash["CIBC"] == 7.0
+    assert cash["ASL"] == 1.5
+    assert audit_rows == []
+    assert "xlsx:" in source_label
+    assert duplicates == []
+
+
+def test_load_cash_by_counterparty_with_pdf_parser_callable(tmp_path: Path) -> None:
+    fake_pdf = tmp_path / "holdings.pdf"
+    fake_pdf.write_bytes(b"%PDF-1.4 fixture")
+
+    def _fake_parser(path: Path) -> dict[str, float]:
+        return {"CIBC": 9.0, "Daiwa": 3.0}
+
+    cash, audit_rows, source_label, duplicates = load_cash_by_counterparty(
+        source_type="pdf",
+        source_path=fake_pdf,
+        pdf_parser=_fake_parser,
+    )
+
+    assert cash["CIBC"] == 9.0
+    assert cash["Daiwa"] == 3.0
+    assert audit_rows == []
+    assert "pdf:" in source_label
+    assert duplicates == []
+
+
+def test_load_cash_by_counterparty_override_precedence(tmp_path: Path) -> None:
+    source_path = tmp_path / "repo_cash.csv"
+    source_path.write_text(
+        "counterparty,cash_value\nCIBC,5.0\nASL,2.5\n",
+        encoding="utf-8",
+    )
+    overrides_path = tmp_path / "cash_overrides_2025-12-31.csv"
+    overrides_path.write_text(
+        "counterparty,cash_value,note\nCIBC,99.0,desk correction\n",
+        encoding="utf-8",
+    )
+
+    cash, audit_rows, source_label, duplicates = load_cash_by_counterparty(
+        source_type="csv",
+        source_path=source_path,
+        overrides_path=overrides_path,
+    )
+
+    assert cash["CIBC"] == 99.0, "Override should take precedence over source"
+    assert cash["ASL"] == 2.5, "Non-overridden source value should be preserved"
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["counterparty"] == "CIBC"
+    assert audit_rows[0]["note"] == "desk correction"
+
+
+def test_load_cash_by_counterparty_none_source_returns_empty(tmp_path: Path) -> None:
+    cash, audit_rows, source_label, duplicates = load_cash_by_counterparty(
+        source_type="none",
+        source_path=None,
+    )
+
+    assert cash == {}
+    assert audit_rows == []
+    assert source_label == "none"
+    assert duplicates == []
+
+
+def test_load_cash_by_counterparty_none_source_type_with_no_path_returns_empty() -> None:
+    cash, audit_rows, source_label, duplicates = load_cash_by_counterparty(
+        source_type=None,
+        source_path=None,
+    )
+
+    assert cash == {}
+    assert source_label == "none"
+
+
+def test_load_cash_by_counterparty_invalid_override_schema_raises(tmp_path: Path) -> None:
+    source_path = tmp_path / "repo_cash.csv"
+    source_path.write_text("counterparty,cash_value\nCIBC,5.0\n", encoding="utf-8")
+    bad_overrides = tmp_path / "bad_overrides.csv"
+    bad_overrides.write_text("name,amount\nCIBC,9.0\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        load_cash_by_counterparty(
+            source_type="csv",
+            source_path=source_path,
+            overrides_path=bad_overrides,
+        )
+
+
+def test_load_cash_by_counterparty_detects_duplicate_names(tmp_path: Path) -> None:
+    source_path = tmp_path / "repo_cash.csv"
+    source_path.write_text(
+        "counterparty,cash_value\nCIBC,5.0\nCIBC,3.0\nASL,2.5\n",
+        encoding="utf-8",
+    )
+
+    cash, _audit_rows, _label, duplicates = load_cash_by_counterparty(
+        source_type="csv",
+        source_path=source_path,
+    )
+
+    assert "CIBC" in duplicates
+    assert cash["CIBC"] == 3.0, "Last value wins on duplicate"
+
+
+def test_load_cash_by_counterparty_auto_detects_csv_extension(tmp_path: Path) -> None:
+    source_path = tmp_path / "repo_cash.csv"
+    source_path.write_text("counterparty,cash_value\nCIBC,4.0\n", encoding="utf-8")
+
+    cash, _audit_rows, source_label, _dupes = load_cash_by_counterparty(
+        source_type=None,
+        source_path=source_path,
+    )
+
+    assert cash["CIBC"] == 4.0
+    assert source_label.startswith("csv:")
+
+
+# ---------------------------------------------------------------------------
+# find_duplicate_counterparty_names tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_duplicate_counterparty_names_returns_duplicates(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.csv"
+    source_path.write_text(
+        "counterparty,cash_value\nCIBC,1.0\nASL,2.0\nCIBC,3.0\n",
+        encoding="utf-8",
+    )
+
+    duplicates = find_duplicate_counterparty_names(source_path)
+
+    assert duplicates == ["CIBC"]
+
+
+def test_find_duplicate_counterparty_names_empty_when_no_duplicates(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.csv"
+    source_path.write_text(
+        "counterparty,cash_value\nCIBC,1.0\nASL,2.0\n",
+        encoding="utf-8",
+    )
+
+    duplicates = find_duplicate_counterparty_names(source_path)
+
+    assert duplicates == []

--- a/tests/pipeline/test_manifest_schema.py
+++ b/tests/pipeline/test_manifest_schema.py
@@ -58,6 +58,44 @@ def test_manifest_schema_defines_limit_breach_summary_shape() -> None:
     assert summary["properties"]["warning_banner"]["type"] == ["string", "null"]
 
 
+def test_manifest_schema_defines_repo_cash_summary_shape() -> None:
+    schema = manifest_schema()
+
+    summary = schema["properties"]["repo_cash_summary"]
+    assert "repo_cash_summary" not in schema["required"]
+    assert summary["required"] == [
+        "source_type",
+        "source_path",
+        "skipped_reason",
+        "overrides_path",
+        "applied_override_count",
+        "raw_override_row_count",
+        "override_audit_rows",
+        "duplicate_counterparty_names",
+        "orphan_override_counterparties",
+        "counterparty_count",
+        "total_cash",
+        "required_counterparties",
+        "missing_required_counterparties",
+        "reconciliation_findings",
+        "fail_policy",
+    ]
+    assert summary["properties"]["source_path"]["type"] == ["string", "null"]
+    assert summary["properties"]["applied_override_count"]["type"] == "integer"
+    assert summary["properties"]["raw_override_row_count"]["type"] == "integer"
+    assert summary["properties"]["override_audit_rows"]["items"]["required"] == [
+        "counterparty",
+        "raw_counterparty",
+        "cash_value",
+        "note",
+    ]
+    assert summary["properties"]["reconciliation_findings"]["items"]["required"] == [
+        "code",
+        "severity",
+        "message",
+    ]
+
+
 def test_manifest_schema_defines_data_quality_shape() -> None:
     schema = manifest_schema()
 

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -332,6 +332,44 @@ def test_apply_daily_holdings_repo_cash_applies_overrides_from_default_file(
     assert any(str(overrides_path) in warning for warning in warnings)
 
 
+def test_apply_daily_holdings_repo_cash_counts_distinct_applied_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    overrides_path = tmp_path / "cash_overrides_2025-12-31.csv"
+    overrides_path.write_text(
+        "\n".join(
+                [
+                    "counterparty,cash_value,note",
+                    "CIBC,8.0,initial correction",
+                    "CIBC,9.0,latest correction",
+                ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = _minimal_workflow_config(tmp_path).model_copy(
+        update={"daily_holdings_pdf": tmp_path / "daily-holdings.pdf"}
+    )
+    parsed_by_variant = _minimal_parsed_by_variant()
+    warnings: list[str] = []
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run_module, "parse_daily_holdings_pdf", lambda _: {"CIBC": 2.0})
+
+    summary = run_module._apply_daily_holdings_repo_cash(
+        config=config,
+        parsed_by_variant=parsed_by_variant,
+        warnings=warnings,
+        as_of_date=date(2025, 12, 31),
+    )
+
+    totals_records = parsed_by_variant["all_programs"]["totals"].to_dict(orient="records")
+    by_counterparty = {row["counterparty"]: row for row in totals_records}
+    assert float(by_counterparty["CIBC"]["Cash"]) == pytest.approx(9.0)
+    assert summary["applied_override_count"] == 1
+    assert summary["raw_override_row_count"] == 2
+
+
 def test_apply_daily_holdings_repo_cash_resolves_default_overrides_from_config_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -484,6 +484,136 @@ def test_daily_holdings_repo_cash_flows_into_all_programs_dropin_output(
     assert float(by_counterparty["ASL"]["Notional"]) == pytest.approx(3.0)
 
 
+def test_load_repo_cash_warns_when_total_below_minimum(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _minimal_workflow_config(tmp_path).model_copy(
+        update={
+            "daily_holdings_pdf": tmp_path / "daily-holdings.pdf",
+            "cash_total_min": 100.0,
+        }
+    )
+    parsed_by_variant = _minimal_parsed_by_variant()
+    warnings: list[str] = []
+
+    monkeypatch.setattr(run_module, "parse_daily_holdings_pdf", lambda _: {"CIBC": 2.0})
+
+    summary = run_module._apply_daily_holdings_repo_cash(
+        config=config,
+        parsed_by_variant=parsed_by_variant,
+        warnings=warnings,
+    )
+
+    assert any("below configured minimum" in w for w in warnings)
+    findings = summary.get("reconciliation_findings", [])
+    assert any(f.get("code") == "cash_total_below_minimum" for f in findings)
+    assert all(
+        f.get("severity") == "warn" for f in findings if f.get("code") == "cash_total_below_minimum"
+    )
+
+
+def test_load_repo_cash_strict_raises_when_total_above_maximum(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _minimal_workflow_config(tmp_path, fail_policy="strict").model_copy(
+        update={
+            "daily_holdings_pdf": tmp_path / "daily-holdings.pdf",
+            "cash_total_max": 1.0,
+        }
+    )
+    parsed_by_variant = _minimal_parsed_by_variant()
+    warnings: list[str] = []
+
+    monkeypatch.setattr(run_module, "parse_daily_holdings_pdf", lambda _: {"CIBC": 99.0})
+
+    with pytest.raises(ValueError, match="exceeds configured maximum"):
+        run_module._apply_daily_holdings_repo_cash(
+            config=config,
+            parsed_by_variant=parsed_by_variant,
+            warnings=warnings,
+        )
+
+
+def test_load_repo_cash_warns_for_duplicate_counterparty_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    structured_source = tmp_path / "repo_cash.csv"
+    structured_source.write_text(
+        "counterparty,cash_value\nCIBC,5.0\nCIBC,3.0\nASL,2.0\n",
+        encoding="utf-8",
+    )
+    config = _minimal_workflow_config(tmp_path).model_copy(
+        update={"cash_source_type": "csv", "cash_source_path": structured_source}
+    )
+    parsed_by_variant = _minimal_parsed_by_variant()
+    warnings: list[str] = []
+
+    summary = run_module._apply_daily_holdings_repo_cash(
+        config=config,
+        parsed_by_variant=parsed_by_variant,
+        warnings=warnings,
+    )
+
+    assert any("duplicate counterparty names" in w for w in warnings)
+    findings = summary.get("reconciliation_findings", [])
+    assert any(f.get("code") == "duplicate_counterparty_names" for f in findings)
+    assert summary.get("duplicate_counterparty_names") == ["CIBC"]
+
+
+def test_load_repo_cash_warns_for_orphan_override_counterparties(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    structured_source = tmp_path / "repo_cash.csv"
+    structured_source.write_text(
+        "counterparty,cash_value\nCIBC,5.0\n",
+        encoding="utf-8",
+    )
+    overrides_path = tmp_path / "cash_overrides_2025-12-31.csv"
+    overrides_path.write_text(
+        "counterparty,cash_value,note\nUnknownBank,99.0,stale override\n",
+        encoding="utf-8",
+    )
+    config = _minimal_workflow_config(tmp_path).model_copy(
+        update={
+            "cash_source_type": "csv",
+            "cash_source_path": structured_source,
+            "cash_overrides_csv": overrides_path,
+        }
+    )
+    parsed_by_variant = _minimal_parsed_by_variant()
+    warnings: list[str] = []
+
+    summary = run_module._apply_daily_holdings_repo_cash(
+        config=config,
+        parsed_by_variant=parsed_by_variant,
+        warnings=warnings,
+    )
+
+    assert any("not found in base source" in w for w in warnings)
+    findings = summary.get("reconciliation_findings", [])
+    assert any(f.get("code") == "orphan_override_counterparties" for f in findings)
+    assert "UnknownBank" in summary.get("orphan_override_counterparties", [])
+
+
+def test_load_repo_cash_summary_includes_skipped_reason_when_no_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _minimal_workflow_config(tmp_path).model_copy(
+        update={"daily_holdings_pdf": None, "cash_source_type": "none"}
+    )
+    parsed_by_variant = _minimal_parsed_by_variant()
+    warnings: list[str] = []
+
+    summary = run_module._apply_daily_holdings_repo_cash(
+        config=config,
+        parsed_by_variant=parsed_by_variant,
+        warnings=warnings,
+    )
+
+    assert summary.get("skipped_reason") is not None
+    assert "none" in str(summary["skipped_reason"]).lower()
+
+
 def test_build_missing_inputs_summary_complete_with_single_optional_gap(tmp_path: Path) -> None:
     config = _minimal_workflow_config(tmp_path)
     input_paths = run_module._resolve_input_paths(config)

--- a/tests/test_manifest_paths.py
+++ b/tests/test_manifest_paths.py
@@ -99,6 +99,85 @@ def test_manifest_build_rejects_nonexistent_artifact_paths(tmp_path: Path) -> No
         )
 
 
+def test_manifest_includes_repo_cash_summary_when_provided(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    workbook_path = run_dir / "Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx"
+    workbook_path.write_bytes(b"hist")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    repo_cash_summary = {
+        "source_type": "csv",
+        "source_path": "inputs/repo_cash_2026-02-13.csv",
+        "overrides_path": "inputs/cash_overrides_2026-02-13.csv",
+        "applied_override_count": 2,
+        "override_audit_rows": [
+            {
+                "counterparty": "ACME",
+                "raw_counterparty": "ACME Bank",
+                "cash_value": "1000.0",
+                "note": "year-end true-up",
+            }
+        ],
+        "counterparty_count": 5,
+        "total_cash": 12345.67,
+        "required_counterparties": ["ACME", "BARCLAYS"],
+        "missing_required_counterparties": [],
+        "reconciliation_findings": [],
+        "fail_policy": "warn",
+        "applied_to_totals": True,
+    }
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(workbook_path.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+        repo_cash_summary=repo_cash_summary,
+    )
+    manifest_path = builder.write(run_dir=run_dir, manifest=manifest)
+
+    parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert "repo_cash_summary" in parsed
+    summary = parsed["repo_cash_summary"]
+    assert summary["source_type"] == "csv"
+    assert summary["source_path"] == "inputs/repo_cash_2026-02-13.csv"
+    assert summary["applied_override_count"] == 2
+    assert summary["override_audit_rows"][0]["counterparty"] == "ACME"
+    assert summary["counterparty_count"] == 5
+    assert summary["total_cash"] == pytest.approx(12345.67)
+    assert summary["fail_policy"] == "warn"
+    assert summary["applied_to_totals"] is True
+
+
+def test_manifest_omits_repo_cash_summary_when_not_provided(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    workbook_path = run_dir / "Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx"
+    workbook_path.write_bytes(b"hist")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(workbook_path.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+    )
+
+    assert "repo_cash_summary" not in manifest
+
+
 def test_manifest_warnings_are_normalized_to_strings(tmp_path: Path) -> None:
     run_dir = tmp_path / "runs" / "2026-02-13"
     run_dir.mkdir(parents=True)

--- a/tests/test_manifest_paths.py
+++ b/tests/test_manifest_paths.py
@@ -115,6 +115,7 @@ def test_manifest_includes_repo_cash_summary_when_provided(tmp_path: Path) -> No
         "source_path": "inputs/repo_cash_2026-02-13.csv",
         "overrides_path": "inputs/cash_overrides_2026-02-13.csv",
         "applied_override_count": 2,
+        "raw_override_row_count": 2,
         "override_audit_rows": [
             {
                 "counterparty": "ACME",
@@ -148,6 +149,7 @@ def test_manifest_includes_repo_cash_summary_when_provided(tmp_path: Path) -> No
     assert summary["source_type"] == "csv"
     assert summary["source_path"] == "inputs/repo_cash_2026-02-13.csv"
     assert summary["applied_override_count"] == 2
+    assert summary["raw_override_row_count"] == 2
     assert summary["override_audit_rows"][0]["counterparty"] == "ACME"
     assert summary["counterparty_count"] == 5
     assert summary["total_cash"] == pytest.approx(12345.67)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:474 -->
> **Source:** Issue #474

Closes #474

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Cash values parsed from PDFs are brittle and easy to override informally. The pipeline needs a structured source preference, an auditable manual override path, and reconciliation checks so repo cash is either filled, warned, or failed intentionally.

#### Tasks
- [x] Add config fields for `cash_source_type`, `cash_source_path`, structured discovery roots, and optional override file in `src/counter_risk/config.py` or existing config models.
- [x] Implement `load_cash_by_counterparty()` in `src/counter_risk/parsers/repo_cash_sources.py` with precedence: override file, structured source, PDF parser.
- [x] Define and validate `cash_overrides_<as_of_date>.csv` with `counterparty`, `cash_value`, and `note` columns.
- [x] Apply shared name canonicalization and registry lookup when joining cash rows to counterparties.
- [x] Add reconciliation checks for total cash range, required counterparties, duplicate names, and override coverage.
- [x] Record cash source type, source path, override rows, reconciliation findings, and skipped/fallback reasons in `manifest.json`.
- [x] Add tests with synthetic CSV/XLSX, synthetic PDF or parser fixture, valid overrides, invalid override schema, missing required counterparty, and out-of-range totals.

#### Acceptance criteria
- [x] Pipeline cash resolution follows the documented precedence order and records which source won.
- [x] Repo cash is never silently omitted; missing or suspicious cash values produce configured warnings or failures.
- [x] Manual overrides appear in `manifest.json` with file reference, counterparty, value, and note.
- [x] Invalid override files fail before downstream calculations consume them.
- [x] Tests cover structured source, PDF fallback, override precedence, reconciliation warning, and reconciliation failure behavior.

<!-- auto-status-summary:end -->