### PR TITLE
Issue #474: Harden repo cash ingestion

### DIFF
--- a/src/counter_risk/parsers/repo_cash_sources.py
+++ b/src/counter_risk/parsers/repo_cash_sources.py
@@ -10,7 +10,7 @@ from counter_risk.normalize import normalize_counterparty
 
 _COUNTERPARTY_HEADER_ALIASES = ("counterparty", "counterparty_name", "name")
 _CASH_HEADER_ALIASES = ("cash_value", "cash", "repo_cash")
-_OVERRIDES_REQUIRED_HEADERS = ("counterparty", "cash_value")
+_OVERRIDES_REQUIRED_HEADERS = ("counterparty", "cash_value", "note")
 
 
 def load_repo_cash_structured_source(
@@ -53,6 +53,12 @@ def load_repo_cash_overrides_csv(path: Path | str) -> tuple[dict[str, float], li
             continue
         cash_value = _coerce_cash_value(raw_cash_value, path=overrides_path, row_index=row_index)
         canonical_counterparty = normalize_counterparty(raw_counterparty)
+        if canonical_counterparty in overrides:
+            raise ValueError(
+                "Overrides file "
+                f"'{overrides_path}' contains duplicate counterparty "
+                f"{canonical_counterparty!r} at row {row_index}."
+            )
         overrides[canonical_counterparty] = cash_value
         audit_rows.append(
             {
@@ -159,6 +165,11 @@ def _rows_to_repo_cash_mapping(rows: list[dict[str, str]], *, path: Path) -> dic
         if not raw_cash:
             continue
         canonical_counterparty = normalize_counterparty(raw_counterparty)
+        if canonical_counterparty in mapping:
+            raise ValueError(
+                f"Structured cash source '{path}' contains duplicate counterparty "
+                f"{canonical_counterparty!r} at row {row_index}."
+            )
         mapping[canonical_counterparty] = _coerce_cash_value(
             raw_cash, path=path, row_index=row_index
         )

--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -54,6 +54,7 @@ class ManifestBuilder:
         ppt_outputs: dict[str, dict[str, str]] | None = None,
         concentration_metrics: list[dict[str, Any]] | None = None,
         limit_breach_summary: dict[str, Any] | None = None,
+        repo_cash_resolution: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         valid_ppt_statuses = {"success", "skipped", "failed"}
         if ppt_status not in valid_ppt_statuses:
@@ -127,6 +128,8 @@ class ManifestBuilder:
             manifest["concentration_metrics"] = concentration_metrics
         if limit_breach_summary is not None:
             manifest["limit_breach_summary"] = limit_breach_summary
+        if repo_cash_resolution is not None:
+            manifest["repo_cash_resolution"] = repo_cash_resolution
         return manifest
 
     def write(self, *, run_dir: Path, manifest: dict[str, Any]) -> Path:

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -361,7 +361,7 @@ def run_pipeline(
             warnings=warnings,
         )
         parsed_by_variant = _parse_inputs(_resolve_input_paths(runtime_config))
-        _apply_daily_holdings_repo_cash(
+        repo_cash_resolution = _apply_daily_holdings_repo_cash(
             config=runtime_config,
             parsed_by_variant=parsed_by_variant,
             warnings=warnings,
@@ -524,6 +524,7 @@ def run_pipeline(
                 concentration_metrics_records if concentration_metrics_records else None
             ),
             limit_breach_summary=limit_breach_summary,
+            repo_cash_resolution=repo_cash_resolution,
         )
         manifest_path = manifest_builder.write(run_dir=run_dir, manifest=manifest)
     except Exception as exc:
@@ -791,15 +792,15 @@ def _apply_daily_holdings_repo_cash(
     warnings: list[str],
     as_of_date: date | None = None,
     config_dir: Path | None = None,
-) -> None:
-    repo_cash_by_counterparty, source_label = _load_repo_cash_by_counterparty(
+) -> dict[str, Any]:
+    repo_cash_by_counterparty, source_label, audit = _load_repo_cash_by_counterparty(
         config=config,
         warnings=warnings,
         as_of_date=as_of_date,
         config_dir=config_dir,
     )
     if not repo_cash_by_counterparty:
-        return
+        return audit
 
     all_programs_sections = parsed_by_variant.get("all_programs")
     if not isinstance(all_programs_sections, dict) or "totals" not in all_programs_sections:
@@ -816,6 +817,10 @@ def _apply_daily_holdings_repo_cash(
         "Applied Repo Cash values to all_programs totals "
         f"for {len(repo_cash_by_counterparty)} counterparties using {source_label}"
     )
+    audit["applied_to_variant"] = "all_programs"
+    audit["counterparty_count"] = len(repo_cash_by_counterparty)
+    audit["total_cash"] = sum(repo_cash_by_counterparty.values())
+    return audit
 
 
 def _load_repo_cash_by_counterparty(
@@ -824,14 +829,24 @@ def _load_repo_cash_by_counterparty(
     warnings: list[str],
     as_of_date: date | None,
     config_dir: Path | None = None,
-) -> tuple[dict[str, float], str]:
+) -> tuple[dict[str, float], str, dict[str, Any]]:
     fail_policy = config.reconciliation.fail_policy
     source_type, source_path = _resolve_repo_cash_source(config)
     source_label = source_type
+    audit: dict[str, Any] = {
+        "source_type": source_type,
+        "source_path": str(source_path) if source_path is not None else None,
+        "override_path": None,
+        "override_rows": [],
+        "checks": [],
+        "counterparty_count": 0,
+        "total_cash": 0.0,
+    }
 
     if source_type == "none" or source_path is None:
         warnings.append("Repo Cash source is not configured (cash_source_type=none).")
-        return {}, "none"
+        audit["status"] = "not_configured"
+        return {}, "none", audit
 
     if source_type == "pdf":
         repo_cash_by_counterparty = parse_daily_holdings_pdf(source_path)
@@ -841,6 +856,8 @@ def _load_repo_cash_by_counterparty(
             source_type=cast(Literal["csv", "xlsx"], source_type),
         )
     source_label = f"{source_type}:{source_path}"
+    audit["status"] = "loaded"
+    audit["source_label"] = source_label
     warnings.append(f"Repo Cash source used: {source_label}")
 
     overrides_path = _resolve_repo_cash_overrides_path(
@@ -850,6 +867,8 @@ def _load_repo_cash_by_counterparty(
     )
     if overrides_path is not None:
         overrides, audit_rows = load_repo_cash_overrides_csv(overrides_path)
+        audit["override_path"] = str(overrides_path)
+        audit["override_rows"] = audit_rows
         if overrides:
             repo_cash_by_counterparty.update(overrides)
             warnings.append(
@@ -873,6 +892,13 @@ def _load_repo_cash_by_counterparty(
         if counterparty not in repo_cash_by_counterparty
     ]
     if missing_required:
+        audit["checks"].append(
+            {
+                "name": "required_counterparties",
+                "status": "fail" if fail_policy == "strict" else "warn",
+                "missing": missing_required,
+            }
+        )
         _handle_repo_cash_condition(
             "Repo Cash source is missing required counterparties: "
             f"{', '.join(missing_required)}.",
@@ -881,13 +907,31 @@ def _load_repo_cash_by_counterparty(
         )
 
     total_cash = sum(repo_cash_by_counterparty.values())
+    audit["counterparty_count"] = len(repo_cash_by_counterparty)
+    audit["total_cash"] = total_cash
     if config.cash_total_min is not None and total_cash < config.cash_total_min:
+        audit["checks"].append(
+            {
+                "name": "cash_total_min",
+                "status": "fail" if fail_policy == "strict" else "warn",
+                "actual": total_cash,
+                "expected_min": config.cash_total_min,
+            }
+        )
         _handle_repo_cash_condition(
             f"Repo Cash total {total_cash:.2f} is below configured minimum {config.cash_total_min:.2f}.",
             warnings=warnings,
             fail_policy=fail_policy,
         )
     if config.cash_total_max is not None and total_cash > config.cash_total_max:
+        audit["checks"].append(
+            {
+                "name": "cash_total_max",
+                "status": "fail" if fail_policy == "strict" else "warn",
+                "actual": total_cash,
+                "expected_max": config.cash_total_max,
+            }
+        )
         _handle_repo_cash_condition(
             f"Repo Cash total {total_cash:.2f} exceeds configured maximum {config.cash_total_max:.2f}.",
             warnings=warnings,
@@ -895,12 +939,18 @@ def _load_repo_cash_by_counterparty(
         )
 
     if not repo_cash_by_counterparty:
+        audit["checks"].append(
+            {
+                "name": "non_empty_source",
+                "status": "fail" if fail_policy == "strict" else "warn",
+            }
+        )
         _handle_repo_cash_condition(
             f"Repo Cash source '{source_label}' did not yield any counterparty values.",
             warnings=warnings,
             fail_policy=fail_policy,
         )
-    return repo_cash_by_counterparty, source_label
+    return repo_cash_by_counterparty, source_label, audit
 
 
 def _resolve_repo_cash_source(config: WorkflowConfig) -> tuple[str, Path | None]:

--- a/tests/parsers/test_repo_cash_sources.py
+++ b/tests/parsers/test_repo_cash_sources.py
@@ -70,6 +70,37 @@ def test_load_repo_cash_overrides_csv_returns_mapping_and_audit_rows(tmp_path: P
     assert audit_rows[0]["note"] == "manual correction"
 
 
+def test_load_repo_cash_overrides_csv_requires_note_column(tmp_path: Path) -> None:
+    overrides_path = tmp_path / "cash_overrides_2025-12-31.csv"
+    overrides_path.write_text(
+        "counterparty,cash_value\nCIBC,9.0\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing required columns: note"):
+        load_repo_cash_overrides_csv(overrides_path)
+
+
+def test_load_repo_cash_structured_source_rejects_duplicate_counterparty(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "repo_cash.csv"
+    source_path.write_text(
+        "\n".join(
+            [
+                "counterparty,cash_value",
+                "CIBC,2.0",
+                "CIBC,3.0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate counterparty 'CIBC'"):
+        load_repo_cash_structured_source(source_path, source_type="csv")
+
+
 def test_load_repo_cash_structured_source_raises_for_source_type_extension_mismatch(
     tmp_path: Path,
 ) -> None:

--- a/tests/pipeline/test_manifest_data_quality.py
+++ b/tests/pipeline/test_manifest_data_quality.py
@@ -79,6 +79,49 @@ def test_manifest_build_data_quality_defaults_to_info_when_no_warnings(tmp_path:
 
     data_quality = manifest["data_quality"]
     assert data_quality["overall_status"] == "info"
+
+
+def test_manifest_build_records_repo_cash_resolution_audit(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    artifact = run_dir / "output.csv"
+    artifact.write_text("ok\n", encoding="utf-8")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    repo_cash_resolution = {
+        "status": "loaded",
+        "source_type": "csv",
+        "source_path": "inputs/repo_cash.csv",
+        "override_path": "inputs/cash_overrides_2026-02-13.csv",
+        "override_rows": [
+            {
+                "counterparty": "CIBC",
+                "raw_counterparty": "CIBC",
+                "cash_value": "9.0",
+                "note": "desk correction",
+            }
+        ],
+        "counterparty_count": 2,
+        "total_cash": 12.0,
+        "checks": [],
+    }
+
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(artifact.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+        repo_cash_resolution=repo_cash_resolution,
+    )
+
+    assert manifest["repo_cash_resolution"] == repo_cash_resolution
+    data_quality = manifest["data_quality"]
     assert data_quality["counts"]["by_severity"] == {"info": 1, "warn": 0, "fail": 0}
     assert data_quality["findings"][0]["code"] == "NO_FINDINGS"
     assert data_quality["recommended_actions"][0]["severity"] == "info"

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -241,7 +241,7 @@ def test_apply_daily_holdings_repo_cash_noop_when_daily_holdings_not_configured(
 
     monkeypatch.setattr(run_module, "parse_daily_holdings_pdf", _unexpected_call)
 
-    run_module._apply_daily_holdings_repo_cash(
+    audit = run_module._apply_daily_holdings_repo_cash(
         config=config,
         parsed_by_variant=parsed_by_variant,
         warnings=warnings,
@@ -249,6 +249,7 @@ def test_apply_daily_holdings_repo_cash_noop_when_daily_holdings_not_configured(
     )
 
     assert any("Repo Cash source is not configured" in warning for warning in warnings)
+    assert audit["status"] == "not_configured"
 
 
 def test_apply_daily_holdings_repo_cash_prefers_structured_source_over_pdf(
@@ -318,7 +319,7 @@ def test_apply_daily_holdings_repo_cash_applies_overrides_from_default_file(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(run_module, "parse_daily_holdings_pdf", lambda _: {"CIBC": 2.0})
 
-    run_module._apply_daily_holdings_repo_cash(
+    audit = run_module._apply_daily_holdings_repo_cash(
         config=config,
         parsed_by_variant=parsed_by_variant,
         warnings=warnings,
@@ -330,6 +331,25 @@ def test_apply_daily_holdings_repo_cash_applies_overrides_from_default_file(
     assert float(by_counterparty["CIBC"]["Cash"]) == pytest.approx(9.0)
     assert float(by_counterparty["ASL"]["Cash"]) == pytest.approx(3.0)
     assert any(str(overrides_path) in warning for warning in warnings)
+    assert audit["source_type"] == "pdf"
+    assert audit["override_path"] == str(overrides_path)
+    assert audit["override_rows"] == [
+        {
+            "counterparty": "CIBC",
+            "raw_counterparty": "CIBC",
+            "cash_value": "9.0",
+            "note": "manual correction",
+        },
+        {
+            "counterparty": "ASL",
+            "raw_counterparty": "ASL",
+            "cash_value": "3.0",
+            "note": "new row",
+        },
+    ]
+    assert audit["applied_to_variant"] == "all_programs"
+    assert audit["counterparty_count"] == 2
+    assert audit["total_cash"] == pytest.approx(12.0)
 
 
 def test_apply_daily_holdings_repo_cash_resolves_default_overrides_from_config_directory(


### PR DESCRIPTION
Closes #474

## Summary
- require note-bearing override CSVs and reject duplicate cash counterparties before downstream use
- preserve a structured repo_cash_resolution audit block in manifests with source, override rows, checks, counts, and totals
- cover source/override validation and manifest audit behavior with focused tests

## Validation
- python -m pytest tests/parsers/test_repo_cash_sources.py tests/pipeline/test_run_pipeline.py::test_apply_daily_holdings_repo_cash_applies_overrides_from_default_file tests/pipeline/test_run_pipeline.py::test_apply_daily_holdings_repo_cash_noop_when_daily_holdings_not_configured tests/pipeline/test_manifest_data_quality.py::test_manifest_build_records_repo_cash_resolution_audit -q --no-cov
- python -m ruff check src/counter_risk/parsers/repo_cash_sources.py src/counter_risk/pipeline/run.py src/counter_risk/pipeline/manifest.py tests/parsers/test_repo_cash_sources.py tests/pipeline/test_run_pipeline.py tests/pipeline/test_manifest_data_quality.py
- python -m mypy src/counter_risk/parsers/repo_cash_sources.py src/counter_risk/pipeline/run.py src/counter_risk/pipeline/manifest.py