### PR TITLE
Issue #610: Add LangSmith fleet records

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ The run-context chat assistant now uses LangChain-backed providers (instead of s
   (`transcript`, `full`, `off`).
 - See [docs/chat_logging.md](docs/chat_logging.md) for mode behavior, payload fields, and
   LangSmith trace linkage.
+- See [docs/langsmith_fleet.md](docs/langsmith_fleet.md) for the
+  dashboard-safe `langsmith-fleet.ndjson` artifact emitted by monthly risk runs.
 
 ## Workflow Run Command
 

--- a/agents/autofix_pr526_run25504881317_followup_2026-05-24.md
+++ b/agents/autofix_pr526_run25504881317_followup_2026-05-24.md
@@ -1,0 +1,22 @@
+# Autofix follow-up diagnostic for PR #526 (run 25504881317)
+
+## Date
+- 2026-05-24 (UTC)
+
+## What was attempted
+- Re-ran a CI-like xdist command to force first-failure capture:
+
+```bash
+pytest -n auto --dist loadscope --ignore=tests/integration --ignore=tests/integrations -m "not release" --maxfail=1 -x -vv -rA --tb=short
+```
+
+## Observed result
+- The run advanced beyond the previously reported late-failure area (~85%) without surfacing a deterministic failing node id or traceback in this environment.
+- No repository-local lint/type errors were introduced during this investigation.
+
+## Current status
+- Root cause remains non-reproducible from workspace-only context.
+- Existing CI metadata for run `25504881317` points to matrix finalization failures (`Python CI / python 3.12`, `Python CI / python 3.13`) but does not include the first concrete failing test/error payload.
+
+## Next required artifact to unblock targeted fix
+Capture the first actual failing test traceback (node id + exception) from the failing CI leg before finalization. With that payload, apply the minimal source/test fix and re-run only the impacted subset.

--- a/docs/langsmith_fleet.md
+++ b/docs/langsmith_fleet.md
@@ -1,0 +1,53 @@
+# LangSmith Fleet Artifact
+
+Counter_Risk writes a dashboard-safe `langsmith-fleet.ndjson` file into each
+monthly run folder. The file follows the Workflows-owned `langsmith-fleet/v1`
+contract for `stranske/Counter_Risk#610` and lets the fleet dashboard inspect
+risk/report observability without reading sensitive exposure or report payloads.
+
+## Records
+
+Each run emits one record for each risk-reporting operation:
+
+- `data-quality`
+- `risk-proxy`
+- `limit-monitoring`
+- `report-generation`
+
+The shared fields include repo, surface, operation, run ID, status, owning issue,
+and recorded timestamp. The domain block includes:
+
+- `as_of_date`
+- `scenario`
+- `data_quality_status`
+- `limit_breach_count`
+- operation-specific counts or artifact references
+
+Artifact references use `artifact:<relative-path>` values. Raw counterparty
+positions, report text, prompt text, and model outputs are not written to this
+artifact.
+
+## LangSmith Configuration
+
+When `LANGSMITH_API_KEY` is present, Counter_Risk defaults LangSmith tracing to
+the repo-specific project `counter-risk` and mirrors the key into
+`LANGCHAIN_API_KEY` for LangChain clients. Without a key, the fleet records use
+status `no_secret`; the pipeline still succeeds and no network call is required.
+
+Operators can correlate records with LangSmith by setting `LANGSMITH_TRACE_ID`
+or `LANGSMITH_TRACE_URL` in runtimes that already know the trace reference.
+
+## Validation
+
+For focused local validation, run:
+
+```bash
+python -m pytest tests/observability/test_langsmith_fleet.py tests/test_langchain_runtime.py -q
+```
+
+For pipeline insertion-point coverage, run:
+
+```bash
+python -m pytest tests/pipeline/test_run_pipeline.py -q
+```
+

--- a/src/counter_risk/chat/providers/langchain_runtime.py
+++ b/src/counter_risk/chat/providers/langchain_runtime.py
@@ -31,6 +31,7 @@ ENV_LANGSMITH_KEY = "LANGSMITH_API_KEY"
 ENV_LANGCHAIN_TRACING_V2 = "LANGCHAIN_TRACING_V2"
 ENV_LANGCHAIN_API_KEY = "LANGCHAIN_API_KEY"
 ENV_LANGCHAIN_PROJECT = "LANGCHAIN_PROJECT"
+ENV_LANGSMITH_PROJECT = "LANGSMITH_PROJECT"
 
 PROVIDER_OPENAI = "openai"
 PROVIDER_ANTHROPIC = "anthropic"
@@ -408,6 +409,7 @@ def _ensure_langsmith_tracing_env() -> bool:
         return False
     os.environ.setdefault(ENV_LANGCHAIN_TRACING_V2, "true")
     os.environ.setdefault(ENV_LANGCHAIN_PROJECT, DEFAULT_LANGCHAIN_PROJECT)
+    os.environ.setdefault(ENV_LANGSMITH_PROJECT, DEFAULT_LANGCHAIN_PROJECT)
     os.environ.setdefault(ENV_LANGCHAIN_API_KEY, api_key)
     os.environ.setdefault(ENV_LANGSMITH_KEY, api_key)
     return True

--- a/src/counter_risk/chat/providers/langchain_runtime.py
+++ b/src/counter_risk/chat/providers/langchain_runtime.py
@@ -15,6 +15,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, cast
 
+from counter_risk.observability.langsmith_fleet import (
+    DEFAULT_PROJECT as DEFAULT_COUNTER_RISK_LANGSMITH_PROJECT,
+)
 from counter_risk.runtime_paths import resolve_runtime_path
 
 ENV_PROVIDER = "LANGCHAIN_PROVIDER"
@@ -37,7 +40,7 @@ GITHUB_MODELS_BASE_URL = "https://models.inference.ai.azure.com"
 DEFAULT_MODEL = "codex-mini-latest"
 
 DEFAULT_SLOT_CONFIG_PATH = "config/llm_slots.json"
-DEFAULT_LANGCHAIN_PROJECT = "workflows-agents"
+DEFAULT_LANGCHAIN_PROJECT = DEFAULT_COUNTER_RISK_LANGSMITH_PROJECT
 
 LANGCHAIN_OPENAI_DIST = "langchain-openai"
 LANGCHAIN_ANTHROPIC_DIST = "langchain-anthropic"

--- a/src/counter_risk/observability/__init__.py
+++ b/src/counter_risk/observability/__init__.py
@@ -1,0 +1,2 @@
+"""Observability helpers for Counter_Risk workflows."""
+

--- a/src/counter_risk/observability/langsmith_fleet.py
+++ b/src/counter_risk/observability/langsmith_fleet.py
@@ -18,6 +18,7 @@ ARTIFACT_NAME: Final = "langsmith-fleet.ndjson"
 DEFAULT_PROJECT: Final = "counter-risk"
 ENV_LANGSMITH_KEY: Final = "LANGSMITH_API_KEY"
 ENV_LANGCHAIN_PROJECT: Final = "LANGCHAIN_PROJECT"
+ENV_LANGSMITH_PROJECT: Final = "LANGSMITH_PROJECT"
 ENV_LANGCHAIN_TRACING_V2: Final = "LANGCHAIN_TRACING_V2"
 ENV_LANGCHAIN_API_KEY: Final = "LANGCHAIN_API_KEY"
 
@@ -47,6 +48,7 @@ def ensure_langsmith_project_defaults() -> bool:
         return False
     os.environ.setdefault(ENV_LANGCHAIN_TRACING_V2, "true")
     os.environ.setdefault(ENV_LANGCHAIN_PROJECT, DEFAULT_PROJECT)
+    os.environ.setdefault(ENV_LANGSMITH_PROJECT, DEFAULT_PROJECT)
     os.environ.setdefault(ENV_LANGCHAIN_API_KEY, api_key)
     return True
 
@@ -171,4 +173,3 @@ def _record(
 
 def _utc_timestamp() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-

--- a/src/counter_risk/observability/langsmith_fleet.py
+++ b/src/counter_risk/observability/langsmith_fleet.py
@@ -1,0 +1,174 @@
+"""Build dashboard-safe LangSmith fleet records for risk workflow runs."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final, Literal
+
+SCHEMA_VERSION: Final = "langsmith-fleet/v1"
+REPO: Final = "stranske/Counter_Risk"
+SURFACE: Final = "risk-reporting"
+GITHUB_ISSUE: Final = "stranske/Counter_Risk#610"
+ARTIFACT_NAME: Final = "langsmith-fleet.ndjson"
+DEFAULT_PROJECT: Final = "counter-risk"
+ENV_LANGSMITH_KEY: Final = "LANGSMITH_API_KEY"
+ENV_LANGCHAIN_PROJECT: Final = "LANGCHAIN_PROJECT"
+ENV_LANGCHAIN_TRACING_V2: Final = "LANGCHAIN_TRACING_V2"
+ENV_LANGCHAIN_API_KEY: Final = "LANGCHAIN_API_KEY"
+
+Status = Literal["success", "error", "fallback", "no_secret", "skipped"]
+
+
+@dataclass(frozen=True)
+class FleetRunContext:
+    """Shared trace context for a Counter_Risk workflow run."""
+
+    run_id: str
+    as_of_date: str
+    scenario: str
+    provider: str | None = None
+    model: str | None = None
+    trace_id: str | None = None
+    trace_url: str | None = None
+    recorded_at: str | None = None
+    github_pr: str | None = None
+
+
+def ensure_langsmith_project_defaults() -> bool:
+    """Apply Counter_Risk LangSmith defaults when a key is present."""
+
+    api_key = os.environ.get(ENV_LANGSMITH_KEY)
+    if not api_key:
+        return False
+    os.environ.setdefault(ENV_LANGCHAIN_TRACING_V2, "true")
+    os.environ.setdefault(ENV_LANGCHAIN_PROJECT, DEFAULT_PROJECT)
+    os.environ.setdefault(ENV_LANGCHAIN_API_KEY, api_key)
+    return True
+
+
+def build_fleet_records(
+    *,
+    context: FleetRunContext,
+    data_quality_status: str,
+    risk_proxy_status: str,
+    concentration_metric_count: int,
+    limit_breach_count: int,
+    limit_max_severity: str | None = None,
+    report_artifacts: Iterable[str] = (),
+    artifact_ref: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return Workflows-compatible records for the major risk/report stages."""
+
+    tracing_enabled = ensure_langsmith_project_defaults()
+    base_status: Status = "success" if tracing_enabled else "no_secret"
+    recorded_at = context.recorded_at or _utc_timestamp()
+    report_refs = tuple(sorted(str(item) for item in report_artifacts if str(item).strip()))
+    shared_domain = {
+        "as_of_date": context.as_of_date,
+        "scenario": context.scenario,
+        "data_quality_status": data_quality_status,
+        "limit_breach_count": int(limit_breach_count),
+    }
+    records = [
+        _record(
+            context=context,
+            operation="data-quality",
+            status=base_status,
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "stage_status": data_quality_status,
+            },
+            artifact_ref=artifact_ref,
+        ),
+        _record(
+            context=context,
+            operation="risk-proxy",
+            status=base_status if risk_proxy_status != "skipped" else "skipped",
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "risk_proxy_status": risk_proxy_status,
+                "concentration_metric_count": max(0, int(concentration_metric_count)),
+            },
+            artifact_ref=artifact_ref,
+        ),
+        _record(
+            context=context,
+            operation="limit-monitoring",
+            status=base_status,
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "limit_max_severity": limit_max_severity or "none",
+            },
+            artifact_ref=artifact_ref,
+        ),
+        _record(
+            context=context,
+            operation="report-generation",
+            status=base_status,
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "report_artifact_count": len(report_refs),
+                "report_artifacts": list(report_refs),
+            },
+            artifact_ref=artifact_ref,
+        ),
+    ]
+    return records
+
+
+def write_fleet_records(path: Path, records: Iterable[Mapping[str, Any]]) -> Path:
+    """Write records as deterministic NDJSON and return the artifact path."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(dict(record), sort_keys=True, separators=(",", ":")) for record in records]
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return path
+
+
+def _record(
+    *,
+    context: FleetRunContext,
+    operation: str,
+    status: Status,
+    recorded_at: str,
+    domain: Mapping[str, Any],
+    artifact_ref: str | None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "repo": REPO,
+        "surface": SURFACE,
+        "operation": operation,
+        "run_id": context.run_id,
+        "status": status,
+        "github_issue": GITHUB_ISSUE,
+        "recorded_at": recorded_at,
+        "domain": dict(domain),
+    }
+    if context.github_pr:
+        record["github_pr"] = context.github_pr
+    if context.provider:
+        record["provider"] = context.provider
+    if context.model:
+        record["model"] = context.model
+    if context.trace_id:
+        record["trace_id"] = context.trace_id
+    if context.trace_url:
+        record["trace_url"] = context.trace_url
+    if artifact_ref:
+        record["artifact_ref"] = artifact_ref
+    return record
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -254,6 +254,7 @@ def manifest_schema() -> dict[str, Any]:
                 "required": [
                     "has_breaches",
                     "breach_count",
+                    "max_severity",
                     "warning_breach_count",
                     "fail_breach_count",
                     "report_path",
@@ -262,6 +263,7 @@ def manifest_schema() -> dict[str, Any]:
                 "properties": {
                     "has_breaches": {"type": "boolean"},
                     "breach_count": {"type": "integer", "minimum": 0},
+                    "max_severity": {"type": ["string", "null"], "enum": ["warning", "fail", None]},
                     "warning_breach_count": {"type": "integer", "minimum": 0},
                     "fail_breach_count": {"type": "integer", "minimum": 0},
                     "report_path": {"type": ["string", "null"]},

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -609,11 +609,24 @@ def _write_langsmith_fleet_artifact(
         risk_proxy_status=risk_proxy_status,
         concentration_metric_count=len(concentration_metrics_records),
         limit_breach_count=int(limit_breach_summary.get("breach_count") or 0),
-        limit_max_severity=cast(str | None, limit_breach_summary.get("max_severity")),
+        limit_max_severity=_limit_summary_max_severity(limit_breach_summary),
         report_artifacts=safe_output_refs,
         artifact_ref=f"artifact:{LANGSMITH_FLEET_ARTIFACT_NAME}",
     )
     return write_fleet_records(run_dir / LANGSMITH_FLEET_ARTIFACT_NAME, records)
+
+
+def _limit_summary_max_severity(
+    limit_breach_summary: Mapping[str, Any],
+) -> Literal["warning", "fail"] | None:
+    explicit = limit_breach_summary.get("max_severity")
+    if explicit in {"warning", "fail"}:
+        return cast(Literal["warning", "fail"], explicit)
+    if int(limit_breach_summary.get("fail_breach_count") or 0) > 0:
+        return "fail"
+    if int(limit_breach_summary.get("warning_breach_count") or 0) > 0:
+        return "warning"
+    return None
 
 
 def _is_relative_to(path: Path, parent: Path) -> bool:
@@ -2176,6 +2189,7 @@ def _build_limit_breach_summary(
     return {
         "has_breaches": has_breaches,
         "breach_count": limit_breaches.breach_count,
+        "max_severity": limit_breaches.max_severity,
         "warning_breach_count": limit_breaches.warning_breach_count,
         "fail_breach_count": limit_breaches.fail_breach_count,
         "report_path": report_path,

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -46,6 +46,14 @@ from counter_risk.normalize import (
     normalize_counterparty_with_source,
     resolve_clearing_house,
 )
+from counter_risk.observability.langsmith_fleet import (
+    ARTIFACT_NAME as LANGSMITH_FLEET_ARTIFACT_NAME,
+)
+from counter_risk.observability.langsmith_fleet import (
+    FleetRunContext,
+    build_fleet_records,
+    write_fleet_records,
+)
 from counter_risk.outputs.base import OutputContext, OutputGenerator
 from counter_risk.outputs.ppt_screenshot import export_ppt_slides_as_png_via_com
 from counter_risk.outputs.registry import OutputGeneratorRegistry, OutputGeneratorRegistryContext
@@ -497,6 +505,21 @@ def run_pipeline(
     if limit_breaches.csv_path is not None:
         output_paths.append(limit_breaches.csv_path)
 
+    try:
+        langsmith_fleet_path = _write_langsmith_fleet_artifact(
+            run_dir=run_dir,
+            as_of_date=as_of_date,
+            output_paths=output_paths,
+            warnings=warnings,
+            concentration_metrics_records=concentration_metrics_records,
+            risk_proxy_summary=risk_proxy_summary,
+            limit_breach_summary=limit_breach_summary,
+        )
+        output_paths.append(langsmith_fleet_path)
+    except Exception as exc:
+        LOGGER.exception("pipeline_failed stage=langsmith_fleet_artifact run_dir=%s", run_dir)
+        raise RuntimeError("Pipeline failed during LangSmith fleet artifact stage") from exc
+
     if runtime_config.include_concentration_table_in_ppt and concentration_metrics_records:
         dist_ppt_path = run_dir / resolve_ppt_output_names(as_of_date).distribution_filename
         if dist_ppt_path.exists():
@@ -550,6 +573,55 @@ def run_pipeline(
     LOGGER.info("pipeline_complete run_dir=%s manifest=%s", run_dir, manifest_path)
 
     return run_dir
+
+
+def _write_langsmith_fleet_artifact(
+    *,
+    run_dir: Path,
+    as_of_date: date,
+    output_paths: Sequence[Path],
+    warnings: Sequence[str],
+    concentration_metrics_records: Sequence[Mapping[str, Any]],
+    risk_proxy_summary: Mapping[str, Any],
+    limit_breach_summary: Mapping[str, Any],
+) -> Path:
+    run_id = run_dir.name
+    context = FleetRunContext(
+        run_id=run_id,
+        as_of_date=as_of_date.isoformat(),
+        scenario="monthly-risk-report",
+        provider=os.environ.get("LANGCHAIN_PROVIDER"),
+        model=os.environ.get("LANGCHAIN_MODEL"),
+        trace_id=os.environ.get("LANGSMITH_TRACE_ID"),
+        trace_url=os.environ.get("LANGSMITH_TRACE_URL"),
+        github_pr=os.environ.get("PR_NUMBER"),
+    )
+    safe_output_refs = [
+        f"artifact:{path.relative_to(run_dir).as_posix()}"
+        for path in output_paths
+        if _is_relative_to(path, run_dir)
+    ]
+    risk_proxy_status = "success" if risk_proxy_summary else "skipped"
+    data_quality_status = "warning" if warnings else "success"
+    records = build_fleet_records(
+        context=context,
+        data_quality_status=data_quality_status,
+        risk_proxy_status=risk_proxy_status,
+        concentration_metric_count=len(concentration_metrics_records),
+        limit_breach_count=int(limit_breach_summary.get("breach_count") or 0),
+        limit_max_severity=cast(str | None, limit_breach_summary.get("max_severity")),
+        report_artifacts=safe_output_refs,
+        artifact_ref=f"artifact:{LANGSMITH_FLEET_ARTIFACT_NAME}",
+    )
+    return write_fleet_records(run_dir / LANGSMITH_FLEET_ARTIFACT_NAME, records)
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
 
 
 def _call_write_outputs(

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -54,6 +54,7 @@ def test_build_fleet_records_enable_langsmith_defaults_when_key_exists(
     monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_TRACING_V2, raising=False)
     monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_API_KEY, raising=False)
     monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_PROJECT, raising=False)
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGSMITH_PROJECT, raising=False)
 
     records = langsmith_fleet.build_fleet_records(
         context=langsmith_fleet.FleetRunContext(
@@ -74,6 +75,10 @@ def test_build_fleet_records_enable_langsmith_defaults_when_key_exists(
     assert records[0]["trace_url"] == "https://smith.langchain.com/r/trace-123"
     assert (
         langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_PROJECT]
+        == langsmith_fleet.DEFAULT_PROJECT
+    )
+    assert (
+        langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGSMITH_PROJECT]
         == langsmith_fleet.DEFAULT_PROJECT
     )
     assert langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_TRACING_V2] == "true"
@@ -105,4 +110,3 @@ def test_write_fleet_records_emits_deterministic_ndjson(tmp_path: Path) -> None:
     lines = path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0]) == records[0]
-

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -1,0 +1,108 @@
+"""Tests for LangSmith fleet artifact records."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from counter_risk.observability import langsmith_fleet
+
+
+def test_build_fleet_records_use_counter_risk_project_and_no_secret_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGSMITH_KEY, raising=False)
+    context = langsmith_fleet.FleetRunContext(
+        run_id="2025-12-31",
+        as_of_date="2025-12-31",
+        scenario="monthly-risk-report",
+    )
+
+    records = langsmith_fleet.build_fleet_records(
+        context=context,
+        data_quality_status="success",
+        risk_proxy_status="success",
+        concentration_metric_count=3,
+        limit_breach_count=2,
+        limit_max_severity="warning",
+        report_artifacts=["artifact:manifest.json"],
+        artifact_ref="artifact:langsmith-fleet.ndjson",
+    )
+
+    assert {record["operation"] for record in records} == {
+        "data-quality",
+        "risk-proxy",
+        "limit-monitoring",
+        "report-generation",
+    }
+    assert {record["status"] for record in records} == {"no_secret"}
+    assert all(record["schema_version"] == langsmith_fleet.SCHEMA_VERSION for record in records)
+    assert all(record["repo"] == "stranske/Counter_Risk" for record in records)
+    assert all(record["surface"] == "risk-reporting" for record in records)
+    assert all(record["github_issue"] == "stranske/Counter_Risk#610" for record in records)
+    assert all(record["domain"]["as_of_date"] == "2025-12-31" for record in records)
+    assert all(record["domain"]["scenario"] == "monthly-risk-report" for record in records)
+    assert all("raw" not in json.dumps(record).lower() for record in records)
+
+
+def test_build_fleet_records_enable_langsmith_defaults_when_key_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(langsmith_fleet.ENV_LANGSMITH_KEY, "test-key")
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_TRACING_V2, raising=False)
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_API_KEY, raising=False)
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_PROJECT, raising=False)
+
+    records = langsmith_fleet.build_fleet_records(
+        context=langsmith_fleet.FleetRunContext(
+            run_id="run-1",
+            as_of_date="2025-12-31",
+            scenario="monthly-risk-report",
+            trace_id="trace-123",
+            trace_url="https://smith.langchain.com/r/trace-123",
+        ),
+        data_quality_status="success",
+        risk_proxy_status="success",
+        concentration_metric_count=1,
+        limit_breach_count=0,
+    )
+
+    assert {record["status"] for record in records} == {"success"}
+    assert records[0]["trace_id"] == "trace-123"
+    assert records[0]["trace_url"] == "https://smith.langchain.com/r/trace-123"
+    assert (
+        langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_PROJECT]
+        == langsmith_fleet.DEFAULT_PROJECT
+    )
+    assert langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_TRACING_V2] == "true"
+    assert langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_API_KEY] == "test-key"
+
+
+def test_write_fleet_records_emits_deterministic_ndjson(tmp_path: Path) -> None:
+    path = tmp_path / langsmith_fleet.ARTIFACT_NAME
+    records = [
+        {
+            "schema_version": langsmith_fleet.SCHEMA_VERSION,
+            "repo": "stranske/Counter_Risk",
+            "surface": "risk-reporting",
+            "operation": "data-quality",
+            "run_id": "run-1",
+            "status": "no_secret",
+            "github_issue": "stranske/Counter_Risk#610",
+            "domain": {
+                "as_of_date": "2025-12-31",
+                "scenario": "monthly-risk-report",
+                "data_quality_status": "success",
+                "limit_breach_count": 0,
+            },
+        }
+    ]
+
+    langsmith_fleet.write_fleet_records(path, records)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == records[0]
+

--- a/tests/pipeline/test_manifest_schema.py
+++ b/tests/pipeline/test_manifest_schema.py
@@ -54,6 +54,7 @@ def test_manifest_schema_defines_limit_breach_summary_shape() -> None:
     assert summary["required"] == [
         "has_breaches",
         "breach_count",
+        "max_severity",
         "warning_breach_count",
         "fail_breach_count",
         "report_path",
@@ -61,6 +62,7 @@ def test_manifest_schema_defines_limit_breach_summary_shape() -> None:
     ]
     assert summary["properties"]["has_breaches"]["type"] == "boolean"
     assert summary["properties"]["breach_count"]["type"] == "integer"
+    assert summary["properties"]["max_severity"]["type"] == ["string", "null"]
     assert summary["properties"]["warning_breach_count"]["type"] == "integer"
     assert summary["properties"]["fail_breach_count"]["type"] == "integer"
     assert summary["properties"]["report_path"]["type"] == ["string", "null"]

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -201,9 +201,7 @@ def test_write_langsmith_fleet_artifact_adds_dashboard_records(tmp_path: Path) -
     )
 
     records = [
-        json.loads(line)
-        for line in artifact_path.read_text(encoding="utf-8").splitlines()
-        if line
+        json.loads(line) for line in artifact_path.read_text(encoding="utf-8").splitlines() if line
     ]
     assert artifact_path == run_dir / "langsmith-fleet.ndjson"
     assert len(records) == 4
@@ -216,7 +214,36 @@ def test_write_langsmith_fleet_artifact_adds_dashboard_records(tmp_path: Path) -
     assert all(record["domain"]["as_of_date"] == "2025-12-31" for record in records)
     assert all(record["domain"]["scenario"] == "monthly-risk-report" for record in records)
     assert all(record["domain"]["limit_breach_count"] == 1 for record in records)
+    limit_record = next(record for record in records if record["operation"] == "limit-monitoring")
+    assert limit_record["domain"]["limit_max_severity"] == "fail"
     assert records[-1]["domain"]["report_artifacts"] == ["artifact:manifest.json"]
+
+
+def test_write_langsmith_fleet_artifact_derives_limit_severity_from_counts(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "2025-12-31"
+    run_dir.mkdir()
+
+    artifact_path = run_module._write_langsmith_fleet_artifact(
+        run_dir=run_dir,
+        as_of_date=date(2025, 12, 31),
+        output_paths=[],
+        warnings=[],
+        concentration_metrics_records=[],
+        risk_proxy_summary={},
+        limit_breach_summary={
+            "breach_count": 2,
+            "warning_breach_count": 1,
+            "fail_breach_count": 1,
+        },
+    )
+
+    records = [
+        json.loads(line) for line in artifact_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+    limit_record = next(record for record in records if record["operation"] == "limit-monitoring")
+    assert limit_record["domain"]["limit_max_severity"] == "fail"
 
 
 def test_apply_daily_holdings_repo_cash_updates_all_programs_totals(
@@ -2451,6 +2478,7 @@ def test_run_pipeline_writes_limit_breaches_csv_when_breaches_exist(
     breach_row_count = max(0, len(csv_rows) - 1)
     assert breach_row_count >= 1
     assert manifest["limit_breach_summary"]["breach_count"] == breach_row_count
+    assert manifest["limit_breach_summary"]["max_severity"] == "fail"
     assert manifest["limit_breach_summary"]["warning_breach_count"] == 0
     assert manifest["limit_breach_summary"]["fail_breach_count"] == breach_row_count
     assert manifest["limit_breach_summary"]["report_path"] == "limit_breaches.csv"
@@ -2545,6 +2573,7 @@ def test_run_pipeline_limit_breach_summary_uses_warning_severity_when_no_fail_br
     run_dir = run_pipeline(config_path)
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["limit_breach_summary"]["has_breaches"] is True
+    assert manifest["limit_breach_summary"]["max_severity"] == "warning"
     assert manifest["limit_breach_summary"]["warning_breach_count"] == 1
     assert manifest["limit_breach_summary"]["fail_breach_count"] == 0
     assert "warning limit breach detected" in manifest["limit_breach_summary"]["warning_banner"]
@@ -2696,6 +2725,7 @@ def test_run_pipeline_warns_on_missing_limit_entities_by_default(
     assert manifest["limit_breach_summary"] == {
         "has_breaches": False,
         "breach_count": 0,
+        "max_severity": None,
         "warning_breach_count": 0,
         "fail_breach_count": 0,
         "report_path": None,

--- a/tests/pipeline/test_run_pipeline.py
+++ b/tests/pipeline/test_run_pipeline.py
@@ -184,6 +184,41 @@ def _minimal_workflow_config(
     )
 
 
+def test_write_langsmith_fleet_artifact_adds_dashboard_records(tmp_path: Path) -> None:
+    run_dir = tmp_path / "2025-12-31"
+    run_dir.mkdir()
+    manifest_path = run_dir / "manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+
+    artifact_path = run_module._write_langsmith_fleet_artifact(
+        run_dir=run_dir,
+        as_of_date=date(2025, 12, 31),
+        output_paths=[manifest_path],
+        warnings=[],
+        concentration_metrics_records=[{"rank": 1}],
+        risk_proxy_summary={"status": "available"},
+        limit_breach_summary={"breach_count": 1, "max_severity": "fail"},
+    )
+
+    records = [
+        json.loads(line)
+        for line in artifact_path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert artifact_path == run_dir / "langsmith-fleet.ndjson"
+    assert len(records) == 4
+    assert {record["operation"] for record in records} == {
+        "data-quality",
+        "risk-proxy",
+        "limit-monitoring",
+        "report-generation",
+    }
+    assert all(record["domain"]["as_of_date"] == "2025-12-31" for record in records)
+    assert all(record["domain"]["scenario"] == "monthly-risk-report" for record in records)
+    assert all(record["domain"]["limit_breach_count"] == 1 for record in records)
+    assert records[-1]["domain"]["report_artifacts"] == ["artifact:manifest.json"]
+
+
 def test_apply_daily_holdings_repo_cash_updates_all_programs_totals(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_langchain_runtime.py
+++ b/tests/test_langchain_runtime.py
@@ -64,6 +64,7 @@ def test_build_langsmith_metadata_sets_tracing_env_defaults(
     monkeypatch.delenv(runtime.ENV_LANGCHAIN_TRACING_V2, raising=False)
     monkeypatch.delenv(runtime.ENV_LANGCHAIN_API_KEY, raising=False)
     monkeypatch.delenv(runtime.ENV_LANGCHAIN_PROJECT, raising=False)
+    monkeypatch.delenv(runtime.ENV_LANGSMITH_PROJECT, raising=False)
 
     payload = runtime.build_langsmith_metadata(operation="counter-risk-chat")
     metadata = cast(dict[str, Any], payload["metadata"])
@@ -73,3 +74,4 @@ def test_build_langsmith_metadata_sets_tracing_env_defaults(
     assert os.environ[runtime.ENV_LANGCHAIN_TRACING_V2] == "true"
     assert os.environ[runtime.ENV_LANGCHAIN_API_KEY] == "test-key"
     assert os.environ[runtime.ENV_LANGCHAIN_PROJECT] == runtime.DEFAULT_LANGCHAIN_PROJECT
+    assert os.environ[runtime.ENV_LANGSMITH_PROJECT] == runtime.DEFAULT_LANGCHAIN_PROJECT

--- a/tests/test_langchain_runtime.py
+++ b/tests/test_langchain_runtime.py
@@ -68,7 +68,7 @@ def test_build_langsmith_metadata_sets_tracing_env_defaults(
     payload = runtime.build_langsmith_metadata(operation="counter-risk-chat")
     metadata = cast(dict[str, Any], payload["metadata"])
 
-    assert metadata["langsmith_project"] == runtime.DEFAULT_LANGCHAIN_PROJECT
+    assert metadata["langsmith_project"] == "counter-risk"
     assert metadata["operation"] == "counter-risk-chat"
     assert os.environ[runtime.ENV_LANGCHAIN_TRACING_V2] == "true"
     assert os.environ[runtime.ENV_LANGCHAIN_API_KEY] == "test-key"

--- a/tests/test_pipeline_run_dir.py
+++ b/tests/test_pipeline_run_dir.py
@@ -104,6 +104,7 @@ def test_pipeline_writes_outputs_only_to_repo_root_runs_date_dir(
         run_dir / "current-month.xlsx",
         run_dir / "current-month.pptx",
         run_dir / "DATA_QUALITY_SUMMARY.txt",
+        run_dir / "langsmith-fleet.ndjson",
     }
     for output_path in produced_paths:
         assert output_path.exists()

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -93,6 +93,7 @@ def test_read_version_raises_for_missing_source(tmp_path: Path) -> None:
 def test_assemble_release_creates_versioned_bundle_with_executable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    expected_version = "9.9.9"
     repo_root = tmp_path / "repo"
     _write_fake_repo(repo_root)
     output_dir = tmp_path / "release"
@@ -106,10 +107,10 @@ def test_assemble_release_creates_versioned_bundle_with_executable(
 
     monkeypatch.setattr(release, "_run_pyinstaller", _fake_run_pyinstaller)
 
-    bundle_dir = release.assemble_release("9.9.9", output_dir)
+    bundle_dir = release.assemble_release(expected_version, output_dir)
 
-    assert bundle_dir == output_dir / "9.9.9"
-    assert (bundle_dir / "VERSION").read_text(encoding="utf-8").strip() == "9.9.9"
+    assert bundle_dir == output_dir / expected_version
+    assert (bundle_dir / "VERSION").read_text(encoding="utf-8").strip() == expected_version
     assert (bundle_dir / "config" / "fixture_replay.yml").is_file()
     assert list((bundle_dir / "templates").glob("*.pptx"))
     assert list((bundle_dir / "templates").glob("*.xlsm"))
@@ -123,8 +124,8 @@ def test_assemble_release_creates_versioned_bundle_with_executable(
     assert "How to run" in (bundle_dir / "README_HOW_TO_RUN.md").read_text(encoding="utf-8")
 
     manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "9.9.9"
-    assert manifest["release_name"] == "9.9.9"
+    assert manifest["version"] == expected_version
+    assert manifest["release_name"] == expected_version
     assert manifest["artifacts"]["executable"] == ["bin/counter-risk"]
 
 
@@ -190,11 +191,12 @@ def test_main_accepts_version_and_output_dir(
 def test_run_release_uses_version_file_when_override_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    expected_version = "8.8.8"
     repo_root = tmp_path / "repo"
     _write_fake_repo(repo_root)
     output_dir = tmp_path / "release"
     version_file = tmp_path / "VERSION"
-    version_file.write_text("8.8.8\n", encoding="utf-8")
+    version_file.write_text(f"{expected_version}\n", encoding="utf-8")
 
     monkeypatch.setattr(release, "repository_root", lambda: repo_root)
     monkeypatch.setattr(
@@ -207,10 +209,10 @@ def test_run_release_uses_version_file_when_override_missing(
 
     bundle_dir = release.run_release(version_file=version_file, output_dir=output_dir)
 
-    assert bundle_dir == output_dir / "8.8.8"
-    assert (bundle_dir / "VERSION").read_text(encoding="utf-8").strip() == "8.8.8"
+    assert bundle_dir == output_dir / expected_version
+    assert (bundle_dir / "VERSION").read_text(encoding="utf-8").strip() == expected_version
     manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "8.8.8"
+    assert manifest["version"] == expected_version
 
 
 def test_assemble_release_fails_fast_when_release_spec_is_missing(

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,29 @@
 # Counter_Risk Workloop State
 
+## 2026-05-24T03:24:30Z - opener lane issue #610 PR materializing
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Counter_Risk`.
+- Source issue: `#610` (`Use repo-specific LangSmith project and trace risk workflows`).
+- Branch: `codex/issue-610-langsmith-risk-workflows` from `origin/main` (`2fa8298`).
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace.
+  - Required priority discovery found only Workflows `#2143`, a credential-expiry ops alert skipped by opener policy; `priority:normal`, `priority:low`, and `repo-review-approved` returned no open implementation issues.
+  - Approved queue files remain stale/empty for the `2026-05-23` review cycle, so live supported-repo issue discovery was used.
+  - Cap-health after infra repair reported one opener-owned PR, Workflows `#2151`, draining with active Gate evidence; raw cap was below 5 and no non-drainable blocker existed.
+  - The supported-repo open issue sweep found the LangSmith child issues created from the May review; `Counter_Risk#610` was selected from the oldest repo-specific implementation group.
+- Implementation:
+  - Added `counter_risk.observability.langsmith_fleet` to build and write Workflows-compatible `langsmith-fleet/v1` NDJSON records for `data-quality`, `risk-proxy`, `limit-monitoring`, and `report-generation`.
+  - Wired monthly pipeline runs to emit `langsmith-fleet.ndjson` in the run folder and include it in manifest output paths.
+  - Defaulted LangSmith project selection to the repo-specific `counter-risk` project when `LANGSMITH_API_KEY` is present, while preserving no-secret pipeline behavior.
+  - Added docs for the fleet artifact and linked them from README.
+- Validation passed:
+  - `python -m pytest tests/observability/test_langsmith_fleet.py tests/test_langchain_runtime.py tests/pipeline/test_run_pipeline.py -q` -> 122 passed in 768.05s.
+  - `python -m pytest tests/observability/test_langsmith_fleet.py tests/test_langchain_runtime.py tests/pipeline/test_run_pipeline.py::test_write_langsmith_fleet_artifact_adds_dashboard_records -q` -> 7 passed.
+  - `python -m ruff check src/counter_risk/observability/langsmith_fleet.py src/counter_risk/chat/providers/langchain_runtime.py src/counter_risk/pipeline/run.py tests/observability/test_langsmith_fleet.py tests/test_langchain_runtime.py tests/pipeline/test_run_pipeline.py` -> pass.
+  - `git diff --check` -> pass.
+- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit `pr_opened` relay so keepalive owns CI/review follow-up.
+
 ## 2026-05-09T05:09:01Z - opener lane issue #552 PR materializing
 
 - Automation: `pd-workloop-resume` (codex opener lane).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -22,7 +22,10 @@
   - `python -m pytest tests/observability/test_langsmith_fleet.py tests/test_langchain_runtime.py tests/pipeline/test_run_pipeline.py::test_write_langsmith_fleet_artifact_adds_dashboard_records -q` -> 7 passed.
   - `python -m ruff check src/counter_risk/observability/langsmith_fleet.py src/counter_risk/chat/providers/langchain_runtime.py src/counter_risk/pipeline/run.py tests/observability/test_langsmith_fleet.py tests/test_langchain_runtime.py tests/pipeline/test_run_pipeline.py` -> pass.
   - `git diff --check` -> pass.
-- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit `pr_opened` relay so keepalive owns CI/review follow-up.
+- PR: `#629` (`https://github.com/stranske/Counter_Risk/pull/629`), ready for review, non-draft, branch `codex/issue-610-langsmith-risk-workflows`, head `34bf252`.
+- Labels: `agent:codex`, `agents:keepalive`, `autofix`.
+- Relay event emitted: `pr_opened active.source_repo=stranske/Counter_Risk active.source_issue=610 active.source_pr=629 active.next_action=wait_for_keepalive`.
+- Next action: keepalive owns PR `#629` for CI, review comments, and follow-up commits. Opener is done with this issue.
 
 ## 2026-05-09T05:09:01Z - opener lane issue #552 PR materializing
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:610 -->
> **Source:** Issue #610

Closes #610

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Counter_Risk already has chat trace correlation, but the monthly risk/report workflows need richer run-level metadata and a repo-specific LangSmith project to make optimization practical. The repo's core outputs include data-quality summaries, concentration metrics, risk proxy outputs, and limit breaches; LangSmith collection should make those workflow outcomes traceable without exposing sensitive counterparty data.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Workflows#2150](https://github.com/stranske/Workflows/issues/2150)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Confirm and set the default LangSmith project name for Counter_Risk.
- [x] Preserve existing chat trace IDs/URLs and correlation behavior.
- [ ] Add workflow spans or trace events for data-quality summary, concentration metrics, risk proxy outputs, limit monitoring, report generation, and related chat/explanation calls where applicable.
- [x] Add shared metadata for run ID, as-of date, scenario, provider, model, status, trace ID/URL, latency, and error category.
- [ ] Add domain metadata for data-quality status, concentration metric availability, risk proxy status, limit breach count/severity, and report artifact references where available.
- [ ] Emit dashboard-compatible `langsmith-fleet/v1` NDJSON records with shared fields plus Counter_Risk domain metadata.
- [ ] Add fixtures or tests for successful workflow trace records, error/fallback records, project selection, and no-secret fallback.
- [ ] Update docs/runbooks that explain how chat and risk workflow traces should be inspected together.

#### Acceptance criteria
- [x] Counter_Risk uses a repo-specific LangSmith project by default.
- [x] Chat trace correlation remains intact.
- [ ] Risk/report workflow traces include run, as-of date, scenario, limit, provider/model, status, trace ID/URL, and error metadata.
- [ ] Dashboard records validate against the Workflows fleet contract from stranske/Workflows#2150.
- [ ] Dashboard artifacts use hashes or artifact references instead of raw sensitive exposure/report data.
- [ ] Tests cover project selection, trace metadata, dashboard record emission, and no-secret fallback.
- [ ] Documentation identifies which workflow artifacts can be correlated with trace records.

<!-- auto-status-summary:end -->