### PR TITLE
Issue #476: Surface risk proxy manifest summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A programmatic replacement for the MOSERS spreadsheet workflow used to evaluate 
 - Updated monthly PowerPoint (screenshots replaced + chart links refreshed)
 - A run folder with a manifest (inputs, hashes, warnings, summaries)
 - A `concentration_metrics.csv` with Top 5/Top 10 share and HHI per `(variant, segment)` (see [docs/concentration_metrics.md](docs/concentration_metrics.md))
+- Optional `risk_rankings.csv` and `risk_top_movers.csv` risk proxy outputs when source columns exist (see [docs/risk_proxy_outputs.md](docs/risk_proxy_outputs.md))
 - Optional “distribution” deliverables (static PPT/PDF) that do not prompt for link refresh
 
 ## Output Generator Configuration

--- a/docs/risk_proxy_outputs.md
+++ b/docs/risk_proxy_outputs.md
@@ -1,0 +1,44 @@
+# Risk Proxy Outputs
+
+Each pipeline run attempts to create deterministic risk-weighted proxy outputs
+from parsed totals rows. The outputs are optional because the source workbooks
+do not always carry volatility, position, or prior-period delta columns.
+
+## Where the outputs land
+
+- `<run_dir>/risk_rankings.csv` - written when at least one proxy has the
+  required current-period input columns.
+- `<run_dir>/risk_top_movers.csv` - written when a computed proxy also has a
+  prior-period delta column available.
+- `<run_dir>/manifest.json` - always includes `risk_proxy_summary`, which tells
+  operators which proxies were computed, which were skipped, and why.
+
+## Proxy formulas
+
+| Proxy name | Required columns | Formula |
+| --- | --- | --- |
+| `risk_proxy_notional_annualized_volatility` | `Notional`, `AnnualizedVolatility` | `Notional * AnnualizedVolatility` |
+| `risk_proxy_position_usd_vol` | `PositionUSD`, `Vol` | `PositionUSD * Vol` |
+
+Rankings sort by descending absolute proxy value, then by counterparty name
+case-insensitively. This makes tied rows stable across reruns.
+
+## Top movers
+
+`risk_top_movers.csv` is written only when prior-period delta columns are
+present:
+
+- Notional proxy: `NotionalChange` or `NotionalChangeFromPriorMonth`
+- Position proxy: `PositionUSDChange` or `PositionChangeFromPriorMonth`
+
+Mover rows report current proxy value, inferred prior proxy value, delta,
+absolute delta, rank, and the delta source column used. Missing prior-period
+delta columns skip only the mover output for that proxy; rankings still write
+when current proxy inputs exist.
+
+## Missing data behavior
+
+When required columns are missing, the pipeline records warnings and marks the
+proxy as `skipped` under `manifest["risk_proxy_summary"]["by_variant"]`.
+Missing volatility or position inputs do not fail the run. Missing mover delta
+inputs skip only `risk_top_movers.csv` for the affected proxy.

--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -53,6 +53,7 @@ class ManifestBuilder:
         ppt_status: str = "success",
         ppt_outputs: dict[str, dict[str, str]] | None = None,
         concentration_metrics: list[dict[str, Any]] | None = None,
+        risk_proxy_summary: dict[str, Any] | None = None,
         limit_breach_summary: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         valid_ppt_statuses = {"success", "skipped", "failed"}
@@ -125,6 +126,8 @@ class ManifestBuilder:
             manifest["ppt_outputs"] = ppt_outputs
         if concentration_metrics is not None:
             manifest["concentration_metrics"] = concentration_metrics
+        if risk_proxy_summary is not None:
+            manifest["risk_proxy_summary"] = risk_proxy_summary
         if limit_breach_summary is not None:
             manifest["limit_breach_summary"] = limit_breach_summary
         return manifest

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -393,11 +393,16 @@ def run_pipeline(
     concentration_metrics_records: list[dict[str, Any]] = []
     concentration_metrics_output_paths: list[Path] = []
     change_attribution_output_paths: list[Path] = []
+    risk_proxy_summary: dict[str, Any] = {}
     try:
         risk_output_paths = _write_risk_outputs(
             run_dir=run_dir,
             parsed_by_variant=parsed_by_variant,
             warnings=warnings,
+        )
+        risk_proxy_summary = _build_risk_proxy_summary(
+            parsed_by_variant=parsed_by_variant,
+            output_paths=risk_output_paths,
         )
     except Exception as exc:
         LOGGER.exception("pipeline_failed stage=write_risk_outputs run_dir=%s", run_dir)
@@ -523,6 +528,7 @@ def run_pipeline(
             concentration_metrics=(
                 concentration_metrics_records if concentration_metrics_records else None
             ),
+            risk_proxy_summary=risk_proxy_summary,
             limit_breach_summary=limit_breach_summary,
         )
         manifest_path = manifest_builder.write(run_dir=run_dir, manifest=manifest)
@@ -1474,6 +1480,101 @@ def _write_risk_outputs(
         )
 
     return output_paths
+
+
+def _build_risk_proxy_summary(
+    *,
+    parsed_by_variant: dict[str, dict[str, Any]],
+    output_paths: Sequence[Path],
+) -> dict[str, Any]:
+    output_names = {path.name for path in output_paths}
+    summary: dict[str, Any] = {
+        "outputs": {
+            "risk_rankings": ("risk_rankings.csv" if "risk_rankings.csv" in output_names else None),
+            "risk_top_movers": (
+                "risk_top_movers.csv" if "risk_top_movers.csv" in output_names else None
+            ),
+        },
+        "by_variant": {},
+    }
+    by_variant: dict[str, Any] = {}
+
+    for variant, parsed_sections in parsed_by_variant.items():
+        totals_table = parsed_sections.get("totals", [])
+        totals_records = _records(totals_table)
+        columns = _column_names(totals_table)
+        variant_summary = {
+            _RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN: _risk_proxy_manifest_entry(
+                columns=columns,
+                records=totals_records,
+                required_columns=("Notional", "AnnualizedVolatility"),
+                formula="Notional * AnnualizedVolatility",
+                delta_candidates=_NOTIONAL_CHANGE_FIELDS_FOR_MOVER_DELTA,
+            ),
+            _RISK_PROXY_POSITION_VOL_COLUMN: _risk_proxy_manifest_entry(
+                columns=columns,
+                records=totals_records,
+                required_columns=("PositionUSD", "Vol"),
+                formula="PositionUSD * Vol",
+                delta_candidates=_POSITION_CHANGE_FIELDS_FOR_MOVER_DELTA,
+            ),
+        }
+        by_variant[variant] = variant_summary
+
+    summary["by_variant"] = by_variant
+    return summary
+
+
+def _risk_proxy_manifest_entry(
+    *,
+    columns: set[str],
+    records: list[dict[str, Any]],
+    required_columns: tuple[str, ...],
+    formula: str,
+    delta_candidates: tuple[str, ...],
+) -> dict[str, Any]:
+    missing_columns = [column for column in required_columns if column not in columns]
+    delta_source_column = _first_available_field(columns=columns, candidates=delta_candidates)
+    if not records:
+        return {
+            "status": "skipped",
+            "formula": formula,
+            "required_columns": list(required_columns),
+            "missing_columns": missing_columns,
+            "skipped_reason": "no totals rows available",
+            "top_movers_status": "skipped",
+            "top_movers_skipped_reason": "no totals rows available",
+            "delta_source_column": None,
+        }
+    if missing_columns:
+        return {
+            "status": "skipped",
+            "formula": formula,
+            "required_columns": list(required_columns),
+            "missing_columns": missing_columns,
+            "skipped_reason": (
+                "missing required proxy input column(s): " + ", ".join(missing_columns)
+            ),
+            "top_movers_status": "skipped",
+            "top_movers_skipped_reason": "proxy inputs unavailable",
+            "delta_source_column": None,
+        }
+
+    top_movers_status = "computed" if delta_source_column is not None else "skipped"
+    entry: dict[str, Any] = {
+        "status": "computed",
+        "formula": formula,
+        "required_columns": list(required_columns),
+        "missing_columns": [],
+        "skipped_reason": None,
+        "top_movers_status": top_movers_status,
+        "delta_source_column": delta_source_column,
+    }
+    if delta_source_column is None:
+        entry["top_movers_skipped_reason"] = "missing prior-period delta column"
+    else:
+        entry["top_movers_skipped_reason"] = None
+    return entry
 
 
 def _write_change_attribution_outputs(

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1641,6 +1641,44 @@ def test_write_risk_outputs_writes_rankings_and_top_movers(tmp_path: Path) -> No
     assert "risk_rankings.csv skipped" not in "\n".join(warnings)
 
 
+def test_build_risk_proxy_summary_reports_computed_and_skipped_outputs(tmp_path: Path) -> None:
+    parsed_by_variant = {
+        "all_programs": {
+            "totals": _FakeDataFrame(
+                records=[
+                    {
+                        "counterparty": "A",
+                        "Notional": 100.0,
+                        "AnnualizedVolatility": 0.3,
+                        "NotionalChange": 10.0,
+                    }
+                ]
+            )
+        },
+        "trend": {"totals": _FakeDataFrame(records=[{"counterparty": "B", "Notional": 50.0}])},
+    }
+
+    summary = run_module._build_risk_proxy_summary(
+        parsed_by_variant=parsed_by_variant,
+        output_paths=[tmp_path / "risk_rankings.csv", tmp_path / "risk_top_movers.csv"],
+    )
+
+    assert summary["outputs"] == {
+        "risk_rankings": "risk_rankings.csv",
+        "risk_top_movers": "risk_top_movers.csv",
+    }
+    notional_entry = summary["by_variant"]["all_programs"][
+        "risk_proxy_notional_annualized_volatility"
+    ]
+    assert notional_entry["status"] == "computed"
+    assert notional_entry["formula"] == "Notional * AnnualizedVolatility"
+    assert notional_entry["delta_source_column"] == "NotionalChange"
+    position_entry = summary["by_variant"]["trend"]["risk_proxy_position_usd_vol"]
+    assert position_entry["status"] == "skipped"
+    assert position_entry["missing_columns"] == ["PositionUSD", "Vol"]
+    assert position_entry["top_movers_skipped_reason"] == "proxy inputs unavailable"
+
+
 def test_write_risk_outputs_warns_and_skips_rankings_when_proxy_columns_missing(
     tmp_path: Path,
 ) -> None:
@@ -1856,6 +1894,12 @@ def test_run_pipeline_writes_risk_outputs_when_proxy_inputs_available(
 
     assert (run_dir / "risk_rankings.csv").exists()
     assert (run_dir / "risk_top_movers.csv").exists()
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    notional_summary = manifest["risk_proxy_summary"]["by_variant"]["all_programs"][
+        "risk_proxy_notional_annualized_volatility"
+    ]
+    assert notional_summary["status"] == "computed"
+    assert notional_summary["delta_source_column"] == "NotionalChange"
 
 
 def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(

--- a/tests/test_manifest_paths.py
+++ b/tests/test_manifest_paths.py
@@ -133,6 +133,41 @@ def test_manifest_warnings_are_normalized_to_strings(tmp_path: Path) -> None:
     assert all(isinstance(entry, str) for entry in manifest["warnings"])
 
 
+def test_manifest_build_includes_risk_proxy_summary_when_supplied(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    rankings_path = run_dir / "risk_rankings.csv"
+    rankings_path.write_text("variant,counterparty,proxy_name,proxy_value,rank\n", encoding="utf-8")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    summary = {
+        "outputs": {"risk_rankings": "risk_rankings.csv", "risk_top_movers": None},
+        "by_variant": {
+            "all_programs": {
+                "risk_proxy_notional_annualized_volatility": {
+                    "status": "computed",
+                    "formula": "Notional * AnnualizedVolatility",
+                }
+            }
+        },
+    }
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(rankings_path.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+        risk_proxy_summary=summary,
+    )
+
+    assert manifest["risk_proxy_summary"] == summary
+
+
 def test_to_relative_artifact_path_normalizes_absolute_path_under_run_dir(tmp_path: Path) -> None:
     run_dir = tmp_path / "runs" / "2026-02-13_1"
     run_dir.mkdir(parents=True)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,29 @@
 # Counter_Risk Workloop State
 
+## 2026-05-07T13:58:14Z - opener lane PR materialization for issue #476
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Counter_Risk`.
+- Source issue: `#476` (`[Agent] [M3] Add risk-weighted exposure proxies and rankings (Notional×Vol, Position×Vol where available)`).
+- Branch: `codex/issue-476-risk-proxy-manifest-docs`.
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace.
+  - Required discovery ran: queue files, `repo-review-approved`, live `priority:high` / `priority:normal` / `priority:low`, raw opener-owned author searches, and cap-health.
+  - Cap-health reported `total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`, so one opener slot was available.
+  - High-priority issues were skipped because they were already materialized into open or merged verifier-pending PRs (`Manager-Database#977/#979`, `Inv-Man-Intake#379/#381`) or otherwise not opener-actionable.
+  - Normal-priority `Counter_Risk#473` and `#474` already have open PRs (`#526`, `#569`); `#475` was already merged and closed after verifier PASS. `#476` was the oldest supported unmaterialized normal-priority issue.
+- Implementation:
+  - Kept the existing `compute_risk_proxies`, `risk_rankings.csv`, and `risk_top_movers.csv` behavior intact.
+  - Added a structured `risk_proxy_summary` manifest block that reports output file presence and per-variant/per-proxy computed vs skipped state, formulas, required columns, missing columns, mover status, and delta source column.
+  - Added docs for `risk_rankings.csv`, `risk_top_movers.csv`, formulas, mover prerequisites, and missing-data behavior, and linked them from the README.
+  - Added targeted tests for manifest persistence, summary computation, and pipeline manifest output.
+- Validation passed:
+  - `python -m pytest tests/compute/test_rollups.py tests/pipeline/test_run_pipeline.py::test_write_risk_outputs_writes_rankings_and_top_movers tests/pipeline/test_run_pipeline.py::test_build_risk_proxy_summary_reports_computed_and_skipped_outputs tests/pipeline/test_run_pipeline.py::test_write_risk_outputs_warns_and_skips_rankings_when_proxy_columns_missing tests/pipeline/test_run_pipeline.py::test_write_risk_outputs_creates_partial_outputs_when_only_notional_proxy_exists tests/pipeline/test_run_pipeline.py::test_run_pipeline_writes_risk_outputs_when_proxy_inputs_available tests/test_manifest_paths.py::test_manifest_build_includes_risk_proxy_summary_when_supplied tests/test_pipeline_run_outputs.py tests/test_fixtures_smoke.py --no-cov` (38 passed).
+  - `python -m ruff check src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/run.py tests/pipeline/test_run_pipeline.py tests/test_manifest_paths.py`.
+  - `python -m black --check src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/run.py tests/pipeline/test_run_pipeline.py tests/test_manifest_paths.py`.
+  - `python -m mypy src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/run.py`.
+- Next action: commit, push, open a ready PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit the `pr_opened` relay event.
+
 ## 2026-05-01T14:12Z - opener PR opened for issue #471
 
 - Automation: `pd-workloop-resume` (codex opener lane).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -6,6 +6,7 @@
 - Source repo: `stranske/Counter_Risk`.
 - Source issue: `#476` (`[Agent] [M3] Add risk-weighted exposure proxies and rankings (Notional×Vol, Position×Vol where available)`).
 - Branch: `codex/issue-476-risk-proxy-manifest-docs`.
+- PR: `#572` (`https://github.com/stranske/Counter_Risk/pull/572`), ready for review, labels `agent:codex`, `agents:keepalive`, `autofix`.
 - Selection:
   - ACTION A succeeded from the neutral Code workspace.
   - Required discovery ran: queue files, `repo-review-approved`, live `priority:high` / `priority:normal` / `priority:low`, raw opener-owned author searches, and cap-health.
@@ -22,7 +23,8 @@
   - `python -m ruff check src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/run.py tests/pipeline/test_run_pipeline.py tests/test_manifest_paths.py`.
   - `python -m black --check src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/run.py tests/pipeline/test_run_pipeline.py tests/test_manifest_paths.py`.
   - `python -m mypy src/counter_risk/pipeline/manifest.py src/counter_risk/pipeline/run.py`.
-- Next action: commit, push, open a ready PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit the `pr_opened` relay event.
+- Relay event emitted: `pr_opened active.source_repo=stranske/Counter_Risk active.source_issue=476 active.source_pr=572 active.next_action=wait_for_keepalive`.
+- Next action: keepalive owns PR `#572` for CI, review comments, and follow-up commits. Opener is done with this issue and should select another eligible issue only after cap allows.
 
 ## 2026-05-01T14:12Z - opener PR opened for issue #471
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:476 -->
> **Source:** Issue #476

Closes #476

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Nominal exposure alone is not enough for risk prioritization. When volatility or position data exists, the run should produce risk-weighted proxy rankings and explain when a proxy could not be computed.

#### Tasks
- [ ] Implement `compute_risk_proxies(exposures_df)` in `src/counter_risk/compute/rollups.py` or a dedicated metrics module.
- [ ] Create `risk_rankings.csv` sorted by each available proxy with stable tie-breaking by canonical counterparty key.
- [ ] Create `risk_top_movers.csv` using prior-period data when available through the existing change-attribution or historical update path.
- [ ] Emit manifest warnings for unavailable proxies when volatility, notional, position, or prior-period columns are missing.
- [ ] Add tests for available-volatility data, missing-volatility data, missing-position data, prior-period unavailable, and deterministic ranking order.
- [ ] Document proxy formulas, required input columns, and missing-data behavior.

#### Acceptance criteria
- [ ] When required inputs exist, the run folder includes risk proxy rankings with formulas matching the documentation.
- [ ] When inputs are missing, the run records a warning and skips only unavailable proxies.
- [ ] Tests verify formulas, sorting, and missing-column behavior.
- [ ] Manifest output tells the operator which proxies were computed and which were skipped.
- [ ] Prior-period mover output is written only when the source comparison data is available and valid.

<!-- auto-status-summary:end -->