### PR TITLE
Register `counter-risk` console-script entry point (#643)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ Repository = "https://github.com/stranske/Template"
 
 [project.scripts]
 mapping_diff_report = "counter_risk.cli.mapping_diff_report:main"
+# `counter-risk` is the documented operator/maintainer entry point (README "run"/"gui").
+# The GUI is exposed via the existing `counter-risk gui` subcommand, so no separate
+# `counter-risk-gui` script is declared (single CLI, single console script).
+counter-risk = "counter_risk.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,11 +39,11 @@ def test_console_script_entry_point_help_exits_zero() -> None:
     from counter_risk.cli import main
 
     try:
-        main(["--help"])
+        exit_code = main(["--help"])
     except SystemExit as exc:  # argparse --help raises SystemExit(0)
         assert exc.code in (0, None)
     else:  # main returned normally
-        pass
+        assert exit_code == 0
 
 
 def test_cli_help_exits_zero() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,45 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
+
+
+def test_console_script_declared() -> None:
+    """The documented `counter-risk` operator command must be a real console script.
+
+    Failing-first gate for issue #643: on the pre-change tree `[project.scripts]`
+    only declares `mapping_diff_report`, so `pip install` produces no `counter-risk`
+    executable and the README's `counter-risk run/gui ...` commands are
+    "command not found". This asserts the missing registration.
+    """
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with pyproject.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    scripts = data["project"]["scripts"]
+    assert scripts["counter-risk"] == "counter_risk.cli:main"
+
+
+def test_console_script_entry_point_help_exits_zero() -> None:
+    """The console-script target (`counter_risk.cli:main`) returns 0 for --help.
+
+    Mirrors the `python -m counter_risk.cli --help` smoke below, but invokes the
+    exact callable that the declared `counter-risk` entry point resolves to,
+    proving the script reaches the real handler.
+    """
+    src_path = str(Path("src").resolve())
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+    from counter_risk.cli import main
+
+    try:
+        main(["--help"])
+    except SystemExit as exc:  # argparse --help raises SystemExit(0)
+        assert exc.code in (0, None)
+    else:  # main returned normally
+        pass
 
 
 def test_cli_help_exits_zero() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:643 -->
> **Source:** Issue #643

Closes #643

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Issue #643 scope: register the documented `counter-risk` console script, document the single-CLI `counter-risk gui` decision, and add regression coverage for the declared entry point.

#### Tasks
- [x] Add `counter-risk = "counter_risk.cli:main"` under `[project.scripts]` in `pyproject.toml` (alongside the existing `mapping_diff_report` line at `pyproject.toml:52-53`).
- [x] Decide whether to also add `counter-risk-gui = "counter_risk.cli:main"` or to rely on the existing `counter-risk gui` subcommand (`counter_risk/cli/__init__.py` `gui_parser`); document the chosen form in the same commit.
- [x] Add a test `test_console_script_declared` to `tests/test_cli.py` that loads `pyproject.toml` with `tomllib` and asserts `project.scripts["counter-risk"] == "counter_risk.cli:main"` (this assertion fails on the current tree).
- [x] Extend `tests/test_cli.py` with a test that runs the installed/declared entry point's target — i.e. import `counter_risk.cli.main` and invoke `main(["--help"])`, asserting it returns `0` (mirrors the existing `python -m` smoke at `tests/test_cli.py:test_cli_help_exits_zero`).
- [x] Verify `requirements.lock` / `requirements-dev.lock` need no change for this (scripts are not lock entries) and confirm `tests/test_dependency_version_alignment.py` still passes.

#### Acceptance criteria
- [x] New test `tests/test_cli.py::test_console_script_declared` asserts the `counter-risk` → `counter_risk.cli:main` mapping and FAILS on the pre-change tree, PASSES after the edit (name the case in the PR description as the failing-first gate).
- [x] In a fresh virtualenv, `pip install .` then `counter-risk --help` exits 0 and the help output contains the `run` and `gui` subcommands (the parser's `prog="counter-risk"`, `counter_risk/cli/__init__.py:44`, already advertises both).
- [x] `counter-risk gui --headless --as-of-date 2025-12-31 --mode all --dry-run-discovery` exits 0 with "Counter Risk GUI headless run completed" (same behavior as the documented `python -m counter_risk.cli gui ...` smoke), proving the script reaches the real handler.

- [x] **Implementation Notes** Entry point: `counter_risk/cli/__init__.py:474`. `build_parser()` (`cli/__init__.py:42`) already sets `prog="counter-risk"`, so help text is consistent once the script exists. Use `tomllib` (stdlib, the repo targets py>=3.12 per `pyproject.toml:10`) in the test rather than adding a parser dependency. Keep the change minimal — a single `[project.scripts]` line plus tests.

- [x] ---

- [x] ---
- [x] _Filed from the 2026-05-29 design-vs-implementation + blueprint review (upgraded issue set)._

<!-- auto-status-summary:end -->
