### PR TITLE
Issue #476: use canonical risk proxy tie-breaks

### DIFF
--- a/docs/risk_proxy_outputs.md
+++ b/docs/risk_proxy_outputs.md
@@ -20,8 +20,9 @@ do not always carry volatility, position, or prior-period delta columns.
 | `risk_proxy_notional_annualized_volatility` | `Notional`, `AnnualizedVolatility` | `Notional * AnnualizedVolatility` |
 | `risk_proxy_position_usd_vol` | `PositionUSD`, `Vol` | `PositionUSD * Vol` |
 
-Rankings sort by descending absolute proxy value, then by counterparty name
-case-insensitively. This makes tied rows stable across reruns.
+Rankings sort by descending absolute proxy value, then by canonical
+counterparty key case-insensitively. This makes tied rows stable across reruns
+even when source files use aliases or display-name variants.
 
 ## Top movers
 

--- a/docs/risk_proxy_outputs.md
+++ b/docs/risk_proxy_outputs.md
@@ -24,6 +24,12 @@ Rankings sort by descending absolute proxy value, then by canonical
 counterparty key case-insensitively. This makes tied rows stable across reruns
 even when source files use aliases or display-name variants.
 
+Input aliases accepted by `compute_risk_proxies`:
+
+- `AnnualizedVolatility` or `annualized_volatility`
+- `PositionUSD` or `position_usd`
+- `Vol` or `vol`
+
 ## Top movers
 
 `risk_top_movers.csv` is written only when prior-period delta columns are
@@ -37,9 +43,19 @@ absolute delta, rank, and the delta source column used. Missing prior-period
 delta columns skip only the mover output for that proxy; rankings still write
 when current proxy inputs exist.
 
+Mover calculations are:
+
+- `current_proxy_value = current_input * volatility_input`
+- `delta = prior_period_delta_input * volatility_input`
+- `prior_proxy_value = current_proxy_value - delta`
+
 ## Missing data behavior
 
 When required columns are missing, the pipeline records warnings and marks the
 proxy as `skipped` under `manifest["risk_proxy_summary"]["by_variant"]`.
 Missing volatility or position inputs do not fail the run. Missing mover delta
 inputs skip only `risk_top_movers.csv` for the affected proxy.
+
+If no proxy has required current-period inputs, `risk_rankings.csv` is skipped
+with a warning. If proxies are computed but no usable prior-period deltas exist,
+`risk_top_movers.csv` is skipped with a warning.

--- a/src/counter_risk/compute/rollups.py
+++ b/src/counter_risk/compute/rollups.py
@@ -41,6 +41,10 @@ _TOP_CHANGE_COLUMNS = (
 )
 _NOTIONAL_PROXY_COLUMNS = ("Notional", "AnnualizedVolatility")
 _POSITION_PROXY_COLUMNS = ("PositionUSD", "Vol")
+_NOTIONAL_PROXY_NOTIONAL_KEYS = ("Notional", "notional")
+_NOTIONAL_PROXY_VOLATILITY_KEYS = ("AnnualizedVolatility", "annualized_volatility")
+_POSITION_PROXY_USD_KEYS = ("PositionUSD", "position_usd")
+_POSITION_PROXY_VOL_KEYS = ("Vol", "vol")
 _RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN = "risk_proxy_notional_annualized_volatility"
 _RISK_PROXY_POSITION_VOL_COLUMN = "risk_proxy_position_usd_vol"
 
@@ -159,6 +163,10 @@ def _column_names_from_rows(table: Any, rows: list[Mapping[str, Any]]) -> tuple[
             seen.add(normalized_key)
             ordered_columns.append(normalized_key)
     return tuple(ordered_columns)
+
+
+def _has_any_column(columns: tuple[str, ...], candidates: tuple[str, ...]) -> bool:
+    return any(candidate in columns for candidate in candidates)
 
 
 def compute_totals(exposures_df: Any) -> Any:
@@ -437,17 +445,26 @@ def compute_risk_proxies(exposures_df: Any) -> Any:
 
     rows = _iter_rows(exposures_df, arg_name="exposures_df")
     columns = _column_names_from_rows(exposures_df, rows)
-    has_notional_proxy_inputs = all(column in columns for column in _NOTIONAL_PROXY_COLUMNS)
-    has_position_proxy_inputs = all(column in columns for column in _POSITION_PROXY_COLUMNS)
+    has_notional_proxy_inputs = _has_any_column(
+        columns, _NOTIONAL_PROXY_NOTIONAL_KEYS
+    ) and _has_any_column(columns, _NOTIONAL_PROXY_VOLATILITY_KEYS)
+    has_position_proxy_inputs = _has_any_column(
+        columns, _POSITION_PROXY_USD_KEYS
+    ) and _has_any_column(columns, _POSITION_PROXY_VOL_KEYS)
 
     proxy_records: list[dict[str, Any]] = []
     for row in rows:
         normalized_row = dict(row)
         if has_notional_proxy_inputs:
-            notional = _find_numeric(row, ("Notional",), field="Notional", default=0.0)
+            notional = _find_numeric(
+                row,
+                _NOTIONAL_PROXY_NOTIONAL_KEYS,
+                field="Notional",
+                default=0.0,
+            )
             annualized_volatility = _find_numeric(
                 row,
-                ("AnnualizedVolatility",),
+                _NOTIONAL_PROXY_VOLATILITY_KEYS,
                 field="AnnualizedVolatility",
                 default=0.0,
             )
@@ -456,8 +473,18 @@ def compute_risk_proxies(exposures_df: Any) -> Any:
             )
 
         if has_position_proxy_inputs:
-            position_usd = _find_numeric(row, ("PositionUSD",), field="PositionUSD", default=0.0)
-            volatility = _find_numeric(row, ("Vol",), field="Vol", default=0.0)
+            position_usd = _find_numeric(
+                row,
+                _POSITION_PROXY_USD_KEYS,
+                field="PositionUSD",
+                default=0.0,
+            )
+            volatility = _find_numeric(
+                row,
+                _POSITION_PROXY_VOL_KEYS,
+                field="Vol",
+                default=0.0,
+            )
             normalized_row[_RISK_PROXY_POSITION_VOL_COLUMN] = position_usd * volatility
 
         proxy_records.append(normalized_row)

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -1514,14 +1514,20 @@ def _write_risk_outputs(
                     f"(one of: {', '.join(_NOTIONAL_CHANGE_FIELDS_FOR_MOVER_DELTA)})"
                 )
             else:
-                mover_inputs_available = True
-                mover_rows.extend(
-                    _mover_rows_for_notional_proxy(
-                        variant=variant,
-                        records=totals_records,
-                        change_field=change_field,
-                    )
+                proxy_mover_rows = _mover_rows_for_notional_proxy(
+                    variant=variant,
+                    records=totals_records,
+                    change_field=change_field,
                 )
+                if proxy_mover_rows:
+                    mover_inputs_available = True
+                    mover_rows.extend(proxy_mover_rows)
+                else:
+                    warnings.append(
+                        "risk top movers skipped for "
+                        f"{variant} {_RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN}: "
+                        "prior-period notional delta values unavailable or invalid"
+                    )
 
         if has_position_vol:
             ranking_rows.extend(
@@ -1542,14 +1548,20 @@ def _write_risk_outputs(
                     f"(one of: {', '.join(_POSITION_CHANGE_FIELDS_FOR_MOVER_DELTA)})"
                 )
             else:
-                mover_inputs_available = True
-                mover_rows.extend(
-                    _mover_rows_for_position_proxy(
-                        variant=variant,
-                        records=totals_records,
-                        change_field=change_field,
-                    )
+                proxy_mover_rows = _mover_rows_for_position_proxy(
+                    variant=variant,
+                    records=totals_records,
+                    change_field=change_field,
                 )
+                if proxy_mover_rows:
+                    mover_inputs_available = True
+                    mover_rows.extend(proxy_mover_rows)
+                else:
+                    warnings.append(
+                        "risk top movers skipped for "
+                        f"{variant} {_RISK_PROXY_POSITION_VOL_COLUMN}: "
+                        "prior-period position delta values unavailable or invalid"
+                    )
 
     output_paths: list[Path] = []
     if ranking_rows:
@@ -1781,16 +1793,19 @@ def _mover_rows_for_notional_proxy(
 ) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for record in records:
-        notional = _to_float(record.get("Notional"))
-        volatility = _to_float(record.get("AnnualizedVolatility"))
-        notional_delta = _to_float(record.get(change_field))
+        counterparty = str(record.get("counterparty", "")).strip()
+        notional = _coerce_float_or_none(record.get("Notional"))
+        volatility = _coerce_float_or_none(record.get("AnnualizedVolatility"))
+        notional_delta = _coerce_float_or_none(record.get(change_field))
+        if not counterparty or notional is None or volatility is None or notional_delta is None:
+            continue
         current_proxy = notional * volatility
         delta_proxy = notional_delta * volatility
         prior_proxy = current_proxy - delta_proxy
         rows.append(
             {
                 "variant": variant,
-                "counterparty": str(record.get("counterparty", "")),
+                "counterparty": counterparty,
                 "proxy_name": _RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN,
                 "current_proxy_value": current_proxy,
                 "prior_proxy_value": prior_proxy,
@@ -1812,16 +1827,19 @@ def _mover_rows_for_position_proxy(
 ) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for record in records:
-        position = _to_float(record.get("PositionUSD"))
-        volatility = _to_float(record.get("Vol"))
-        position_delta = _to_float(record.get(change_field))
+        counterparty = str(record.get("counterparty", "")).strip()
+        position = _coerce_float_or_none(record.get("PositionUSD"))
+        volatility = _coerce_float_or_none(record.get("Vol"))
+        position_delta = _coerce_float_or_none(record.get(change_field))
+        if not counterparty or position is None or volatility is None or position_delta is None:
+            continue
         current_proxy = position * volatility
         delta_proxy = position_delta * volatility
         prior_proxy = current_proxy - delta_proxy
         rows.append(
             {
                 "variant": variant,
-                "counterparty": str(record.get("counterparty", "")),
+                "counterparty": counterparty,
                 "proxy_name": _RISK_PROXY_POSITION_VOL_COLUMN,
                 "current_proxy_value": current_proxy,
                 "prior_proxy_value": prior_proxy,
@@ -1847,9 +1865,12 @@ def _first_available_field(*, columns: set[str], candidates: tuple[str, ...]) ->
 
 def _coerce_float_or_none(value: Any) -> float | None:
     try:
-        return float(value)
+        number = float(value)
     except (TypeError, ValueError):
         return None
+    if not math.isfinite(number):
+        return None
+    return number
 
 
 def _write_csv_rows(*, path: Path, fieldnames: tuple[str, ...], rows: list[dict[str, Any]]) -> None:

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -1474,14 +1474,20 @@ def _write_risk_outputs(
         has_notional_vol = "Notional" in columns and "AnnualizedVolatility" in columns
         has_position_vol = "PositionUSD" in columns and "Vol" in columns
         if not has_notional_vol:
+            missing_notional_proxy_columns = [
+                column for column in ("Notional", "AnnualizedVolatility") if column not in columns
+            ]
             warnings.append(
                 "risk proxy notional-volatility skipped for "
-                f"{variant}: requires Notional and AnnualizedVolatility columns"
+                f"{variant}: missing required columns ({', '.join(missing_notional_proxy_columns)})"
             )
         if not has_position_vol:
+            missing_position_proxy_columns = [
+                column for column in ("PositionUSD", "Vol") if column not in columns
+            ]
             warnings.append(
                 "risk proxy position-volatility skipped for "
-                f"{variant}: requires PositionUSD and Vol columns"
+                f"{variant}: missing required columns ({', '.join(missing_position_proxy_columns)})"
             )
         if not has_notional_vol and not has_position_vol:
             continue
@@ -1504,7 +1510,8 @@ def _write_risk_outputs(
                 warnings.append(
                     "risk top movers skipped for "
                     f"{variant} {_RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN}: "
-                    "requires a notional prior-month delta column"
+                    "missing prior-period notional delta column "
+                    f"(one of: {', '.join(_NOTIONAL_CHANGE_FIELDS_FOR_MOVER_DELTA)})"
                 )
             else:
                 mover_inputs_available = True
@@ -1531,7 +1538,8 @@ def _write_risk_outputs(
                 warnings.append(
                     "risk top movers skipped for "
                     f"{variant} {_RISK_PROXY_POSITION_VOL_COLUMN}: "
-                    "requires a position prior-month delta column"
+                    "missing prior-period position delta column "
+                    f"(one of: {', '.join(_POSITION_CHANGE_FIELDS_FOR_MOVER_DELTA)})"
                 )
             else:
                 mover_inputs_available = True

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -1463,7 +1463,8 @@ def _write_risk_outputs(
     ranking_inputs_available = False
     mover_inputs_available = False
 
-    for variant, parsed_sections in parsed_by_variant.items():
+    for variant in sorted(parsed_by_variant, key=str.casefold):
+        parsed_sections = parsed_by_variant[variant]
         totals_table = parsed_sections.get("totals", [])
         totals_records = _records(totals_table)
         if not totals_records:

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -197,6 +197,10 @@ _REQUIRED_INPUT_FIELDS: tuple[str, ...] = (
 )
 _RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN = "risk_proxy_notional_annualized_volatility"
 _RISK_PROXY_POSITION_VOL_COLUMN = "risk_proxy_position_usd_vol"
+_RISK_PROXY_FORMULAS: dict[str, str] = {
+    _RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN: "Notional * AnnualizedVolatility",
+    _RISK_PROXY_POSITION_VOL_COLUMN: "PositionUSD * Vol",
+}
 _NOTIONAL_CHANGE_FIELDS_FOR_MOVER_DELTA: tuple[str, ...] = (
     "NotionalChange",
     "NotionalChangeFromPriorMonth",
@@ -1572,6 +1576,7 @@ def _write_risk_outputs(
                 "variant",
                 "counterparty",
                 "proxy_name",
+                "formula",
                 "proxy_value",
                 "rank",
             ),
@@ -1592,6 +1597,7 @@ def _write_risk_outputs(
                 "variant",
                 "counterparty",
                 "proxy_name",
+                "formula",
                 "current_proxy_value",
                 "prior_proxy_value",
                 "delta",
@@ -1775,6 +1781,7 @@ def _rank_proxy_rows(
                 "variant": variant,
                 "counterparty": str(record.get("counterparty", "")),
                 "proxy_name": proxy_column,
+                "formula": _RISK_PROXY_FORMULAS.get(proxy_column, ""),
                 "proxy_value": _to_float(record.get(proxy_column)),
                 "rank": index,
             }
@@ -1807,6 +1814,7 @@ def _mover_rows_for_notional_proxy(
                 "variant": variant,
                 "counterparty": counterparty,
                 "proxy_name": _RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN,
+                "formula": _RISK_PROXY_FORMULAS[_RISK_PROXY_NOTIONAL_VOLATILITY_COLUMN],
                 "current_proxy_value": current_proxy,
                 "prior_proxy_value": prior_proxy,
                 "delta": delta_proxy,
@@ -1841,6 +1849,7 @@ def _mover_rows_for_position_proxy(
                 "variant": variant,
                 "counterparty": counterparty,
                 "proxy_name": _RISK_PROXY_POSITION_VOL_COLUMN,
+                "formula": _RISK_PROXY_FORMULAS[_RISK_PROXY_POSITION_VOL_COLUMN],
                 "current_proxy_value": current_proxy,
                 "prior_proxy_value": prior_proxy,
                 "delta": delta_proxy,

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -1744,7 +1744,7 @@ def _rank_proxy_rows(
         records,
         key=lambda record: (
             -abs(_to_float(record.get(proxy_column))),
-            str(record.get("counterparty", "")).casefold(),
+            _counterparty_canonical_sort_key(record),
         ),
     )
     rows: list[dict[str, Any]] = []
@@ -1759,6 +1759,12 @@ def _rank_proxy_rows(
             }
         )
     return rows
+
+
+def _counterparty_canonical_sort_key(record: Mapping[str, Any]) -> str:
+    counterparty = str(record.get("counterparty", ""))
+    resolution = normalize_counterparty_with_source(counterparty)
+    return str(resolution.canonical_key or resolution.canonical_name).casefold()
 
 
 def _mover_rows_for_notional_proxy(
@@ -1784,7 +1790,9 @@ def _mover_rows_for_notional_proxy(
                 "delta_source_column": change_field,
             }
         )
-    rows.sort(key=lambda row: (-abs(_to_float(row["delta"])), str(row["counterparty"]).casefold()))
+    rows.sort(
+        key=lambda row: (-abs(_to_float(row["delta"])), _counterparty_canonical_sort_key(row))
+    )
     for index, row in enumerate(rows, start=1):
         row["rank"] = index
     return rows
@@ -1813,7 +1821,9 @@ def _mover_rows_for_position_proxy(
                 "delta_source_column": change_field,
             }
         )
-    rows.sort(key=lambda row: (-abs(_to_float(row["delta"])), str(row["counterparty"]).casefold()))
+    rows.sort(
+        key=lambda row: (-abs(_to_float(row["delta"])), _counterparty_canonical_sort_key(row))
+    )
     for index, row in enumerate(rows, start=1):
         row["rank"] = index
     return rows

--- a/tests/compute/test_rollups.py
+++ b/tests/compute/test_rollups.py
@@ -317,3 +317,22 @@ def test_compute_risk_proxies_calculates_both_proxies_when_all_inputs_exist(
 def test_compute_risk_proxies_requires_dataframe_like_or_iterable_of_mappings() -> None:
     with pytest.raises(TypeError, match="exposures_df must be a pandas-like DataFrame"):
         compute_risk_proxies(1.23)
+
+
+def test_compute_risk_proxies_supports_lowercase_proxy_input_aliases() -> None:
+    records = _as_records(
+        compute_risk_proxies(
+            [
+                {
+                    "counterparty": "A",
+                    "notional": 50.0,
+                    "annualized_volatility": 0.2,
+                    "position_usd": 2000.0,
+                    "vol": 0.1,
+                }
+            ]
+        )
+    )
+
+    assert records[0]["risk_proxy_notional_annualized_volatility"] == pytest.approx(10.0)
+    assert records[0]["risk_proxy_position_usd_vol"] == pytest.approx(200.0)

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1796,7 +1796,16 @@ def test_write_risk_outputs_writes_rankings_and_top_movers(tmp_path: Path) -> No
         for row in ranking_rows
     )
     assert any(
+        row["proxy_name"] == "risk_proxy_notional_annualized_volatility"
+        and row["formula"] == "Notional * AnnualizedVolatility"
+        for row in ranking_rows
+    )
+    assert any(
         row["proxy_name"] == "risk_proxy_position_usd_vol" and row["rank"] == "1"
+        for row in ranking_rows
+    )
+    assert any(
+        row["proxy_name"] == "risk_proxy_position_usd_vol" and row["formula"] == "PositionUSD * Vol"
         for row in ranking_rows
     )
 
@@ -1805,6 +1814,10 @@ def test_write_risk_outputs_writes_rankings_and_top_movers(tmp_path: Path) -> No
     assert {row["proxy_name"] for row in mover_rows} == {
         "risk_proxy_notional_annualized_volatility",
         "risk_proxy_position_usd_vol",
+    }
+    assert {row["formula"] for row in mover_rows} == {
+        "Notional * AnnualizedVolatility",
+        "PositionUSD * Vol",
     }
     assert "risk_rankings.csv skipped" not in "\n".join(warnings)
 
@@ -2203,6 +2216,12 @@ def test_run_pipeline_writes_risk_outputs_when_proxy_inputs_available(
 
     assert (run_dir / "risk_rankings.csv").exists()
     assert (run_dir / "risk_top_movers.csv").exists()
+    with (run_dir / "risk_rankings.csv").open("r", encoding="utf-8", newline="") as stream:
+        ranking_rows = list(csv.DictReader(stream))
+    assert {row["formula"] for row in ranking_rows} == {
+        "Notional * AnnualizedVolatility",
+        "PositionUSD * Vol",
+    }
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
     notional_summary = manifest["risk_proxy_summary"]["by_variant"]["all_programs"][
         "risk_proxy_notional_annualized_volatility"

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1945,6 +1945,90 @@ def test_rank_proxy_rows_breaks_ties_by_canonical_counterparty_key(
     assert [row["counterparty"] for row in rows] == ["Z Display", "A Display"]
 
 
+def test_notional_top_movers_break_ties_by_canonical_counterparty_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Resolution:
+        def __init__(self, canonical_key: str) -> None:
+            self.canonical_key = canonical_key
+            self.canonical_name = canonical_key
+
+    canonical_keys = {
+        "Z Display": "a-canonical",
+        "A Display": "z-canonical",
+    }
+
+    monkeypatch.setattr(
+        run_module,
+        "normalize_counterparty_with_source",
+        lambda counterparty: _Resolution(canonical_keys[str(counterparty)]),
+    )
+
+    rows = run_module._mover_rows_for_notional_proxy(
+        variant="all_programs",
+        change_field="NotionalChange",
+        records=[
+            {
+                "counterparty": "A Display",
+                "Notional": 100.0,
+                "AnnualizedVolatility": 0.5,
+                "NotionalChange": 20.0,
+            },
+            {
+                "counterparty": "Z Display",
+                "Notional": 100.0,
+                "AnnualizedVolatility": 0.5,
+                "NotionalChange": 20.0,
+            },
+        ],
+    )
+
+    assert [row["counterparty"] for row in rows] == ["Z Display", "A Display"]
+    assert [row["rank"] for row in rows] == [1, 2]
+
+
+def test_position_top_movers_break_ties_by_canonical_counterparty_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Resolution:
+        def __init__(self, canonical_key: str) -> None:
+            self.canonical_key = canonical_key
+            self.canonical_name = canonical_key
+
+    canonical_keys = {
+        "Z Display": "a-canonical",
+        "A Display": "z-canonical",
+    }
+
+    monkeypatch.setattr(
+        run_module,
+        "normalize_counterparty_with_source",
+        lambda counterparty: _Resolution(canonical_keys[str(counterparty)]),
+    )
+
+    rows = run_module._mover_rows_for_position_proxy(
+        variant="all_programs",
+        change_field="PositionUSDChange",
+        records=[
+            {
+                "counterparty": "A Display",
+                "PositionUSD": 100.0,
+                "Vol": 0.25,
+                "PositionUSDChange": -20.0,
+            },
+            {
+                "counterparty": "Z Display",
+                "PositionUSD": 100.0,
+                "Vol": 0.25,
+                "PositionUSDChange": 20.0,
+            },
+        ],
+    )
+
+    assert [row["counterparty"] for row in rows] == ["Z Display", "A Display"]
+    assert [row["rank"] for row in rows] == [1, 2]
+
+
 def test_write_risk_outputs_writes_rankings_in_deterministic_variant_order(tmp_path: Path) -> None:
     warnings: list[str] = []
     parsed_by_variant = {
@@ -2157,6 +2241,9 @@ def test_run_pipeline_writes_risk_outputs_when_proxy_inputs_available(
                         "Notional": 100.0,
                         "AnnualizedVolatility": 0.2,
                         "NotionalChange": 20.0,
+                        "PositionUSD": 200.0,
+                        "Vol": 0.1,
+                        "PositionUSDChange": 40.0,
                     }
                 ]
             ),

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -2007,6 +2007,43 @@ def test_write_risk_outputs_warns_when_prior_period_columns_missing(tmp_path: Pa
     )
 
 
+def test_write_risk_outputs_skips_movers_when_prior_period_values_invalid(tmp_path: Path) -> None:
+    warnings: list[str] = []
+    parsed_by_variant = {
+        "all_programs": {
+            "totals": _FakeDataFrame(
+                records=[
+                    {
+                        "counterparty": "A",
+                        "Notional": 120.0,
+                        "AnnualizedVolatility": 0.25,
+                        "NotionalChange": "not-a-number",
+                        "PositionUSD": 400.0,
+                        "Vol": 0.4,
+                        "PositionUSDChange": None,
+                    }
+                ]
+            )
+        }
+    }
+
+    output_paths = run_module._write_risk_outputs(
+        run_dir=tmp_path, parsed_by_variant=parsed_by_variant, warnings=warnings
+    )
+
+    assert tmp_path / "risk_rankings.csv" in output_paths
+    assert tmp_path / "risk_top_movers.csv" not in output_paths
+    assert any(
+        "prior-period notional delta values unavailable or invalid" in warning
+        for warning in warnings
+    )
+    assert any(
+        "prior-period position delta values unavailable or invalid" in warning
+        for warning in warnings
+    )
+    assert any("risk_top_movers.csv skipped" in warning for warning in warnings)
+
+
 def test_write_change_attribution_outputs_writes_markdown_and_csv(tmp_path: Path) -> None:
     warnings: list[str] = []
     parsed_by_variant = {

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1903,6 +1903,37 @@ def test_write_risk_outputs_creates_partial_outputs_when_only_notional_proxy_exi
     assert any("requires PositionUSD and Vol columns" in warning for warning in warnings)
 
 
+def test_rank_proxy_rows_breaks_ties_by_canonical_counterparty_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Resolution:
+        def __init__(self, canonical_key: str) -> None:
+            self.canonical_key = canonical_key
+            self.canonical_name = canonical_key
+
+    canonical_keys = {
+        "Z Display": "a-canonical",
+        "A Display": "z-canonical",
+    }
+
+    monkeypatch.setattr(
+        run_module,
+        "normalize_counterparty_with_source",
+        lambda counterparty: _Resolution(canonical_keys[str(counterparty)]),
+    )
+
+    rows = run_module._rank_proxy_rows(
+        variant="all_programs",
+        proxy_column="risk_proxy_notional_annualized_volatility",
+        records=[
+            {"counterparty": "A Display", "risk_proxy_notional_annualized_volatility": 10.0},
+            {"counterparty": "Z Display", "risk_proxy_notional_annualized_volatility": 10.0},
+        ],
+    )
+
+    assert [row["counterparty"] for row in rows] == ["Z Display", "A Display"]
+
+
 def test_write_change_attribution_outputs_writes_markdown_and_csv(tmp_path: Path) -> None:
     warnings: list[str] = []
     parsed_by_variant = {

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1863,10 +1863,8 @@ def test_write_risk_outputs_warns_and_skips_rankings_when_proxy_columns_missing(
 
     assert output_paths == []
     assert not (tmp_path / "risk_rankings.csv").exists()
-    assert any(
-        "requires Notional and AnnualizedVolatility columns" in warning for warning in warnings
-    )
-    assert any("requires PositionUSD and Vol columns" in warning for warning in warnings)
+    assert any("missing required columns (AnnualizedVolatility)" in warning for warning in warnings)
+    assert any("missing required columns (PositionUSD, Vol)" in warning for warning in warnings)
     assert any("risk_rankings.csv skipped" in warning for warning in warnings)
 
 
@@ -1900,7 +1898,7 @@ def test_write_risk_outputs_creates_partial_outputs_when_only_notional_proxy_exi
     assert {row["proxy_name"] for row in ranking_rows} == {
         "risk_proxy_notional_annualized_volatility"
     }
-    assert any("requires PositionUSD and Vol columns" in warning for warning in warnings)
+    assert any("missing required columns (PositionUSD, Vol)" in warning for warning in warnings)
 
 
 def test_rank_proxy_rows_breaks_ties_by_canonical_counterparty_key(
@@ -1970,7 +1968,43 @@ def test_write_risk_outputs_writes_rankings_in_deterministic_variant_order(tmp_p
         ranking_rows = list(csv.DictReader(stream))
 
     assert [row["variant"] for row in ranking_rows] == ["all_programs", "trend"]
-    assert any("requires PositionUSD and Vol columns" in warning for warning in warnings)
+    assert any("missing required columns (PositionUSD, Vol)" in warning for warning in warnings)
+
+
+def test_write_risk_outputs_warns_when_prior_period_columns_missing(tmp_path: Path) -> None:
+    warnings: list[str] = []
+    parsed_by_variant = {
+        "all_programs": {
+            "totals": _FakeDataFrame(
+                records=[
+                    {
+                        "counterparty": "A",
+                        "Notional": 120.0,
+                        "AnnualizedVolatility": 0.25,
+                        "PositionUSD": 400.0,
+                        "Vol": 0.4,
+                    }
+                ]
+            )
+        }
+    }
+
+    output_paths = run_module._write_risk_outputs(
+        run_dir=tmp_path, parsed_by_variant=parsed_by_variant, warnings=warnings
+    )
+
+    assert tmp_path / "risk_rankings.csv" in output_paths
+    assert tmp_path / "risk_top_movers.csv" not in output_paths
+    assert any(
+        "missing prior-period notional delta column (one of: NotionalChange, NotionalChangeFromPriorMonth)"
+        in warning
+        for warning in warnings
+    )
+    assert any(
+        "missing prior-period position delta column (one of: PositionUSDChange, PositionChangeFromPriorMonth)"
+        in warning
+        for warning in warnings
+    )
 
 
 def test_write_change_attribution_outputs_writes_markdown_and_csv(tmp_path: Path) -> None:

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -1934,6 +1934,45 @@ def test_rank_proxy_rows_breaks_ties_by_canonical_counterparty_key(
     assert [row["counterparty"] for row in rows] == ["Z Display", "A Display"]
 
 
+def test_write_risk_outputs_writes_rankings_in_deterministic_variant_order(tmp_path: Path) -> None:
+    warnings: list[str] = []
+    parsed_by_variant = {
+        "trend": {
+            "totals": _FakeDataFrame(
+                records=[
+                    {
+                        "counterparty": "Trend Cpty",
+                        "Notional": 75.0,
+                        "AnnualizedVolatility": 0.2,
+                    }
+                ]
+            )
+        },
+        "all_programs": {
+            "totals": _FakeDataFrame(
+                records=[
+                    {
+                        "counterparty": "All Cpty",
+                        "Notional": 100.0,
+                        "AnnualizedVolatility": 0.3,
+                    }
+                ]
+            )
+        },
+    }
+
+    output_paths = run_module._write_risk_outputs(
+        run_dir=tmp_path, parsed_by_variant=parsed_by_variant, warnings=warnings
+    )
+
+    assert tmp_path / "risk_rankings.csv" in output_paths
+    with (tmp_path / "risk_rankings.csv").open("r", encoding="utf-8", newline="") as stream:
+        ranking_rows = list(csv.DictReader(stream))
+
+    assert [row["variant"] for row in ranking_rows] == ["all_programs", "trend"]
+    assert any("requires PositionUSD and Vol columns" in warning for warning in warnings)
+
+
 def test_write_change_attribution_outputs_writes_markdown_and_csv(tmp_path: Path) -> None:
     warnings: list[str] = []
     parsed_by_variant = {

--- a/tests/test_risk_proxy_outputs_doc.py
+++ b/tests/test_risk_proxy_outputs_doc.py
@@ -1,0 +1,26 @@
+"""Validation tests for risk proxy output documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_risk_proxy_outputs_doc_covers_formulas_inputs_and_missing_data() -> None:
+    doc_path = Path(__file__).resolve().parents[1] / "docs" / "risk_proxy_outputs.md"
+    assert doc_path.is_file()
+
+    contents = doc_path.read_text(encoding="utf-8")
+
+    assert "risk_proxy_notional_annualized_volatility" in contents
+    assert "Notional * AnnualizedVolatility" in contents
+    assert "risk_proxy_position_usd_vol" in contents
+    assert "PositionUSD * Vol" in contents
+    assert "NotionalChange" in contents
+    assert "NotionalChangeFromPriorMonth" in contents
+    assert "PositionUSDChange" in contents
+    assert "PositionChangeFromPriorMonth" in contents
+    assert "prior_proxy_value = current_proxy_value - delta" in contents
+    assert 'manifest["risk_proxy_summary"]["by_variant"]' in contents
+    assert "risk_rankings.csv" in contents
+    assert "risk_top_movers.csv" in contents
+    assert "skipped with a warning" in contents


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:476 -->
> **Source:** Issue #476

Closes #476

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Nominal exposure alone is not enough for risk prioritization. When volatility or position data exists, the run should produce risk-weighted proxy rankings and explain when a proxy could not be computed.

#### Tasks
- [x] Implement `compute_risk_proxies(exposures_df)` in `src/counter_risk/compute/rollups.py` or a dedicated metrics module.
- [x] Create `risk_rankings.csv` sorted by each available proxy with stable tie-breaking by canonical counterparty key.
- [x] Create `risk_top_movers.csv` using prior-period data when available through the existing change-attribution or historical update path.
- [x] Emit manifest warnings for unavailable proxies when volatility, notional, position, or prior-period columns are missing.
- [x] Add tests for available-volatility data, missing-volatility data, missing-position data, prior-period unavailable, and deterministic ranking order.
- [x] Document proxy formulas, required input columns, and missing-data behavior.

#### Acceptance criteria
- [x] When required inputs exist, the run folder includes risk proxy rankings with formulas matching the documentation.
- [x] When inputs are missing, the run records a warning and skips only unavailable proxies.
- [x] Tests verify formulas, sorting, and missing-column behavior.
- [x] Manifest output tells the operator which proxies were computed and which were skipped.
- [x] Prior-period mover output is written only when the source comparison data is available and valid.

<!-- auto-status-summary:end -->