### PR TITLE
Issue #477: Add limit monitoring severity controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A programmatic replacement for the MOSERS spreadsheet workflow used to evaluate 
 - A `DATA_QUALITY_SUMMARY.txt` and manifest `data_quality` object for green/yellow/red operator review (see [docs/data_quality.md](docs/data_quality.md))
 - A `concentration_metrics.csv` with Top 5/Top 10 share and HHI per `(variant, segment)` (see [docs/concentration_metrics.md](docs/concentration_metrics.md))
 - Optional `risk_rankings.csv` and `risk_top_movers.csv` risk proxy outputs when source columns exist (see [docs/risk_proxy_outputs.md](docs/risk_proxy_outputs.md))
+- A `limit_breaches.csv` when configured exposure limits are breached (see [docs/limit_monitoring.md](docs/limit_monitoring.md))
 - Optional “distribution” deliverables (static PPT/PDF) that do not prompt for link refresh
 
 ## Output Generator Configuration

--- a/config/limits.yml
+++ b/config/limits.yml
@@ -18,16 +18,34 @@ strict_missing_entities: false
 #   Must be > 0.
 # - limit_kind (required string): interpretation of limit_value.
 #   Valid values: absolute_notional | percent_of_total
+# - severity (optional string): operator escalation level.
+#   Valid values: warning | fail
+#   Default: warning
+# - enabled (optional boolean): false keeps the entry documented but excludes
+#   it from missing-entity and breach checks.
+#   Default: true
 # - notes (optional string): operator-facing context for the configured policy.
 limits:
   - entity_type: counterparty
     entity_name: citibank
     limit_value: 250000000
     limit_kind: absolute_notional
+    severity: fail
+    enabled: true
     notes: Committee approved gross notional cap for single counterparty.
 
   - entity_type: clearing_house
     entity_name: cme
     limit_value: 0.35
     limit_kind: percent_of_total
+    severity: warning
+    enabled: true
     notes: Max 35 percent of total exposure at a single clearing house.
+
+  - entity_type: custom_group
+    entity_name: staged_policy_example
+    limit_value: 0.25
+    limit_kind: percent_of_total
+    severity: warning
+    enabled: false
+    notes: Disabled example entry; enable only after risk owners approve the policy.

--- a/docs/limit_monitoring.md
+++ b/docs/limit_monitoring.md
@@ -21,6 +21,28 @@ Each `limits` entry has these fields:
 Duplicate keys are rejected during config load. A key is the tuple
 `entity_type`, normalized `entity_name`, and `limit_kind`.
 
+## Safe Maintainer Update Process
+
+Use this checklist when adding or revising a limit in `config/limits.yml`:
+
+1. Find the canonical entity key used by pipeline outputs and set `entity_name`
+   to that key (for example `citibank`, `cme`, or another normalized name).
+2. Choose the smallest valid scope for `entity_type`:
+   `counterparty`, `fcm`, `clearing_house`, `segment`, or `custom_group`.
+3. Set `limit_kind` to match policy intent:
+   `absolute_notional` for dollar caps, `percent_of_total` for concentration caps.
+4. Set `severity` explicitly (`warning` or `fail`) and include `notes` explaining
+   policy ownership or approval context.
+5. If the limit is staged and not active, set `enabled: false` instead of removing
+   the entry so history remains auditable.
+6. Run validation tests before merging:
+   `pytest tests/test_limits_config.py tests/compute/test_limits.py -m "not slow"`
+7. Run one pipeline fixture test to confirm breach artifacts still render correctly:
+   `pytest tests/pipeline/test_run_pipeline.py::test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist -m "not slow"`
+
+If a run warns that configured entities are missing, either correct `entity_name`
+or intentionally set `strict_missing_entities: true` to fail fast in CI.
+
 ## Outputs
 
 When one or more enabled limits breach, the run folder includes

--- a/docs/limit_monitoring.md
+++ b/docs/limit_monitoring.md
@@ -18,7 +18,7 @@ Each `limits` entry has these fields:
 | `enabled` | no | Set `false` to document a staged policy without evaluating it; defaults to `true`. |
 | `notes` | no | Operator-facing policy context included in breach records. |
 
-Duplicate active keys are rejected during config load. A key is the tuple
+Duplicate keys are rejected during config load. A key is the tuple
 `entity_type`, normalized `entity_name`, and `limit_kind`.
 
 ## Outputs

--- a/docs/limit_monitoring.md
+++ b/docs/limit_monitoring.md
@@ -39,6 +39,24 @@ Use this checklist when adding or revising a limit in `config/limits.yml`:
    `pytest tests/test_limits_config.py tests/compute/test_limits.py -m "not slow"`
 7. Run one pipeline fixture test to confirm breach artifacts still render correctly:
    `pytest tests/pipeline/test_run_pipeline.py::test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist -m "not slow"`
+8. Run strict missing-entity coverage so bad canonical names fail fast in CI:
+   `pytest tests/pipeline/test_run_pipeline.py::test_run_pipeline_strict_missing_limit_entities_fails -m "not slow"`
+
+Practical edit pattern for maintainers:
+
+1. Copy an existing entry in `config/limits.yml`.
+2. Update `entity_type`, `entity_name`, `limit_kind`, and `limit_value`.
+3. Set `severity` and `enabled` intentionally (avoid relying on defaults in policy PRs).
+4. Add or update `notes` with approval context.
+5. Run the three commands above before opening a PR.
+
+Common validation failures and fixes:
+
+- `duplicate limit keys are not allowed`: remove or merge entries that share
+  the same `entity_type`, normalized `entity_name`, and `limit_kind`.
+- `severity` validation errors: use only `warning` or `fail`.
+- missing-entity warnings: correct `entity_name` to match exposure canonical
+  keys, or set `strict_missing_entities: true` when the policy requires fail-fast behavior.
 
 If a run warns that configured entities are missing, either correct `entity_name`
 or intentionally set `strict_missing_entities: true` to fail fast in CI.

--- a/docs/limit_monitoring.md
+++ b/docs/limit_monitoring.md
@@ -1,0 +1,47 @@
+# Limit Monitoring
+
+The monthly pipeline evaluates configured exposure limits during each run and
+writes breach artifacts beside the other run outputs. Limits are maintained in
+`config/limits.yml`.
+
+## Configuration
+
+Each `limits` entry has these fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `entity_type` | yes | Dimension to evaluate: `counterparty`, `fcm`, `clearing_house`, `segment`, or `custom_group`. |
+| `entity_name` | yes | Canonical entity key. Whitespace is collapsed to underscores and compared case-insensitively. |
+| `limit_value` | yes | Positive threshold value. |
+| `limit_kind` | yes | `absolute_notional` for gross notional caps or `percent_of_total` for share-of-total caps. |
+| `severity` | no | `warning` or `fail`; defaults to `warning`. |
+| `enabled` | no | Set `false` to document a staged policy without evaluating it; defaults to `true`. |
+| `notes` | no | Operator-facing policy context included in breach records. |
+
+Duplicate active keys are rejected during config load. A key is the tuple
+`entity_type`, normalized `entity_name`, and `limit_kind`.
+
+## Outputs
+
+When one or more enabled limits breach, the run folder includes
+`limit_breaches.csv` with deterministic rows:
+
+- `entity_type`
+- `entity_name`
+- `limit_kind`
+- `severity`
+- `actual_value`
+- `limit_value`
+- `breach_amount`
+- `notes`
+
+The manifest includes `limit_breach_summary`, the warning list includes a
+human-readable limit summary, and the run-folder `README.txt` shows a warning
+banner with the highest observed severity.
+
+## Missing Entities
+
+If a configured enabled entity is not present in the exposure rows, the default
+behavior is to add a manifest warning and continue. Set
+`strict_missing_entities: true` to fail the run instead. Disabled limits are not
+checked for missing entities.

--- a/src/counter_risk/compute/limits.py
+++ b/src/counter_risk/compute/limits.py
@@ -64,7 +64,7 @@ def _to_dataframe_or_records(*, records: list[dict[str, Any]], columns: tuple[st
     for column in columns:
         if column not in frame.columns:
             frame[column] = None
-    if "notes" in frame.columns:
+    if "notes" in frame.columns and hasattr(frame, "__getitem__"):
         frame["notes"] = frame["notes"].astype(object).where(frame["notes"].notna(), None)
     return frame.loc[:, list(columns)]
 

--- a/src/counter_risk/compute/limits.py
+++ b/src/counter_risk/compute/limits.py
@@ -181,8 +181,8 @@ def check_limits(exposures_df: Any, limits_cfg: Any) -> Any:
     """Evaluate absolute-notional and percentage-of-total limit breaches.
 
     Returns a DataFrame-like table (or list of dict records if pandas is unavailable)
-    with columns: entity_type, entity_name, limit_kind, actual_value, limit_value,
-    and breach_amount.
+    with columns: entity_type, entity_name, limit_kind, severity, actual_value,
+    limit_value, breach_amount, and notes.
     """
 
     rows = _iter_rows(exposures_df, arg_name="exposures_df")

--- a/src/counter_risk/compute/limits.py
+++ b/src/counter_risk/compute/limits.py
@@ -16,9 +16,11 @@ _BREACH_COLUMNS = (
     "entity_type",
     "entity_name",
     "limit_kind",
+    "severity",
     "actual_value",
     "limit_value",
     "breach_amount",
+    "notes",
 )
 _ENTITY_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "counterparty": ("counterparty", "counterparty_name", "name"),
@@ -61,7 +63,7 @@ def _to_dataframe_or_records(*, records: list[dict[str, Any]], columns: tuple[st
     frame = pd.DataFrame(records) if records else pd.DataFrame(columns=columns)
     for column in columns:
         if column not in frame.columns:
-            frame[column] = 0.0
+            frame[column] = None
     return frame.loc[:, list(columns)]
 
 
@@ -153,6 +155,8 @@ def find_missing_limit_entities(exposures_df: Any, limits_cfg: Any) -> list[dict
 
     missing: list[dict[str, str]] = []
     for limit in limits.limits:
+        if not limit.enabled:
+            continue
         if limit.entity_name in entity_values_by_type[limit.entity_type]:
             continue
         missing.append(
@@ -182,13 +186,14 @@ def check_limits(exposures_df: Any, limits_cfg: Any) -> Any:
     rows = _iter_rows(exposures_df, arg_name="exposures_df")
     limits = _coerce_limits(limits_cfg)
 
-    if not rows or not limits.limits:
+    enabled_limits = [limit for limit in limits.limits if limit.enabled]
+    if not rows or not enabled_limits:
         return _to_dataframe_or_records(records=[], columns=_BREACH_COLUMNS)
 
     total_abs_notional = sum(abs(_find_notional(row)) for row in rows)
     records: list[dict[str, Any]] = []
 
-    for limit in limits.limits:
+    for limit in enabled_limits:
         aliases = _ENTITY_COLUMN_ALIASES[limit.entity_type]
         matched_abs_notional = 0.0
         found_match = False
@@ -221,9 +226,11 @@ def check_limits(exposures_df: Any, limits_cfg: Any) -> Any:
                 "entity_type": limit.entity_type,
                 "entity_name": limit.entity_name,
                 "limit_kind": limit.limit_kind,
+                "severity": limit.severity,
                 "actual_value": actual_value,
                 "limit_value": float(limit.limit_value),
                 "breach_amount": breach_amount,
+                "notes": limit.notes,
             }
         )
 

--- a/src/counter_risk/compute/limits.py
+++ b/src/counter_risk/compute/limits.py
@@ -64,6 +64,8 @@ def _to_dataframe_or_records(*, records: list[dict[str, Any]], columns: tuple[st
     for column in columns:
         if column not in frame.columns:
             frame[column] = None
+    if "notes" in frame.columns:
+        frame["notes"] = frame["notes"].astype(object).where(frame["notes"].notna(), None)
     return frame.loc[:, list(columns)]
 
 

--- a/src/counter_risk/gui/runner.py
+++ b/src/counter_risk/gui/runner.py
@@ -206,6 +206,26 @@ def _read_data_quality_status_color(output_dir: Path | None) -> str:
     return read_overall_status_color(output_dir / "DATA_QUALITY_SUMMARY.txt")
 
 
+def _load_limit_breach_banner(run_dir: Path) -> str | None:
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    summary = payload.get("limit_breach_summary")
+    if not isinstance(summary, dict):
+        return None
+    warning_banner = summary.get("warning_banner")
+    if not isinstance(warning_banner, str):
+        return None
+    rendered = warning_banner.strip()
+    return rendered or None
+
+
 def launch_gui(
     *,
     initial_state: GuiRunState | None = None,
@@ -236,6 +256,7 @@ def launch_gui(
     status_var = tk.StringVar(value="Idle")
     result_var = tk.StringVar(value="")
     quality_var = tk.StringVar(value="")
+    limit_banner_var = tk.StringVar(value="None")
 
     def _state_from_form() -> GuiRunState:
         return GuiRunState(
@@ -264,14 +285,18 @@ def launch_gui(
                 status_var.set("Complete")
                 result_var.set("Success")
                 quality_var.set(result.data_quality_status or "UNAVAILABLE - Summary not found")
+                if result.output_dir is not None:
+                    limit_banner_var.set(_load_limit_breach_banner(result.output_dir) or "None")
             else:
                 status_var.set("Error")
                 result_var.set(f"Exit code {result.exit_code}")
                 quality_var.set("")
+                limit_banner_var.set("None")
         except Exception as exc:  # pragma: no cover - UI safety
             status_var.set("Error")
             result_var.set(str(exc))
             quality_var.set("")
+            limit_banner_var.set("None")
             messagebox.showerror("Counter Risk Runner", str(exc))
 
     def _open_output() -> None:
@@ -358,5 +383,9 @@ def launch_gui(
     ttk.Label(root, textvariable=result_var).grid(row=12, column=1, sticky="w", padx=8, pady=4)
     ttk.Label(root, text="Data Quality").grid(row=13, column=0, sticky="w", padx=8, pady=4)
     ttk.Label(root, textvariable=quality_var).grid(row=13, column=1, sticky="w", padx=8, pady=4)
+    ttk.Label(root, text="Limit Breach").grid(row=14, column=0, sticky="w", padx=8, pady=4)
+    ttk.Label(root, textvariable=limit_banner_var).grid(
+        row=14, column=1, sticky="w", padx=8, pady=4
+    )
 
     root.mainloop()

--- a/src/counter_risk/limits_config.py
+++ b/src/counter_risk/limits_config.py
@@ -3,10 +3,31 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+
+class _NoDuplicateSafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate keys in mappings."""
+
+
+def _construct_mapping_no_duplicates(
+    loader: _NoDuplicateSafeLoader, node: yaml.nodes.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = cast(Any, loader.construct_object(key_node, deep=deep))  # type: ignore[no-untyped-call]
+        if key in mapping:
+            raise ValueError(f"duplicate key '{key}'")
+        mapping[key] = cast(Any, loader.construct_object(value_node, deep=deep))  # type: ignore[no-untyped-call]
+    return mapping
+
+
+_NoDuplicateSafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping_no_duplicates
+)
 
 
 class LimitEntry(BaseModel):
@@ -79,9 +100,11 @@ def load_limits_config(path: str | Path = Path("config/limits.yml")) -> LimitsCo
 
     config_path = Path(path)
     try:
-        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        raw = yaml.load(config_path.read_text(encoding="utf-8"), Loader=_NoDuplicateSafeLoader)
     except OSError as exc:
         raise ValueError(f"Unable to read limits config file '{config_path}': {exc}") from exc
+    except ValueError as exc:
+        raise ValueError(f"Invalid YAML in limits config file '{config_path}': {exc}") from exc
     except yaml.YAMLError as exc:
         raise ValueError(f"Invalid YAML in limits config file '{config_path}': {exc}") from exc
 

--- a/src/counter_risk/limits_config.py
+++ b/src/counter_risk/limits_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 
 class LimitEntry(BaseModel):
@@ -18,6 +18,8 @@ class LimitEntry(BaseModel):
     entity_name: str = Field(min_length=1)
     limit_value: float = Field(gt=0)
     limit_kind: Literal["absolute_notional", "percent_of_total"]
+    severity: Literal["warning", "fail"] = "warning"
+    enabled: bool = True
     notes: str | None = None
 
     @field_validator("entity_name")
@@ -47,6 +49,20 @@ class LimitsConfig(BaseModel):
     schema_version: Literal[1]
     strict_missing_entities: bool = False
     limits: list[LimitEntry] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_unique_limit_keys(self) -> LimitsConfig:
+        seen: set[tuple[str, str, str]] = set()
+        duplicates: list[str] = []
+        for limit in self.limits:
+            key = (limit.entity_type, limit.entity_name, limit.limit_kind)
+            if key in seen:
+                duplicates.append(":".join(key))
+            seen.add(key)
+        if duplicates:
+            duplicate_list = ", ".join(sorted(duplicates))
+            raise ValueError(f"duplicate limit keys are not allowed: {duplicate_list}")
+        return self
 
 
 def _format_limits_validation_error(error: ValidationError) -> str:

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -251,10 +251,19 @@ def manifest_schema() -> dict[str, Any]:
             },
             "limit_breach_summary": {
                 "type": "object",
-                "required": ["has_breaches", "breach_count", "report_path", "warning_banner"],
+                "required": [
+                    "has_breaches",
+                    "breach_count",
+                    "warning_breach_count",
+                    "fail_breach_count",
+                    "report_path",
+                    "warning_banner",
+                ],
                 "properties": {
                     "has_breaches": {"type": "boolean"},
                     "breach_count": {"type": "integer", "minimum": 0},
+                    "warning_breach_count": {"type": "integer", "minimum": 0},
+                    "fail_breach_count": {"type": "integer", "minimum": 0},
                     "report_path": {"type": ["string", "null"]},
                     "warning_banner": {"type": ["string", "null"]},
                 },

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -237,6 +237,7 @@ class LimitBreachEvaluation:
 
     csv_path: Path | None
     breach_count: int
+    max_severity: Literal["warning", "fail"] | None = None
 
 
 ScreenshotReplacer = Callable[[Path, Path, dict[str, Path]], None]
@@ -2008,10 +2009,19 @@ def _compute_and_write_limit_breaches(
     if not breaches_records:
         return LimitBreachEvaluation(csv_path=None, breach_count=0)
 
+    max_severity: Literal["warning", "fail"] = (
+        "fail"
+        if any(str(row.get("severity", "")).casefold() == "fail" for row in breaches_records)
+        else "warning"
+    )
     csv_path = run_dir / "limit_breaches.csv"
     write_limit_breaches_csv(breaches_result, csv_path)
     LOGGER.info("limit_breaches_written path=%s", csv_path)
-    return LimitBreachEvaluation(csv_path=csv_path, breach_count=len(breaches_records))
+    return LimitBreachEvaluation(
+        csv_path=csv_path,
+        breach_count=len(breaches_records),
+        max_severity=max_severity,
+    )
 
 
 def _format_missing_limit_entities_warning(missing_entities: list[dict[str, str]]) -> str:
@@ -2033,8 +2043,10 @@ def _build_limit_breach_summary(
     warning_banner = None
     if has_breaches and report_path is not None:
         plurality = "breach" if limit_breaches.breach_count == 1 else "breaches"
+        severity_prefix = f"{limit_breaches.max_severity} " if limit_breaches.max_severity else ""
         warning_banner = (
-            f"{limit_breaches.breach_count} limit {plurality} detected. Review {report_path}."
+            f"{limit_breaches.breach_count} {severity_prefix}limit {plurality} detected. "
+            f"Review {report_path}."
         )
     return {
         "has_breaches": has_breaches,
@@ -2061,14 +2073,21 @@ def _build_limit_warning_banner_for_run_dir(run_dir: Path) -> RunFolderWarningBa
     if not csv_path.exists():
         return None
 
+    max_severity: Literal["warning", "fail"] = "warning"
     with csv_path.open("r", encoding="utf-8", newline="") as stream:
-        row_count = sum(1 for _ in csv.DictReader(stream))
+        rows = list(csv.DictReader(stream))
+        row_count = len(rows)
+        if any(str(row.get("severity", "")).casefold() == "fail" for row in rows):
+            max_severity = "fail"
     if row_count <= 0:
         return None
 
     plurality = "breach" if row_count == 1 else "breaches"
     title = f"Limit {plurality.capitalize()} Detected ({row_count})"
-    message = f"Warning banner: {row_count} configured limit {plurality} were detected."
+    message = (
+        f"Warning banner: {row_count} configured limit {plurality} were detected "
+        f"(highest severity: {max_severity})."
+    )
     return RunFolderWarningBanner(
         title=title,
         message=message,

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -238,6 +238,8 @@ class LimitBreachEvaluation:
     csv_path: Path | None
     breach_count: int
     max_severity: Literal["warning", "fail"] | None = None
+    warning_breach_count: int = 0
+    fail_breach_count: int = 0
 
 
 ScreenshotReplacer = Callable[[Path, Path, dict[str, Path]], None]
@@ -2009,11 +2011,11 @@ def _compute_and_write_limit_breaches(
     if not breaches_records:
         return LimitBreachEvaluation(csv_path=None, breach_count=0)
 
-    max_severity: Literal["warning", "fail"] = (
-        "fail"
-        if any(str(row.get("severity", "")).casefold() == "fail" for row in breaches_records)
-        else "warning"
+    fail_breach_count = sum(
+        1 for row in breaches_records if str(row.get("severity", "")).casefold() == "fail"
     )
+    warning_breach_count = len(breaches_records) - fail_breach_count
+    max_severity: Literal["warning", "fail"] = "fail" if fail_breach_count > 0 else "warning"
     csv_path = run_dir / "limit_breaches.csv"
     write_limit_breaches_csv(breaches_result, csv_path)
     LOGGER.info("limit_breaches_written path=%s", csv_path)
@@ -2021,6 +2023,8 @@ def _compute_and_write_limit_breaches(
         csv_path=csv_path,
         breach_count=len(breaches_records),
         max_severity=max_severity,
+        warning_breach_count=warning_breach_count,
+        fail_breach_count=fail_breach_count,
     )
 
 
@@ -2051,6 +2055,8 @@ def _build_limit_breach_summary(
     return {
         "has_breaches": has_breaches,
         "breach_count": limit_breaches.breach_count,
+        "warning_breach_count": limit_breaches.warning_breach_count,
+        "fail_breach_count": limit_breaches.fail_breach_count,
         "report_path": report_path,
         "warning_banner": warning_banner,
     }

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2074,11 +2074,12 @@ def _build_limit_warning_banner_for_run_dir(run_dir: Path) -> RunFolderWarningBa
         return None
 
     max_severity: Literal["warning", "fail"] = "warning"
+    row_count = 0
     with csv_path.open("r", encoding="utf-8", newline="") as stream:
-        rows = list(csv.DictReader(stream))
-        row_count = len(rows)
-        if any(str(row.get("severity", "")).casefold() == "fail" for row in rows):
-            max_severity = "fail"
+        for row in csv.DictReader(stream):
+            row_count += 1
+            if str(row.get("severity", "")).casefold() == "fail":
+                max_severity = "fail"
     if row_count <= 0:
         return None
 

--- a/tests/compute/test_limits.py
+++ b/tests/compute/test_limits.py
@@ -56,6 +56,8 @@ def test_check_limits_detects_absolute_and_percent_breaches_across_entity_types(
                 "entity_name": "Alpha Bank",
                 "limit_value": 100.0,
                 "limit_kind": "absolute_notional",
+                "severity": "fail",
+                "notes": "Single-name cap.",
             },
             {
                 "entity_type": "fcm",
@@ -91,41 +93,51 @@ def test_check_limits_detects_absolute_and_percent_breaches_across_entity_types(
             "entity_type": "clearing_house",
             "entity_name": "cme",
             "limit_kind": "percent_of_total",
+            "severity": "warning",
             "actual_value": pytest.approx(170.0 / 200.0),
             "limit_value": 0.6,
             "breach_amount": pytest.approx((170.0 / 200.0) - 0.6),
+            "notes": None,
         },
         {
             "entity_type": "counterparty",
             "entity_name": "alpha_bank",
             "limit_kind": "absolute_notional",
+            "severity": "fail",
             "actual_value": 120.0,
             "limit_value": 100.0,
             "breach_amount": 20.0,
+            "notes": "Single-name cap.",
         },
         {
             "entity_type": "custom_group",
             "entity_name": "trend_energy",
             "limit_kind": "percent_of_total",
+            "severity": "warning",
             "actual_value": pytest.approx(120.0 / 200.0),
             "limit_value": 0.4,
             "breach_amount": pytest.approx((120.0 / 200.0) - 0.4),
+            "notes": None,
         },
         {
             "entity_type": "fcm",
             "entity_name": "fcm_one",
             "limit_kind": "percent_of_total",
+            "severity": "warning",
             "actual_value": pytest.approx(170.0 / 200.0),
             "limit_value": 0.65,
             "breach_amount": pytest.approx((170.0 / 200.0) - 0.65),
+            "notes": None,
         },
         {
             "entity_type": "segment",
             "entity_name": "treasury",
             "limit_kind": "percent_of_total",
+            "severity": "warning",
             "actual_value": pytest.approx(90.0 / 200.0),
             "limit_value": 0.2,
             "breach_amount": pytest.approx((90.0 / 200.0) - 0.2),
+            "notes": None,
         },
     ]
 
@@ -240,8 +252,11 @@ def test_write_limit_breaches_csv_writes_expected_rows(tmp_path: Path) -> None:
 
     assert out.exists()
     lines = out.read_text(encoding="utf-8").strip().splitlines()
-    assert lines[0] == "entity_type,entity_name,limit_kind,actual_value,limit_value,breach_amount"
-    assert "counterparty,a,absolute_notional,11.0,10.0,1.0" in lines[1:]
+    assert (
+        lines[0]
+        == "entity_type,entity_name,limit_kind,severity,actual_value,limit_value,breach_amount,notes"
+    )
+    assert "counterparty,a,absolute_notional,warning,11.0,10.0,1.0," in lines[1:]
 
 
 def test_find_missing_limit_entities_returns_sorted_missing_targets() -> None:
@@ -279,3 +294,29 @@ def test_find_missing_limit_entities_returns_sorted_missing_targets() -> None:
         {"entity_type": "counterparty", "entity_name": "missing_name"},
         {"entity_type": "fcm", "entity_name": "fcm_missing"},
     ]
+
+
+def test_check_limits_skips_disabled_limits_for_breaches_and_missing_entities() -> None:
+    exposures = [{"counterparty": "A", "notional": 25.0}]
+    limits_cfg = {
+        "schema_version": 1,
+        "limits": [
+            {
+                "entity_type": "counterparty",
+                "entity_name": "A",
+                "limit_value": 10.0,
+                "limit_kind": "absolute_notional",
+                "enabled": False,
+            },
+            {
+                "entity_type": "counterparty",
+                "entity_name": "Missing",
+                "limit_value": 10.0,
+                "limit_kind": "absolute_notional",
+                "enabled": False,
+            },
+        ],
+    }
+
+    assert _as_records(check_limits(exposures, limits_cfg)) == []
+    assert find_missing_limit_entities(exposures, limits_cfg) == []

--- a/tests/integration/test_cli_run.py
+++ b/tests/integration/test_cli_run.py
@@ -21,6 +21,7 @@ def _write_workflow_config(
 
     lines = [
         "as_of_date: 2025-12-31",
+        "enable_ppt_output: false",
         f"mosers_all_programs_xlsx: {fixtures_root / 'MOSERS Counterparty Risk Summary 12-31-2025 - All Programs.xlsx'}",
         f"mosers_ex_trend_xlsx: {ex_trend_path}",
         f"mosers_trend_xlsx: {fixtures_root / 'MOSERS Counterparty Risk Summary 12-31-2025 - Trend.xlsx'}",

--- a/tests/pipeline/test_manifest_schema.py
+++ b/tests/pipeline/test_manifest_schema.py
@@ -51,9 +51,18 @@ def test_manifest_schema_defines_limit_breach_summary_shape() -> None:
     schema = manifest_schema()
 
     summary = schema["properties"]["limit_breach_summary"]
-    assert summary["required"] == ["has_breaches", "breach_count", "report_path", "warning_banner"]
+    assert summary["required"] == [
+        "has_breaches",
+        "breach_count",
+        "warning_breach_count",
+        "fail_breach_count",
+        "report_path",
+        "warning_banner",
+    ]
     assert summary["properties"]["has_breaches"]["type"] == "boolean"
     assert summary["properties"]["breach_count"]["type"] == "integer"
+    assert summary["properties"]["warning_breach_count"]["type"] == "integer"
+    assert summary["properties"]["fail_breach_count"]["type"] == "integer"
     assert summary["properties"]["report_path"]["type"] == ["string", "null"]
     assert summary["properties"]["warning_banner"]["type"] == ["string", "null"]
 

--- a/tests/pipeline/test_run_folder_readme.py
+++ b/tests/pipeline/test_run_folder_readme.py
@@ -86,10 +86,10 @@ def test_run_folder_readme_created_when_ppt_enabled_and_registered_in_manifest(
     (run_dir / "limit_breaches.csv").write_text(
         "\n".join(
             [
-                "entity_type,entity_name,limit_kind,actual_value,limit_value,breach_amount",
-                "counterparty,a,absolute_notional,10,5,5",
-                "counterparty,b,absolute_notional,11,5,6",
-                "counterparty,c,absolute_notional,12,5,7",
+                "entity_type,entity_name,limit_kind,severity,actual_value,limit_value,breach_amount,notes",
+                "counterparty,a,absolute_notional,warning,10,5,5,",
+                "counterparty,b,absolute_notional,fail,11,5,6,",
+                "counterparty,c,absolute_notional,warning,12,5,7,",
             ]
         )
         + "\n",
@@ -113,6 +113,7 @@ def test_run_folder_readme_created_when_ppt_enabled_and_registered_in_manifest(
     assert "\n2." in content
     assert "\n3." in content
     assert "WARNING: Limit Breaches Detected (3)" in content
+    assert "highest severity: fail" in content
     assert "Review breach details: limit_breaches.csv" in content
 
     manifest = ManifestBuilder(

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -2175,6 +2175,152 @@ def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(
     )
 
 
+def test_run_pipeline_limit_breach_summary_uses_warning_severity_when_no_fail_breaches(
+    tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixtures = Path("tests/fixtures")
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "as_of_date: 2025-12-31",
+                f"mosers_all_programs_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - All Programs.xlsx'}",
+                f"mosers_ex_trend_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - Ex Trend.xlsx'}",
+                f"mosers_trend_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - Trend.xlsx'}",
+                f"hist_all_programs_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx'}",
+                f"hist_ex_llc_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - ex LLC 3 Year.xlsx'}",
+                f"hist_llc_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - LLC 3 Year.xlsx'}",
+                f"monthly_pptx: {fixtures / 'Monthly Counterparty Exposure Report.pptx'}",
+                f"output_root: {tmp_path / 'runs'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    limits_path = tmp_path / "config" / "limits.yml"
+    limits_path.parent.mkdir(parents=True, exist_ok=True)
+    limits_path.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "limits:",
+                "  - entity_type: counterparty",
+                "    entity_name: citibank",
+                "    limit_value: 250000000",
+                "    limit_kind: absolute_notional",
+                "    severity: warning",
+                "    notes: Warning-only threshold for review.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    totals = _FakeDataFrame(
+        records=[
+            {
+                "counterparty": "Citibank",
+                "Notional": 300_000_000.0,
+                "NotionalChange": 10_000_000.0,
+            }
+        ]
+    )
+    futures = _FakeDataFrame(
+        records=[
+            {
+                "account": "acct-1",
+                "description": "desc",
+                "class": "Treasury",
+                "fcm": "fcm-a",
+                "clearing_house": "ch-a",
+                "notional": 50_000_000.0,
+            }
+        ]
+    )
+    parsed = {
+        "all_programs": {"totals": totals, "futures": futures},
+        "ex_trend": {"totals": totals, "futures": futures},
+        "trend": {"totals": totals, "futures": futures},
+    }
+    monkeypatch.setattr("counter_risk.pipeline.run._parse_inputs", lambda _: parsed)
+    monkeypatch.setattr(
+        "counter_risk.pipeline.run._update_historical_outputs",
+        lambda *, run_dir, config, parsed_by_variant, as_of_date, formatting_profile, warnings: [],
+    )
+    monkeypatch.setattr(
+        "counter_risk.pipeline.run._write_outputs",
+        lambda *, run_dir, config, as_of_date, warnings: (
+            [],
+            run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SKIPPED),
+        ),
+    )
+
+    run_dir = run_pipeline(config_path)
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["limit_breach_summary"]["has_breaches"] is True
+    assert "warning limit breach detected" in manifest["limit_breach_summary"]["warning_banner"]
+    assert any(
+        "Limit breach summary:" in warning and "warning limit breach detected" in warning
+        for warning in manifest["warnings"]
+    )
+
+
+def test_run_pipeline_invalid_limits_config_fails_during_limit_breach_stage(
+    tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixtures = Path("tests/fixtures")
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "as_of_date: 2025-12-31",
+                f"mosers_all_programs_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - All Programs.xlsx'}",
+                f"mosers_ex_trend_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - Ex Trend.xlsx'}",
+                f"mosers_trend_xlsx: {fixtures / 'MOSERS Counterparty Risk Summary 12-31-2025 - Trend.xlsx'}",
+                f"hist_all_programs_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx'}",
+                f"hist_ex_llc_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - ex LLC 3 Year.xlsx'}",
+                f"hist_llc_3yr_xlsx: {fixtures / 'Historical Counterparty Risk Graphs - LLC 3 Year.xlsx'}",
+                f"monthly_pptx: {fixtures / 'Monthly Counterparty Exposure Report.pptx'}",
+                f"output_root: {tmp_path / 'runs'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    limits_path = tmp_path / "config" / "limits.yml"
+    limits_path.parent.mkdir(parents=True, exist_ok=True)
+    limits_path.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "limits:",
+                "  - entity_type: counterparty",
+                "    entity_name: citibank",
+                "    limit_kind: absolute_notional",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    parsed = _minimal_parsed_by_variant()
+    monkeypatch.setattr("counter_risk.pipeline.run._parse_inputs", lambda _: parsed)
+    monkeypatch.setattr(
+        "counter_risk.pipeline.run._update_historical_outputs",
+        lambda *, run_dir, config, parsed_by_variant, as_of_date, formatting_profile, warnings: [],
+    )
+    monkeypatch.setattr(
+        "counter_risk.pipeline.run._write_outputs",
+        lambda *, run_dir, config, as_of_date, warnings: (
+            [],
+            run_module.PptProcessingResult(status=run_module.PptProcessingStatus.SKIPPED),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Pipeline failed during limit breach stage"):
+        run_pipeline(config_path)
+
+
 def test_run_pipeline_warns_on_missing_limit_entities_by_default(
     tmp_path: Path, fake_pandas: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -2103,6 +2103,8 @@ def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(
                 "    entity_name: citibank",
                 "    limit_value: 250000000",
                 "    limit_kind: absolute_notional",
+                "    severity: fail",
+                "    notes: Single-name risk limit.",
             ]
         )
         + "\n",
@@ -2153,8 +2155,12 @@ def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(
     limit_breaches_path = run_dir / "limit_breaches.csv"
     assert limit_breaches_path.exists()
     content = limit_breaches_path.read_text(encoding="utf-8")
-    assert "entity_type,entity_name,limit_kind,actual_value,limit_value,breach_amount" in content
-    assert "counterparty,citibank,absolute_notional" in content
+    assert (
+        "entity_type,entity_name,limit_kind,severity,actual_value,limit_value,breach_amount,notes"
+        in content
+    )
+    assert "counterparty,citibank,absolute_notional,fail" in content
+    assert "Single-name risk limit." in content
 
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
     assert "limit_breaches.csv" in manifest["output_paths"]
@@ -2162,6 +2168,7 @@ def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(
     assert manifest["limit_breach_summary"]["breach_count"] >= 1
     assert manifest["limit_breach_summary"]["report_path"] == "limit_breaches.csv"
     assert "limit_breaches.csv" in manifest["limit_breach_summary"]["warning_banner"]
+    assert "fail limit" in manifest["limit_breach_summary"]["warning_banner"]
     assert any(
         "Limit breach summary:" in warning and "limit_breaches.csv" in warning
         for warning in manifest["warnings"]

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -2169,6 +2169,8 @@ def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(
     breach_row_count = max(0, len(csv_rows) - 1)
     assert breach_row_count >= 1
     assert manifest["limit_breach_summary"]["breach_count"] == breach_row_count
+    assert manifest["limit_breach_summary"]["warning_breach_count"] == 0
+    assert manifest["limit_breach_summary"]["fail_breach_count"] == breach_row_count
     assert manifest["limit_breach_summary"]["report_path"] == "limit_breaches.csv"
     assert "limit_breaches.csv" in manifest["limit_breach_summary"]["warning_banner"]
     assert "fail limit" in manifest["limit_breach_summary"]["warning_banner"]
@@ -2261,6 +2263,8 @@ def test_run_pipeline_limit_breach_summary_uses_warning_severity_when_no_fail_br
     run_dir = run_pipeline(config_path)
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["limit_breach_summary"]["has_breaches"] is True
+    assert manifest["limit_breach_summary"]["warning_breach_count"] == 1
+    assert manifest["limit_breach_summary"]["fail_breach_count"] == 0
     assert "warning limit breach detected" in manifest["limit_breach_summary"]["warning_banner"]
     assert any(
         "Limit breach summary:" in warning and "warning limit breach detected" in warning
@@ -2410,6 +2414,8 @@ def test_run_pipeline_warns_on_missing_limit_entities_by_default(
     assert manifest["limit_breach_summary"] == {
         "has_breaches": False,
         "breach_count": 0,
+        "warning_breach_count": 0,
+        "fail_breach_count": 0,
         "report_path": None,
         "warning_banner": None,
     }

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -2165,7 +2165,10 @@ def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
     assert "limit_breaches.csv" in manifest["output_paths"]
     assert manifest["limit_breach_summary"]["has_breaches"] is True
-    assert manifest["limit_breach_summary"]["breach_count"] >= 1
+    csv_rows = [line for line in content.splitlines() if line.strip()]
+    breach_row_count = max(0, len(csv_rows) - 1)
+    assert breach_row_count >= 1
+    assert manifest["limit_breach_summary"]["breach_count"] == breach_row_count
     assert manifest["limit_breach_summary"]["report_path"] == "limit_breaches.csv"
     assert "limit_breaches.csv" in manifest["limit_breach_summary"]["warning_banner"]
     assert "fail limit" in manifest["limit_breach_summary"]["warning_banner"]

--- a/tests/test_gui_runner.py
+++ b/tests/test_gui_runner.py
@@ -16,6 +16,46 @@ from counter_risk.gui.runner import GuiRunState, execute_gui_run, launch_gui
 from counter_risk.runner_launch import resolve_ppt_output_dir
 
 
+def test_load_limit_breach_banner_returns_warning_banner(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "limit_breach_summary": {
+                    "has_breaches": True,
+                    "breach_count": 2,
+                    "report_path": "limit_breaches.csv",
+                    "warning_banner": "2 fail limit breaches detected. Review limit_breaches.csv.",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        gui_runner._load_limit_breach_banner(run_dir)
+        == "2 fail limit breaches detected. Review limit_breaches.csv."
+    )
+
+
+def test_load_limit_breach_banner_returns_none_for_missing_or_invalid_manifest(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    assert gui_runner._load_limit_breach_banner(run_dir) is None
+
+    (run_dir / "manifest.json").write_text("{not json", encoding="utf-8")
+    assert gui_runner._load_limit_breach_banner(run_dir) is None
+
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"limit_breach_summary": {"warning_banner": "  "}}),
+        encoding="utf-8",
+    )
+    assert gui_runner._load_limit_breach_banner(run_dir) is None
+
+
 def test_execute_gui_run_builds_run_args_and_writes_settings(tmp_path: Path) -> None:
     captured: dict[str, list[str]] = {}
 

--- a/tests/test_limit_monitoring_docs.py
+++ b/tests/test_limit_monitoring_docs.py
@@ -20,3 +20,5 @@ def test_limit_monitoring_doc_contains_safe_maintainer_update_process() -> None:
         'pytest tests/test_limits_config.py tests/compute/test_limits.py -m "not slow"' in contents
     )
     assert "test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist" in contents
+    assert "test_run_pipeline_strict_missing_limit_entities_fails" in contents
+    assert "duplicate limit keys are not allowed" in contents

--- a/tests/test_limit_monitoring_docs.py
+++ b/tests/test_limit_monitoring_docs.py
@@ -1,0 +1,22 @@
+"""Validation tests for limit monitoring maintainer documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_limit_monitoring_doc_contains_safe_maintainer_update_process() -> None:
+    doc_path = Path(__file__).resolve().parents[1] / "docs" / "limit_monitoring.md"
+    assert doc_path.is_file()
+
+    contents = doc_path.read_text(encoding="utf-8")
+
+    assert "## Safe Maintainer Update Process" in contents
+    assert "config/limits.yml" in contents
+    assert "`warning` or `fail`" in contents
+    assert "enabled: false" in contents
+    assert "strict_missing_entities: true" in contents
+    assert (
+        'pytest tests/test_limits_config.py tests/compute/test_limits.py -m "not slow"' in contents
+    )
+    assert "test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist" in contents

--- a/tests/test_limits_config.py
+++ b/tests/test_limits_config.py
@@ -118,3 +118,26 @@ def test_load_limits_config_rejects_duplicate_limit_keys(tmp_path: Path) -> None
 
     with pytest.raises(ValueError, match="duplicate limit keys"):
         load_limits_config(config_path)
+
+
+def test_load_limits_config_rejects_duplicate_yaml_keys(tmp_path: Path) -> None:
+    config_path = tmp_path / "limits.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "limits:",
+                "  - entity_type: counterparty",
+                "    entity_name: Citibank",
+                "    limit_value: 100",
+                "    limit_kind: absolute_notional",
+                "    severity: warning",
+                "    severity: fail",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Invalid YAML"):
+        load_limits_config(config_path)

--- a/tests/test_limits_config.py
+++ b/tests/test_limits_config.py
@@ -29,10 +29,12 @@ def test_load_limits_config_supports_optional_notes(tmp_path: Path) -> None:
                 "    entity_name: CME FCM",
                 "    limit_value: 50000000",
                 "    limit_kind: absolute_notional",
+                "    severity: fail",
                 "  - entity_type: custom_group",
                 "    entity_name: Trend Energy",
                 "    limit_value: 0.2",
                 "    limit_kind: percent_of_total",
+                "    enabled: false",
                 "    notes: '   Max concentration for trend energy sleeve.   '",
             ]
         )
@@ -46,6 +48,8 @@ def test_load_limits_config_supports_optional_notes(tmp_path: Path) -> None:
     assert config.limits[1].notes == "Max concentration for trend energy sleeve."
     assert config.limits[0].entity_name == "cme_fcm"
     assert config.limits[1].entity_name == "trend_energy"
+    assert config.limits[0].severity == "fail"
+    assert config.limits[1].enabled is False
 
 
 def test_load_limits_config_rejects_missing_required_fields(tmp_path: Path) -> None:
@@ -80,6 +84,7 @@ def test_load_limits_config_rejects_invalid_types_and_values(tmp_path: Path) -> 
                 "    entity_name: citibank",
                 "    limit_value: -10",
                 "    limit_kind: unknown_kind",
+                "    severity: urgent",
             ]
         )
         + "\n",
@@ -87,4 +92,29 @@ def test_load_limits_config_rejects_invalid_types_and_values(tmp_path: Path) -> 
     )
 
     with pytest.raises(ValueError, match="Limits config validation failed"):
+        load_limits_config(config_path)
+
+
+def test_load_limits_config_rejects_duplicate_limit_keys(tmp_path: Path) -> None:
+    config_path = tmp_path / "limits.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "limits:",
+                "  - entity_type: counterparty",
+                "    entity_name: Citibank",
+                "    limit_value: 100",
+                "    limit_kind: absolute_notional",
+                "  - entity_type: counterparty",
+                "    entity_name: citibank",
+                "    limit_value: 200",
+                "    limit_kind: absolute_notional",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate limit keys"):
         load_limits_config(config_path)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -100,6 +100,32 @@
 - Relay event emitted: `pr_opened active.source_repo=stranske/Counter_Risk active.source_issue=476 active.source_pr=572 active.next_action=wait_for_keepalive`.
 - Next action: keepalive owns PR `#572` for CI, review comments, and follow-up commits. Opener is done with this issue and should select another eligible issue only after cap allows.
 
+## 2026-05-07T15:01Z - opener lane materializing issue #477
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Selected repo: `stranske/Counter_Risk`.
+- Selected issue: `#477` (`[Agent] [M3] Add limit monitoring framework (config-driven limits, breach flags, and operator warnings)`, `priority:normal`, `repo-review-approved`).
+- Branch: `codex/issue-477-limit-monitoring` from fresh `origin/main` in isolated temp clone `/tmp/counter-risk-477-codex-rdtPz2/repo`.
+- PR: pending creation after push.
+- Selection rationale:
+  - ACTION A succeeded; `active.*` was cross-lane informational and did not gate discovery.
+  - Approved queue has `issues_count=0`; live priority discovery governed selection.
+  - High-priority candidates were skipped because they already had linked open or merged verifier-lane PRs (`Manager-Database#979 -> #999`, `Inv-Man-Intake#379 -> #393`, `Inv-Man-Intake#381 -> #400`).
+  - Cap-health before materialization reported `total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`, leaving one opener slot.
+  - `Counter_Risk#477` was the oldest unlinked supported normal-priority implementation issue; no PR matched issue `#477` immediately before commit.
+- Implementation:
+  - Added `severity` and `enabled` fields to limit config entries, with duplicate-key validation across entity type, normalized entity name, and limit kind.
+  - Disabled limits are excluded from missing-entity checks and breach calculations.
+  - Limit breach CSV rows now include severity and notes, so operator escalation context stays attached to each breach.
+  - Manifest and run-folder warning banners now include the highest breach severity without changing the manifest schema shape.
+  - Added `docs/limit_monitoring.md` and linked it from README.
+- Validation:
+  - `python -m pytest tests/test_limits_config.py tests/compute/test_limits.py tests/pipeline/test_run_pipeline.py::test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist tests/pipeline/test_run_pipeline.py::test_run_pipeline_warns_on_missing_limit_entities_by_default tests/pipeline/test_run_pipeline.py::test_run_pipeline_strict_missing_limit_entities_fails tests/pipeline/test_run_folder_readme.py::test_run_folder_readme_created_when_ppt_enabled_and_registered_in_manifest tests/pipeline/test_run_folder_outputs.py::test_build_run_folder_readme_content_includes_limit_warning_banner_when_provided tests/pipeline/test_manifest_schema.py::test_manifest_schema_defines_limit_breach_summary_shape tests/pipeline/test_manifest_data_quality.py` -> 26 passed.
+  - `python -m ruff check src/counter_risk/limits_config.py src/counter_risk/compute/limits.py src/counter_risk/pipeline/run.py tests/test_limits_config.py tests/compute/test_limits.py tests/pipeline/test_run_pipeline.py tests/pipeline/test_run_folder_readme.py` -> pass.
+  - `python -m black --check src/counter_risk/limits_config.py src/counter_risk/compute/limits.py src/counter_risk/pipeline/run.py tests/test_limits_config.py tests/compute/test_limits.py tests/pipeline/test_run_pipeline.py tests/pipeline/test_run_folder_readme.py` -> pass.
+  - `python -m mypy src/counter_risk/limits_config.py src/counter_risk/compute/limits.py` -> pass.
+- Next action: push branch, open ready PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit `pr_opened`.
+
 ## 2026-05-01T14:12Z - opener PR opened for issue #471
 
 - Automation: `pd-workloop-resume` (codex opener lane).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -106,7 +106,7 @@
 - Selected repo: `stranske/Counter_Risk`.
 - Selected issue: `#477` (`[Agent] [M3] Add limit monitoring framework (config-driven limits, breach flags, and operator warnings)`, `priority:normal`, `repo-review-approved`).
 - Branch: `codex/issue-477-limit-monitoring` from fresh `origin/main` in isolated temp clone `/tmp/counter-risk-477-codex-rdtPz2/repo`.
-- PR: pending creation after push.
+- PR: `https://github.com/stranske/Counter_Risk/pull/573` (`OPEN`, non-draft, branch `codex/issue-477-limit-monitoring`, labels `agent:codex`, `agents:keepalive`, `autofix`).
 - Selection rationale:
   - ACTION A succeeded; `active.*` was cross-lane informational and did not gate discovery.
   - Approved queue has `issues_count=0`; live priority discovery governed selection.
@@ -124,7 +124,9 @@
   - `python -m ruff check src/counter_risk/limits_config.py src/counter_risk/compute/limits.py src/counter_risk/pipeline/run.py tests/test_limits_config.py tests/compute/test_limits.py tests/pipeline/test_run_pipeline.py tests/pipeline/test_run_folder_readme.py` -> pass.
   - `python -m black --check src/counter_risk/limits_config.py src/counter_risk/compute/limits.py src/counter_risk/pipeline/run.py tests/test_limits_config.py tests/compute/test_limits.py tests/pipeline/test_run_pipeline.py tests/pipeline/test_run_folder_readme.py` -> pass.
   - `python -m mypy src/counter_risk/limits_config.py src/counter_risk/compute/limits.py` -> pass.
-- Next action: push branch, open ready PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit `pr_opened`.
+- Relay: emitted `pr_opened active.source_repo=stranske/Counter_Risk active.source_issue=477 active.source_pr=573 active.next_action=wait_for_keepalive`.
+- Cap state post-PR: 5/5 opener-owned PRs. Keepalive owns PR #573 now; opener should not fix CI or review comments on this lane.
+- Next action: wait for keepalive.
 
 ## 2026-05-01T14:12Z - opener PR opened for issue #471
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:477 -->
> **Source:** Issue #477

Closes #477

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The report should flag breaches against configurable limits, not just display exposures. A limit framework makes policy thresholds visible to operators and downstream review automation.

#### Tasks
- [x] Define `config/limits.yml` with entity type, canonical entity key/name, limit value, limit kind, severity, and notes.
- [x] Validate limit config in `src/counter_risk/limits_config.py`, including duplicate keys, invalid severities, and disabled limits.
- [x] Implement `check_limits(exposures_df, limits_cfg) -> breaches_df` in `src/counter_risk/compute/limits.py` or equivalent.
- [x] Write `limit_breaches.csv` and add a breach summary to `manifest.json`.
- [x] Display a concise Runner UI warning/banner when breaches exist.
- [x] Add synthetic fixture tests for no breach, warning breach, fail breach, unknown entity, disabled limit, and invalid config.
- [x] Document how maintainers should add or revise limits.

#### Acceptance criteria
- [x] A fixture run with a breach writes `limit_breaches.csv` and a manifest breach summary.
- [x] Runner UI surfaces breach status without requiring the operator to open raw CSV files.
- [x] Tests verify severity handling and deterministic breach detection.
- [x] Invalid limit config fails with a clear validation error.
- [x] Documentation explains how maintainers update `config/limits.yml` safely.

<!-- auto-status-summary:end -->