### PR TITLE
Issue #479: Series-inclusion API and registry maintainer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Source choice and overrides are emitted in run warnings, which are persisted in 
 2. Run `mapping_diff_report`.
 3. Interpret `UNMAPPED`, `FALLBACK_MAPPED`, and `SUGGESTIONS` sections.
 
+See [docs/name_registry.md](docs/name_registry.md) for the full maintainer
+process: schema rules, alias collision behavior, per-variant
+`series_included` flags, validation commands, and a review checklist.
+
 ## Repository automation (high level)
 
 This repo is integrated with the central [stranske/Workflows](https://github.com/stranske/Workflows) library.

--- a/docs/name_registry.md
+++ b/docs/name_registry.md
@@ -1,0 +1,113 @@
+# Name Registry Maintainer Process
+
+The name registry at `config/name_registry.yml` is the canonical source of
+counterparty and clearing-house aliases used by the Counter Risk pipeline.
+Parsers and writers route through `counter_risk.normalize.resolve_counterparty`
+and `resolve_clearing_house`, which consult the registry first and fall back to
+a small set of hardcoded mappings only when the registry has no match.
+
+This page explains how to update the registry safely.
+
+## Schema
+
+```yaml
+schema_version: 1
+entries:
+  - canonical_key: bank_of_america         # snake_case identifier, globally unique
+    display_name: Bank of America          # workbook/PPT label
+    aliases:                               # at least one; deduplicated case/whitespace
+      - Bank of America
+      - Bank of America NA
+    series_included:                       # optional; defaults to all-True when omitted
+      all_programs: true
+      ex_trend: true
+      trend: true
+```
+
+The schema is enforced by `counter_risk.name_registry.NameRegistryConfig`
+(pydantic). Aliases collide if any two normalized forms (apostrophe, dash, and
+whitespace canonicalization plus casefold) clash across different
+`canonical_key`s. The validator rejects collisions and duplicate
+`canonical_key`s outright.
+
+## Adding or editing an entry
+
+1. Decide whether the new name belongs to an existing entry (add an alias) or
+   needs its own `canonical_key` (separate counterparty).
+2. Edit `config/name_registry.yml`. Keep `canonical_key` snake_case
+   (`^[a-z0-9]+(?:_[a-z0-9]+)*$`); set `display_name` to the label that should
+   appear in workbook headers and PPT outputs.
+3. Add every observed spelling to `aliases`. Curly quotes, em-dashes, and
+   doubled spaces are normalized at lookup time, so you do not need to repeat
+   punctuation variants.
+4. Validate before committing:
+
+   ```bash
+   python -c "from counter_risk.name_registry import load_name_registry; load_name_registry()"
+   ```
+
+   A `ValueError` with `Name registry validation failed:` is raised if the
+   schema, alias collision, or duplicate-key rules are violated. Surface the
+   exact offending field from the message and fix it.
+5. Run the focused tests:
+
+   ```bash
+   python -m pytest tests/test_name_registry.py tests/test_normalization_registry_first.py
+   ```
+
+## Per-variant inclusion flags
+
+Some counterparties belong to certain reporting variants only. Use
+`series_included` to express that. The flag set is:
+
+| Variant | Description |
+| --- | --- |
+| `all_programs` | Combined all-programs reporting |
+| `ex_trend` | Ex-Trend (LLC) reporting |
+| `trend` | Trend-only reporting |
+
+Omit the block when the entry should appear in every variant. When present, all
+three keys are required (pydantic `extra=forbid`). At runtime call
+`NameRegistryConfig.is_series_included(canonical_key, variant)` to check
+whether a name participates in a given variant; unknown canonical keys default
+to `True` so the pipeline does not silently drop names the registry has not yet
+caught up to.
+
+## Finding unmapped names
+
+Run the mapping diff report whenever you ingest a new month or onboard a new
+data source. It compares observed raw names against the registry and groups
+them as unmapped, fallback-mapped, or registry-mapped:
+
+```bash
+python -m counter_risk.cli.mapping_diff_report \
+  --normalization-name "Bank of America NA" \
+  --normalization-name "Citigroup" \
+  --reconciliation-name "ICE Clear Europe"
+```
+
+Output sections:
+
+- `UNMAPPED` — raw names with no registry or fallback hit. Add these to the
+  registry as new `canonical_key`s or as aliases on an existing entry.
+- `FALLBACK_MAPPED` — names matched only by the legacy fallback table in
+  `counter_risk.normalize`. Promote them into the registry to keep
+  `source="registry"` for new outputs.
+- `SUGGESTIONS` — title-cased candidates for unmapped names; treat as a starting
+  point only.
+- `NAME_RESOLUTIONS` — full per-name trace for review.
+
+## Review checklist
+
+Before merging an edit:
+
+- [ ] `canonical_key` is snake_case and unique across the file.
+- [ ] At least one alias exists for every entry.
+- [ ] No alias is shared across different `canonical_key`s after
+      whitespace/apostrophe/dash canonicalization.
+- [ ] `display_name` matches what should appear in operator-facing outputs.
+- [ ] `series_included` is set only when at least one variant should be
+      excluded.
+- [ ] `python -m pytest tests/test_name_registry.py` passes.
+- [ ] Mapping diff report on the latest source data shows zero `UNMAPPED`
+      counterparties (or each one has a recorded reason for staying out).

--- a/src/counter_risk/name_registry.py
+++ b/src/counter_risk/name_registry.py
@@ -9,6 +9,10 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
+# Variants whose inclusion can be toggled per registry entry.
+SeriesVariant = Literal["all_programs", "ex_trend", "trend"]
+SERIES_VARIANTS: tuple[SeriesVariant, ...] = ("all_programs", "ex_trend", "trend")
+
 _CANONICAL_KEY_PATTERN = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
 
 # Mirror the same substitutions as normalize.canonicalize_name to keep alias
@@ -113,6 +117,24 @@ class NameRegistryConfig(BaseModel):
                         f"{alias!r} maps to both {existing!r} and {entry.canonical_key!r}"
                     )
         return self
+
+    def is_series_included(self, canonical_key: str, variant: SeriesVariant) -> bool:
+        """Return whether ``canonical_key`` participates in ``variant``.
+
+        Entries with no ``series_included`` block default to inclusion in every
+        variant, matching the historical "include unless told otherwise" rule
+        used before per-variant flags existed. Unknown ``canonical_key`` values
+        also default to ``True`` so callers do not silently drop names that the
+        registry has not yet caught up to.
+        """
+        if variant not in SERIES_VARIANTS:
+            raise ValueError(f"Unknown variant {variant!r}; expected one of {SERIES_VARIANTS!r}.")
+        for entry in self.entries:
+            if entry.canonical_key == canonical_key:
+                if entry.series_included is None:
+                    return True
+                return bool(getattr(entry.series_included, variant))
+        return True
 
 
 def _format_registry_validation_error(error: ValidationError) -> str:

--- a/tests/test_name_registry.py
+++ b/tests/test_name_registry.py
@@ -282,3 +282,31 @@ def test_load_name_registry_rejects_dash_variant_duplicate_across_entries(tmp_pa
 
     with pytest.raises(ValueError, match="Name registry validation failed"):
         load_name_registry(config_path)
+
+
+def test_is_series_included_defaults_true_when_flags_omitted() -> None:
+    registry = load_name_registry(Path("config/name_registry.yml"))
+
+    for variant in ("all_programs", "ex_trend", "trend"):
+        assert registry.is_series_included("bank_of_america", variant) is True
+
+
+def test_is_series_included_respects_per_variant_flags() -> None:
+    registry = load_name_registry(Path("config/name_registry.yml"))
+
+    assert registry.is_series_included("ice_euro", "all_programs") is True
+    assert registry.is_series_included("ice_euro", "ex_trend") is True
+    assert registry.is_series_included("ice_euro", "trend") is False
+
+
+def test_is_series_included_returns_true_for_unknown_canonical_key() -> None:
+    registry = load_name_registry(Path("config/name_registry.yml"))
+
+    assert registry.is_series_included("not_in_registry", "trend") is True
+
+
+def test_is_series_included_rejects_unknown_variant() -> None:
+    registry = load_name_registry(Path("config/name_registry.yml"))
+
+    with pytest.raises(ValueError, match="Unknown variant"):
+        registry.is_series_included("ice_euro", "unrecognized_variant")  # type: ignore[arg-type]

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,35 @@
 # Counter_Risk Workloop State
 
+## 2026-05-07T18:07:00Z - opener lane PR materialization for issue #479
+
+- Automation: `pd-workloop-resume` (claude_code opener lane).
+- Source repo: `stranske/Counter_Risk`.
+- Source issue: `#479` (`[Agent] [M1] Add a counterparty mapping registry + maintainers workflow for updating series headers safely`).
+- Branch: `claude/issue-479-counterparty-name-registry`.
+- Selection: Selected as the oldest unlinked priority:normal issue across the
+  fleet (createdAt 2026-04-26T21:33:46Z). All priority:high were already
+  linked (Inv-Man-Intake#379→#393 MERGED, Inv-Man-Intake#381→#400 MERGED,
+  Manager-Database#979→#999 OPEN). Cap-health at selection: 4/5 opener-owned
+  open (codex: Counter_Risk#574, #573, #526, Manager-Database#999; claude: 0).
+- Implementation:
+  - Added `is_series_included(canonical_key, variant)` API to
+    `NameRegistryConfig` so the existing `series_included` YAML block has a
+    consumer-facing helper. Defaults to `True` for entries without flags or
+    unknown canonical keys; rejects unrecognized variant names.
+  - Added focused tests in `tests/test_name_registry.py` covering default
+    inclusion, per-variant respect (using `ice_euro`'s `trend: false` flag),
+    unknown-canonical-key fallthrough, and unknown-variant rejection.
+  - Added `docs/name_registry.md` documenting the maintainer process: schema,
+    add/edit workflow, validation command, per-variant flags, mapping diff
+    workflow, and review checklist. Linked from README's Name Registry
+    Workflow section.
+- Validation passed:
+  - `python -m pytest tests/test_name_registry.py tests/test_normalization_registry_first.py tests/test_mapping_diff_report.py tests/test_mapping_diff_report_cli.py tests/test_normalize.py --no-cov` -> 103 passed.
+  - `python -m ruff check src/counter_risk/name_registry.py tests/test_name_registry.py` -> All checks passed.
+  - `python -m black --check src/counter_risk/name_registry.py tests/test_name_registry.py` -> 2 files would be left unchanged.
+  - `python -m mypy src/counter_risk/name_registry.py` -> Success: no issues found.
+- Pre-push dedup recheck: `gh pr list --repo stranske/Counter_Risk --search "479"` returned only PR #521 (issue #469 false positive). No PR exists for issue #479. Cap still 4/5.
+
 ## 2026-05-07T13:58:14Z - opener lane PR materialization for issue #476
 
 - Automation: `pd-workloop-resume` (codex opener lane).


### PR DESCRIPTION
Closes #479.

## Summary

Counter_Risk's `config/name_registry.yml` already carries optional
`series_included` flags for per-variant inclusion, but no runtime code
consumes them, and there is no maintainer documentation explaining the
schema, alias rules, or mapping-diff workflow. This PR closes both gaps
without touching the existing parser/writer wiring.

- Adds `NameRegistryConfig.is_series_included(canonical_key, variant)`
  with safe defaults: entries without flags include in every variant,
  unknown canonical keys default to `True` so the pipeline does not
  silently drop names the registry has not caught up to. Unknown
  variant names raise `ValueError`.
- Adds `docs/name_registry.md` documenting schema, add/edit workflow,
  validation command (`load_name_registry()`), per-variant flag
  semantics, mapping-diff CLI usage, and a review checklist. Linked
  from the README's existing Name Registry Workflow section.
- Adds focused tests in `tests/test_name_registry.py` exercising the
  default-True behavior, per-variant respect (using the existing
  `ice_euro` entry's `trend: false`), unknown-canonical-key fallthrough,
  and unknown-variant rejection.

## Acceptance criteria mapping (issue #479)

- Known aliases resolve to canonical keys before workbook/header
  matching — already covered by `resolve_counterparty` /
  `resolve_clearing_house` and existing tests
  (`tests/test_normalization_registry_first.py`).
- Unknown source names appear in a mapping diff report — already covered
  by `counter_risk.cli.mapping_diff_report` and existing tests.
- Tests cover alias matching, display names, unknown-name reporting, and
  series-inclusion flags — series-inclusion tests added in this PR; the
  rest were already in place.
- Documentation tells maintainers how to update the registry safely —
  added `docs/name_registry.md` and linked from README in this PR.
- Registry lookups use the same canonicalization helper as
  parser/workbook/PPT matching — already covered: parser.py and
  writer.py call `normalize_counterparty` / `normalize_clearing_house`
  which delegate through `_load_alias_lookup` /
  `canonicalize_name`.

## Test plan

- [x] `python -m pytest tests/test_name_registry.py tests/test_normalization_registry_first.py tests/test_mapping_diff_report.py tests/test_mapping_diff_report_cli.py tests/test_normalize.py --no-cov` (103 passed)
- [x] `python -m ruff check src/counter_risk/name_registry.py tests/test_name_registry.py`
- [x] `python -m black --check src/counter_risk/name_registry.py tests/test_name_registry.py`
- [x] `python -m mypy src/counter_risk/name_registry.py`

## Notes

This PR keeps scope tight. The `series_included` flag now has a
documented runtime API (`is_series_included`) that future work can call
from the historical-workbook generator if/when per-variant filtering is
needed there; this PR does not change variant-filtering behavior in the
existing pipeline.