### PR TITLE
Issue #593: document output folder naming

### DIFF
--- a/docs/operator_ux_decision.md
+++ b/docs/operator_ux_decision.md
@@ -146,10 +146,10 @@ Decision rule:
 ## Output Folder Convention and Naming
 
 - Standard output root: shared drive run-output directory managed by operations.
-- Automatic per-run folder naming:
-  - Standard runs use the as-of date directly, for example `runs/2026-01-31`.
-  - Runs with `run_date` configured in YAML use `<as_of_date>__run_<run_date>`, for example `runs/2026-01-31__run_2026-02-05`.
-  - Same-date repeat runs append a numeric suffix to the selected pattern, for example `runs/2026-01-31_1`.
+- Per-run folder name format:
+  - Standard runs: `<as_of_date>` (example `runs/2026-01-31`).
+  - With `run_date` configured in YAML: `<as_of_date>__run_<run_date>` (example `runs/2026-01-31__run_2026-02-05`).
+  - Same-date repeat runs append a numeric suffix to the selected pattern (example `runs/2026-01-31_1`).
 - CLI override: passing `--output-dir` skips automatic naming and uses the caller-supplied directory, which must be empty or newly created.
 - Required contents:
   - Updated historical workbooks

--- a/docs/operator_ux_decision.md
+++ b/docs/operator_ux_decision.md
@@ -146,8 +146,11 @@ Decision rule:
 ## Output Folder Convention and Naming
 
 - Standard output root: shared drive run-output directory managed by operations.
-- Per-run folder name format:
-  - `CounterRisk_<as_of_date:YYYY-MM-DD>_<variant>_<run_timestamp:YYYYMMDD_HHMMSS>`
+- Automatic per-run folder naming:
+  - Standard runs use the as-of date directly, for example `runs/2026-01-31`.
+  - Runs with `run_date` configured in YAML use `<as_of_date>__run_<run_date>`, for example `runs/2026-01-31__run_2026-02-05`.
+  - Same-date repeat runs append a numeric suffix to the selected pattern, for example `runs/2026-01-31_1`.
+- CLI override: passing `--output-dir` skips automatic naming and uses the caller-supplied directory, which must be empty or newly created.
 - Required contents:
   - Updated historical workbooks
   - Updated monthly PPT outputs in the run folder
@@ -155,7 +158,7 @@ Decision rule:
   - `DATA_QUALITY_SUMMARY.txt`
 
 Example:
-- `CounterRisk_2026-01-31_AllPrograms_20260205_091530`
+- `runs/2026-01-31`
 
 ## Non-Repo Update Delivery Mechanism
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:593 -->
> **Source:** Issue #593

Closes #593

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/operator_ux_decision.md` lines 148–158 ("Output Folder Convention and Naming") specifies the per-run folder format as `CounterRisk_<as_of_date:YYYY-MM-DD>_<variant>_<run_timestamp:YYYYMMDD_HHMMSS>` with example `CounterRisk_2026-01-31_AllPrograms_20260205_091530`. The actual pipeline (`src/counter_risk/pipeline/run.py:598–611`, `_create_run_directory`) creates date-only folders such as `runs/2026-02-13`, or `runs/2026-02-13__run_2026-02-14` when `run_date` is configured in the YAML config, with a `_1`/`_2` collision suffix for same-date repeat runs. This is confirmed by `tests/test_pipeline_run_dir.py` (line 95: `expected_run_dir = tmp_path / "runs" / "2026-02-13"`; line 213: `assert run_dir == tmp_path / "runs" / "2026-02-13__run_2026-02-14"`). An operator reading the stale section would expect a `CounterRisk_`-prefixed folder containing a variant and timestamp component, and could fail to locate the actual run output on the shared drive.

#### Tasks
- [x] Open `docs/operator_ux_decision.md` and locate the "Output Folder Convention and Naming" section (lines 148–158).
- [x] Replace the `Per-run folder name format` bullet and its value `CounterRisk_<as_of_date:YYYY-MM-DD>_<variant>_<run_timestamp:YYYYMMDD_HHMMSS>` with the two implemented patterns: `<as_of_date>` (e.g., `runs/2026-01-31`) for standard runs, and `<as_of_date>__run_<run_date>` (e.g., `runs/2026-01-31__run_2026-02-05`) when `run_date` is explicitly configured in the YAML config.
- [x] Replace the stale example `CounterRisk_2026-01-31_AllPrograms_20260205_091530` with a correct example such as `runs/2026-01-31` (standard) and optionally `runs/2026-01-31__run_2026-02-05` (run_date variant).
- [x] Add a note that same-date repeat runs append a numeric suffix (e.g., `runs/2026-01-31_1`) and that passing `--output-dir` on the CLI skips automatic naming entirely, using the caller-supplied path instead.
- [x] Run `pytest tests/test_pipeline_run_dir.py -v` with no code changes to confirm all tests still pass.

#### Acceptance criteria
- [x] `docs/operator_ux_decision.md` "Output Folder Convention and Naming" section documents both `<as_of_date>` and `<as_of_date>__run_<run_date>` naming patterns with at least one correct example (e.g., `runs/2026-01-31`).
- [x] `rg "CounterRisk_2026" docs/operator_ux_decision.md` returns no matches after the update.
- [x] The section no longer contains the string `_<variant>_<run_timestamp:` in any format spec or example.
- [x] `pytest tests/test_pipeline_run_dir.py -v` passes with no code changes, confirming the documented patterns match the implemented naming logic in `src/counter_risk/pipeline/run.py:598–611`.
- [x] The updated example is consistent with what `_create_run_directory` would produce for a January 2026 `as_of_date` with no `run_date` configured (i.e., a plain ISO-date folder under `runs/`).

<!-- auto-status-summary:end -->