### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.12
+RUFF_VERSION=0.15.13
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=1.20.2
+MYPY_VERSION=2.1.0
 PYTEST_VERSION=9.0.3
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.13.5
+COVERAGE_VERSION=7.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pandas>=2.2.3,<3",
     "black==26.3.1",
     "ruff>=0.15.13",
-    "mypy==2.1.0",
+    "mypy>=1.20.2,<2",
     "types-PyYAML==6.0.12.20260408",
     # Required by scripts/sync_test_dependencies.py when --fix is needed in CI
     "tomlkit>=0.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dev = [
     "pytest-xdist==3.8.0",
     "pandas>=2.2.3,<3",
     "black==26.3.1",
-    "ruff>=0.15.12",
-    "mypy>=1.20.2",
+    "ruff>=0.15.13",
+    "mypy>=2.1.0",
     "types-PyYAML==6.0.12.20260408",
     # Required by scripts/sync_test_dependencies.py when --fix is needed in CI
     "tomlkit>=0.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pandas>=2.2.3,<3",
     "black==26.3.1",
     "ruff>=0.15.13",
-    "mypy>=1.20.2,<2",
+    "mypy==2.1.0",
     "types-PyYAML==6.0.12.20260408",
     # Required by scripts/sync_test_dependencies.py when --fix is needed in CI
     "tomlkit>=0.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 [project.optional-dependencies]
 app = []
 dev = [
-    "pytest==8.4.2",
+    "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-xdist==3.8.0",
     "pandas>=2.2.3,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pandas>=2.2.3,<3",
     "black==26.3.1",
     "ruff>=0.15.13",
-    "mypy>=1.19.1,<2",
+    "mypy==2.1.0",
     "types-PyYAML==6.0.12.20260408",
     # Required by scripts/sync_test_dependencies.py when --fix is needed in CI
     "tomlkit>=0.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pandas>=2.2.3,<3",
     "black==26.3.1",
     "ruff>=0.15.13",
-    "mypy>=2.1.0",
+    "mypy>=1.19.1,<2",
     "types-PyYAML==6.0.12.20260408",
     # Required by scripts/sync_test_dependencies.py when --fix is needed in CI
     "tomlkit>=0.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 [project.optional-dependencies]
 app = []
 dev = [
-    "pytest==9.0.3",
+    "pytest==8.4.2",
     "pytest-cov==7.1.0",
     "pytest-xdist==3.8.0",
     "pandas>=2.2.3,<3",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -2,8 +2,6 @@
 #    uv pip compile pyproject.toml --extra dev --universal --output-file requirements-dev.lock
 annotated-types==0.7.0
     # via pydantic
-ast-serialize==0.3.0
-    # via mypy
 black==26.3.1
     # via my-project (pyproject.toml)
 click==8.3.1
@@ -20,11 +18,11 @@ execnet==2.1.2
     # via pytest-xdist
 iniconfig==2.3.0
     # via pytest
-librt==0.11.0 ; platform_python_implementation != 'PyPy'
+librt==0.8.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==2.1.0
+mypy==1.20.2
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -58,7 +58,7 @@ pydantic-core==2.18.4
     # via pydantic
 pygments==2.19.2
     # via pytest
-pytest==8.4.2
+pytest==9.0.3
     # via
     #   my-project (pyproject.toml)
     #   pytest-cov

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -2,7 +2,9 @@
 #    uv pip compile pyproject.toml --extra dev --universal --output-file requirements-dev.lock
 annotated-types==0.7.0
     # via pydantic
-black==26.1.0
+ast-serialize==0.3.0
+    # via mypy
+black==26.3.1
     # via my-project (pyproject.toml)
 click==8.3.1
     # via black
@@ -10,7 +12,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
     #   pytest
-coverage==7.13.4
+coverage==7.14.0
     # via pytest-cov
 et-xmlfile==2.0.0
     # via openpyxl
@@ -18,11 +20,11 @@ execnet==2.1.2
     # via pytest-xdist
 iniconfig==2.3.0
     # via pytest
-librt==0.8.0 ; platform_python_implementation != 'PyPy'
+librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==1.19.1
+mypy==2.1.0
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -56,12 +58,12 @@ pydantic-core==2.18.4
     # via pydantic
 pygments==2.19.2
     # via pytest
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   my-project (pyproject.toml)
     #   pytest-cov
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via my-project (pyproject.toml)
 pytest-xdist==3.8.0
     # via my-project (pyproject.toml)
@@ -73,13 +75,13 @@ pytokens==0.4.1
     # via black
 pytz==2025.2
     # via pandas
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via my-project (pyproject.toml)
-ruff==0.15.1
+ruff==0.15.13
     # via my-project (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-tomlkit==0.13.3
+tomlkit==0.14.0
     # via my-project (pyproject.toml)
 typing-extensions==4.15.0
     # via

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -2,6 +2,8 @@
 #    uv pip compile pyproject.toml --extra dev --universal --output-file requirements-dev.lock
 annotated-types==0.7.0
     # via pydantic
+ast-serialize==0.3.0
+    # via mypy
 black==26.3.1
     # via my-project (pyproject.toml)
 click==8.3.1
@@ -18,11 +20,11 @@ execnet==2.1.2
     # via pytest-xdist
 iniconfig==2.3.0
     # via pytest
-librt==0.8.0 ; platform_python_implementation != 'PyPy'
+librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==1.20.2
+mypy==2.1.0
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -58,7 +58,7 @@ pydantic-core==2.18.4
     # via pydantic
 pygments==2.19.2
     # via pytest
-pytest==9.0.3
+pytest==8.4.2
     # via
     #   my-project (pyproject.toml)
     #   pytest-cov

--- a/requirements.lock
+++ b/requirements.lock
@@ -79,7 +79,7 @@ librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==1.19.1
+mypy==2.1.0
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,6 +9,8 @@ anyio==4.12.1
     #   anthropic
     #   httpx
     #   openai
+ast-serialize==0.3.0
+    # via mypy
 black==26.3.1
     # via my-project (pyproject.toml)
 certifi==2026.2.25
@@ -73,11 +75,11 @@ langchain-protocol==0.0.14
     # via langchain-core
 langsmith==0.7.9
     # via langchain-core
-librt==0.8.0 ; platform_python_implementation != 'PyPy'
+librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==1.20.2
+mypy==2.1.0
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,8 +9,6 @@ anyio==4.12.1
     #   anthropic
     #   httpx
     #   openai
-ast-serialize==0.3.0
-    # via mypy
 black==26.3.1
     # via my-project (pyproject.toml)
 certifi==2026.2.25
@@ -75,11 +73,11 @@ langchain-protocol==0.0.14
     # via langchain-core
 langsmith==0.7.9
     # via langchain-core
-librt==0.11.0 ; platform_python_implementation != 'PyPy'
+librt==0.8.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==2.1.0
+mypy==1.20.2
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via

--- a/requirements.lock
+++ b/requirements.lock
@@ -77,7 +77,7 @@ librt==0.8.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==2.1.0
+mypy==1.19.1
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via

--- a/requirements.lock
+++ b/requirements.lock
@@ -25,7 +25,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   click
     #   pytest
     #   tqdm
-coverage==7.13.5
+coverage==7.14.0
     # via pytest-cov
 distro==1.9.0
     # via
@@ -77,7 +77,7 @@ librt==0.8.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==1.20.2
+mypy==2.1.0
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -153,7 +153,7 @@ requests==2.32.5
     #   tiktoken
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.15.12
+ruff==0.15.13
     # via my-project (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/requirements.lock
+++ b/requirements.lock
@@ -127,7 +127,7 @@ pydantic-core==2.46.3
     # via pydantic
 pygments==2.19.2
     # via pytest
-pytest==9.0.3
+pytest==8.4.2
     # via
     #   my-project (pyproject.toml)
     #   pytest-cov

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,6 +9,8 @@ anyio==4.12.1
     #   anthropic
     #   httpx
     #   openai
+ast-serialize==0.3.0
+    # via mypy
 black==26.3.1
     # via my-project (pyproject.toml)
 certifi==2026.2.25
@@ -73,7 +75,7 @@ langchain-protocol==0.0.14
     # via langchain-core
 langsmith==0.7.9
     # via langchain-core
-librt==0.8.0 ; platform_python_implementation != 'PyPy'
+librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx

--- a/requirements.lock
+++ b/requirements.lock
@@ -127,7 +127,7 @@ pydantic-core==2.46.3
     # via pydantic
 pygments==2.19.2
     # via pytest
-pytest==8.4.2
+pytest==9.0.3
     # via
     #   my-project (pyproject.toml)
     #   pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ python-pptx==1.0.2
 openpyxl>=3.1,<4
 langchain-openai>=1.0.1,<2
 langchain-anthropic>=1.4.2,<2
-pytest==9.0.2
-pytest-cov==7.0.0
+pytest==9.0.3
+pytest-cov==7.1.0
 pandas>=2.3,<4
 pyinstaller>=6.20.0,<7
 setuptools>=61.0


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 5 version updates:
  - ruff: >=0.15.12 -> >=0.15.13
  - mypy: >=1.20.2 -> >=2.1.0
  - requirements.lock:coverage: 7.13.5 -> ==7.14.0
  - requirements.lock:mypy: 1.20.2 -> ==2.1.0
  - requirements.lock:ruff: 0.15.12 -> ==0.15.13

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`