### PR TITLE
Enforce full run manifest against manifest_schema() and gate it (#648)

### DIFF
--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -13,6 +13,7 @@ from typing import Any
 from counter_risk.config import WorkflowConfig
 from counter_risk.dates import DateResolution
 from counter_risk.pipeline.data_quality import build_data_quality
+from counter_risk.pipeline.manifest_schema import validate_manifest
 from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
 from counter_risk.pipeline.warnings import WarningsCollector
 
@@ -144,6 +145,9 @@ class ManifestBuilder:
                 encoding="utf-8",
             )
             self._register_summary_artifact(manifest)
+            is_valid, reason = validate_manifest(manifest)
+            if not is_valid:
+                raise ValueError(f"Manifest failed schema validation: {reason}")
             path.write_text(
                 json.dumps(manifest, sort_keys=True, indent=2) + "\n",
                 encoding="utf-8",

--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -139,15 +139,17 @@ class ManifestBuilder:
     def write(self, *, run_dir: Path, manifest: dict[str, Any]) -> Path:
         summary_path = run_dir / _DATA_QUALITY_SUMMARY_FILENAME
         path = run_dir / "manifest.json"
+        # Build the summary text and register its artifact in-memory, then validate
+        # the manifest *before* touching disk. Writing the summary first meant a
+        # schema-validation failure left a partially-written run directory; validating
+        # up front keeps the failure path side-effect free.
+        summary_text = self._build_data_quality_summary(manifest)
+        self._register_summary_artifact(manifest)
+        is_valid, reason = validate_manifest(manifest)
+        if not is_valid:
+            raise ValueError(f"Manifest failed schema validation: {reason}")
         try:
-            summary_path.write_text(
-                self._build_data_quality_summary(manifest),
-                encoding="utf-8",
-            )
-            self._register_summary_artifact(manifest)
-            is_valid, reason = validate_manifest(manifest)
-            if not is_valid:
-                raise ValueError(f"Manifest failed schema validation: {reason}")
+            summary_path.write_text(summary_text, encoding="utf-8")
             path.write_text(
                 json.dumps(manifest, sort_keys=True, indent=2) + "\n",
                 encoding="utf-8",

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -156,6 +156,46 @@ _REPO_CASH_SUMMARY_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+# A single date-resolution entry as emitted by ``DateResolution.to_manifest_entry``
+# (``src/counter_risk/dates.py``) and the unresolved fallback in
+# ``ManifestBuilder._render_date_resolution_entry``. ``details`` is an open-ended
+# provenance map (e.g. ``{"config_field": "as_of_date"}``), so it stays untyped.
+_DATE_RESOLUTION_ENTRY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["value", "source", "details"],
+    "properties": {
+        "value": {"type": "string"},
+        "source": {"type": "string"},
+        "details": {"type": "object"},
+    },
+    "additionalProperties": False,
+}
+
+# ``date_resolution`` block emitted unconditionally by ``ManifestBuilder.build``
+# (``src/counter_risk/pipeline/manifest.py``).
+_DATE_RESOLUTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["as_of_date", "run_date"],
+    "properties": {
+        "as_of_date": _DATE_RESOLUTION_ENTRY_SCHEMA,
+        "run_date": _DATE_RESOLUTION_ENTRY_SCHEMA,
+    },
+    "additionalProperties": False,
+}
+
+# ``risk_proxy_summary`` block emitted conditionally by ``ManifestBuilder.build``
+# (sourced from ``_build_risk_proxy_summary`` in ``src/counter_risk/pipeline/run.py``).
+# The per-variant payload is open-ended, so the inner objects stay permissive.
+_RISK_PROXY_SUMMARY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["outputs", "by_variant"],
+    "properties": {
+        "outputs": {"type": "object"},
+        "by_variant": {"type": "object"},
+    },
+    "additionalProperties": True,
+}
+
 
 def manifest_schema() -> dict[str, Any]:
     """Return the run manifest schema used by pipeline validation."""
@@ -272,6 +312,8 @@ def manifest_schema() -> dict[str, Any]:
                 "additionalProperties": False,
             },
             "repo_cash_summary": _REPO_CASH_SUMMARY_SCHEMA,
+            "date_resolution": _DATE_RESOLUTION_SCHEMA,
+            "risk_proxy_summary": _RISK_PROXY_SUMMARY_SCHEMA,
         },
         "additionalProperties": False,
     }
@@ -356,4 +398,104 @@ def validate_manifest_data_quality(manifest: Mapping[str, Any]) -> tuple[bool, s
                 f"Manifest data_quality recommended_actions[{index}] must include non-empty action.",
             )
 
+    return True, None
+
+
+def _matches_type(value: Any, type_name: str) -> bool:
+    """Return True when ``value`` matches a single JSON Schema ``type`` name."""
+
+    if type_name == "object":
+        return isinstance(value, Mapping)
+    if type_name == "array":
+        return isinstance(value, list)
+    if type_name == "string":
+        return isinstance(value, str)
+    if type_name == "integer":
+        # JSON integers are not booleans, even though ``bool`` subclasses ``int``.
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if type_name == "boolean":
+        return isinstance(value, bool)
+    if type_name == "null":
+        return value is None
+    # Unknown type keyword: be permissive rather than reject valid runs.
+    return True
+
+
+def _check_node(value: Any, schema: Mapping[str, Any], path: str) -> str | None:
+    """Validate ``value`` against ``schema`` at ``path``.
+
+    Returns a deterministic, human-readable reason on the first failure, or
+    ``None`` when the node (and its descendants) conform. Supports the subset of
+    JSON Schema the manifest schema actually uses: ``type`` (including union
+    types like ``["string", "null"]``), ``required``, ``enum``, ``minimum``,
+    ``minLength``, ``minItems``, nested ``properties``, array ``items``, and
+    ``additionalProperties`` (``False``/``True``).
+    """
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        type_names = expected_type if isinstance(expected_type, list) else [expected_type]
+        if not any(_matches_type(value, name) for name in type_names):
+            rendered = " or ".join(str(name) for name in type_names)
+            return f"{path} must be of type {rendered}, got {type(value).__name__}"
+
+    if "enum" in schema and value not in schema["enum"]:
+        allowed = ", ".join(repr(option) for option in schema["enum"])
+        return f"{path} must be one of: {allowed}"
+
+    if (
+        "minimum" in schema
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value < schema["minimum"]
+    ):
+        return f"{path} must be >= {schema['minimum']}"
+
+    if "minLength" in schema and isinstance(value, str) and len(value) < schema["minLength"]:
+        return f"{path} must have at least {schema['minLength']} character(s)"
+
+    if "minItems" in schema and isinstance(value, list) and len(value) < schema["minItems"]:
+        return f"{path} must have at least {schema['minItems']} item(s)"
+
+    if isinstance(value, Mapping):
+        for required_key in schema.get("required", []):
+            if required_key not in value:
+                return f"{path} is missing required key '{required_key}'"
+
+        properties = schema.get("properties", {})
+        additional = schema.get("additionalProperties", True)
+        for key, child_value in value.items():
+            if key in properties:
+                child_path = f"{path}.{key}" if path else str(key)
+                reason = _check_node(child_value, properties[key], child_path)
+                if reason is not None:
+                    return reason
+            elif additional is False:
+                return f"{path} contains unexpected key '{key}' (additionalProperties is false)"
+
+    if isinstance(value, list):
+        items_schema = schema.get("items")
+        if isinstance(items_schema, Mapping):
+            for index, item in enumerate(value):
+                reason = _check_node(item, items_schema, f"{path}[{index}]")
+                if reason is not None:
+                    return reason
+
+    return None
+
+
+def validate_manifest(manifest: Mapping[str, Any]) -> tuple[bool, str | None]:
+    """Validate a full run manifest against :func:`manifest_schema`.
+
+    Returns ``(True, None)`` when ``manifest`` conforms, or ``(False, reason)``
+    with a deterministic human-readable explanation of the first violation
+    (type mismatch, missing required key, bad enum value, or an unknown
+    top-level/nested key rejected by ``additionalProperties: False``).
+    """
+
+    reason = _check_node(manifest, manifest_schema(), "manifest")
+    if reason is not None:
+        return False, reason
     return True, None

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -431,7 +431,10 @@ def _check_node(value: Any, schema: Mapping[str, Any], path: str) -> str | None:
     JSON Schema the manifest schema actually uses: ``type`` (including union
     types like ``["string", "null"]``), ``required``, ``enum``, ``minimum``,
     ``minLength``, ``minItems``, nested ``properties``, array ``items``, and
-    ``additionalProperties`` (``False``/``True``).
+    ``additionalProperties`` in all three forms the manifest schema relies on:
+    ``False`` (reject unknown keys), ``True`` (accept any), and the schema-object
+    form (validate every non-``properties`` key's value against that sub-schema,
+    e.g. the ``by_category`` / ``by_variant`` maps).
     """
 
     expected_type = schema.get("type")
@@ -474,6 +477,14 @@ def _check_node(value: Any, schema: Mapping[str, Any], path: str) -> str | None:
                     return reason
             elif additional is False:
                 return f"{path} contains unexpected key '{key}' (additionalProperties is false)"
+            elif isinstance(additional, Mapping):
+                # Schema-object form: every key not covered by ``properties`` must
+                # validate against the ``additionalProperties`` sub-schema (e.g. the
+                # ``by_category`` / ``by_variant`` maps in ``manifest_schema()``).
+                child_path = f"{path}.{key}" if path else str(key)
+                reason = _check_node(child_value, additional, child_path)
+                if reason is not None:
+                    return reason
 
     if isinstance(value, list):
         items_schema = schema.get("items")
@@ -491,8 +502,10 @@ def validate_manifest(manifest: Mapping[str, Any]) -> tuple[bool, str | None]:
 
     Returns ``(True, None)`` when ``manifest`` conforms, or ``(False, reason)``
     with a deterministic human-readable explanation of the first violation
-    (type mismatch, missing required key, bad enum value, or an unknown
-    top-level/nested key rejected by ``additionalProperties: False``).
+    (type mismatch, missing required key, bad enum value, an unknown
+    top-level/nested key rejected by ``additionalProperties: False``, or a value
+    under an ``additionalProperties`` schema-object map that violates that
+    sub-schema).
     """
 
     reason = _check_node(manifest, manifest_schema(), "manifest")

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2543,6 +2543,13 @@ def _write_outputs(
 
     if refresh_result.status == PptProcessingStatus.FAILED:
         manifest_ppt_outputs["master"]["status"] = "failed"
+        manifest_ppt_outputs["distribution"] = {
+            "role": "distribution",
+            "status": "skipped",
+            "path": target_distribution_ppt.relative_to(run_dir).as_posix(),
+            "generation_step": "ppt_distribution",
+            "skipped_reason": "Master PPT refresh failed; distribution PPT derivation skipped.",
+        }
         LOGGER.warning(
             "Skipping distribution PPT derivation because Master PPT refresh failed: %s",
             target_master_ppt,

--- a/tests/pipeline/test_manifest_schema_conformance.py
+++ b/tests/pipeline/test_manifest_schema_conformance.py
@@ -1,0 +1,103 @@
+"""End-to-end conformance of a built manifest against ``manifest_schema()``.
+
+Unlike ``tests/pipeline/test_manifest_schema.py`` (which only asserts on the
+schema dict's own shape), this module constructs a real manifest through
+``ManifestBuilder.build`` and validates it with ``validate_manifest`` so the run
+contract cannot silently drift. It is deliberately *not* named
+``test_run_pipeline_*`` and not placed under ``tests/integration`` so it runs in
+the PR gate (``pytest -m "not release and not slow"``) rather than only on main.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from counter_risk.config import WorkflowConfig
+from counter_risk.pipeline.manifest import ManifestBuilder
+from counter_risk.pipeline.manifest_schema import validate_manifest
+
+
+def _make_config(tmp_path: Path) -> WorkflowConfig:
+    return WorkflowConfig(
+        as_of_date=date(2026, 2, 13),
+        mosers_all_programs_xlsx=tmp_path / "all.xlsx",
+        mosers_ex_trend_xlsx=tmp_path / "ex.xlsx",
+        mosers_trend_xlsx=tmp_path / "trend.xlsx",
+        hist_all_programs_3yr_xlsx=tmp_path / "hist-all.xlsx",
+        hist_ex_llc_3yr_xlsx=tmp_path / "hist-ex.xlsx",
+        hist_llc_3yr_xlsx=tmp_path / "hist-trend.xlsx",
+        monthly_pptx=tmp_path / "monthly.pptx",
+        output_root=tmp_path / "output-root",
+    )
+
+
+def _build_manifest(tmp_path: Path) -> tuple[ManifestBuilder, Path, dict]:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    workbook_path = run_dir / "Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx"
+    ppt_path = run_dir / "Monthly Counterparty Exposure Report.pptx"
+    workbook_path.write_bytes(b"hist")
+    ppt_path.write_bytes(b"ppt")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(workbook_path.name), Path(ppt_path.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+    )
+    return builder, run_dir, manifest
+
+
+def test_built_manifest_conforms_to_schema(tmp_path: Path) -> None:
+    """A manifest produced by ``ManifestBuilder.build`` must satisfy the schema.
+
+    On the un-reconciled schema this FAILS because the unconditionally emitted
+    ``date_resolution`` key trips ``additionalProperties: False``; it PASSES once
+    the schema accepts the keys the builder already emits.
+    """
+
+    _builder, _run_dir, manifest = _build_manifest(tmp_path)
+
+    # Guard against the regression this issue fixes: these keys are emitted by
+    # the builder and must be representable in the schema.
+    assert "date_resolution" in manifest
+
+    is_valid, reason = validate_manifest(manifest)
+    assert is_valid, reason
+    assert reason is None
+
+
+def test_validate_manifest_rejects_unknown_top_level_key(tmp_path: Path) -> None:
+    """An un-schema'd top-level key is rejected with a reason naming the key."""
+
+    _builder, _run_dir, manifest = _build_manifest(tmp_path)
+    manifest["__unknown__"] = 1
+
+    is_valid, reason = validate_manifest(manifest)
+    assert is_valid is False
+    assert reason is not None
+    assert "__unknown__" in reason
+
+
+def test_write_raises_on_unknown_key(tmp_path: Path) -> None:
+    """``ManifestBuilder.write`` must raise ``ValueError`` for an un-schema'd key.
+
+    This proves a real run that produces an unexpected key fails at write time
+    rather than silently persisting a drifted contract.
+    """
+
+    builder, run_dir, manifest = _build_manifest(tmp_path)
+    manifest["__unknown__"] = 1
+
+    with pytest.raises(ValueError, match="Manifest failed schema validation"):
+        builder.write(run_dir=run_dir, manifest=manifest)

--- a/tests/pipeline/test_manifest_schema_conformance.py
+++ b/tests/pipeline/test_manifest_schema_conformance.py
@@ -101,3 +101,42 @@ def test_write_raises_on_unknown_key(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Manifest failed schema validation"):
         builder.write(run_dir=run_dir, manifest=manifest)
+
+
+def test_validate_manifest_enforces_additional_properties_subschema(tmp_path: Path) -> None:
+    """Values under an ``additionalProperties`` schema-object map are validated.
+
+    ``unmatched_mappings.by_variant`` declares
+    ``additionalProperties: {"type": "array", ...}``; a non-array value must be
+    rejected. Previously only the ``additionalProperties: False`` form was
+    enforced, so schema-object maps (``by_variant`` / ``by_category``) silently
+    accepted any value, defeating the point of gating the full manifest.
+    """
+
+    _builder, _run_dir, manifest = _build_manifest(tmp_path)
+    manifest["unmatched_mappings"]["by_variant"]["all_programs"] = "not-an-array"
+
+    is_valid, reason = validate_manifest(manifest)
+    assert is_valid is False
+    assert reason is not None
+    assert "by_variant.all_programs" in reason
+    assert "array" in reason
+
+
+def test_write_validation_failure_leaves_no_partial_output(tmp_path: Path) -> None:
+    """A schema-validation failure in ``write`` must not persist partial files.
+
+    Regression guard: the data-quality summary used to be written to disk before
+    the manifest was validated, so a failing manifest left a stray
+    ``DATA_QUALITY_SUMMARY.txt`` in the run directory. Validation now happens
+    before any write, so the failure path is side-effect free.
+    """
+
+    builder, run_dir, manifest = _build_manifest(tmp_path)
+    manifest["__unknown__"] = 1
+
+    with pytest.raises(ValueError, match="Manifest failed schema validation"):
+        builder.write(run_dir=run_dir, manifest=manifest)
+
+    assert not (run_dir / "DATA_QUALITY_SUMMARY.txt").exists()
+    assert not (run_dir / "manifest.json").exists()

--- a/tests/test_manifest_paths.py
+++ b/tests/test_manifest_paths.py
@@ -113,6 +113,7 @@ def test_manifest_includes_repo_cash_summary_when_provided(tmp_path: Path) -> No
     repo_cash_summary = {
         "source_type": "csv",
         "source_path": "inputs/repo_cash_2026-02-13.csv",
+        "skipped_reason": None,
         "overrides_path": "inputs/cash_overrides_2026-02-13.csv",
         "applied_override_count": 2,
         "raw_override_row_count": 2,
@@ -124,6 +125,8 @@ def test_manifest_includes_repo_cash_summary_when_provided(tmp_path: Path) -> No
                 "note": "year-end true-up",
             }
         ],
+        "duplicate_counterparty_names": [],
+        "orphan_override_counterparties": [],
         "counterparty_count": 5,
         "total_cash": 12345.67,
         "required_counterparties": ["ACME", "BARCLAYS"],


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:648 -->
> **Source:** Issue #648

Closes #648

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
**Why.** `manifest_schema()` (`src/counter_risk/pipeline/manifest_schema.py:160-277`) is a complete contract with `additionalProperties: False` (`manifest_schema.py:276`), but it is **never validated against an actual written `manifest.json`**. Confirmed by grep: no `def validate_manifest` and no `validate(manifest, schema)` call site exists anywhere in `src/` or `tests/` beyond the two partial helpers `validate_manifest_ppt_outputs` and `validate_manifest_data_quality` (`manifest_schema.py:280,305`). The existing `tests/pipeline/test_manifest_schema.py` only asserts on the schema *dict's own shape* (e.g. `schema["properties"]["ppt_outputs"]["required"]`), never on a built manifest. So the run contract can silently drift — and in fact **already has**: `ManifestBuilder.build` unconditionally emits `date_resolution` (`manifest.py:100`) and conditionally emits `risk_proxy_summary` (`manifest.py:130-131`, sourced from `run.py:442`/`run.py:612`), neither of which appears in `manifest_schema()` (grep for `date_resolution`/`risk_proxy_summary` in `manifest_schema.py` → zero hits). A naive `additionalProperties: False` validation would reject every real production run today. This defeats the "runs replay & test" guarantee the blueprint requires and is the gating prerequisite for the provenance, structured-warnings, and evidence issues below (each adds a manifest key that must survive validation).

**Scope.** (1) Add a single full-manifest validator and invoke it at write time. (2) Reconcile the schema so it accepts the keys the builder already emits (`date_resolution`, `risk_proxy_summary`) — fix the **schema**, not the builder, to avoid breaking existing manifest consumers. (3) Add a NON-`slow` test that builds a real manifest via `ManifestBuilder` and asserts conformance, so the check runs in the PR Gate (`pr-00-gate.yml`), not only post-merge.

**Non-Goals.**

#### Tasks
- [ ] Do NOT add any new manifest *payload* fields here (provenance, structured warnings, evidence each have their own issue).
- [ ] Do NOT add the heavyweight `jsonschema` package solely for this; a hand-rolled walker consistent with the existing partial validators is acceptable (see Implementation Notes). If `jsonschema` is added, it must be a real runtime dependency in `pyproject.toml`, not an undeclared import.
- [ ] Scaffold-only completion is explicitly disallowed: a `validate_manifest` function that exists but is never called from `ManifestBuilder.write`, or that is only exercised on a hand-built fixture dict (not a `ManifestBuilder`-produced manifest), does NOT satisfy this issue.
- [ ] Do NOT route schema validation through `run_fixture_replay` (`src/counter_risk/pipeline/fixture_replay.py:43`) — that function writes its own minimal `{mode, outputs}` manifest (`fixture_replay.py:69-77`), NOT a `ManifestBuilder` manifest, so it cannot exercise the schema.

#### Acceptance criteria
- [ ] Add `validate_manifest(manifest: Mapping[str, Any]) -> tuple[bool, str | None]` to `src/counter_risk/pipeline/manifest_schema.py`, validating `manifest` against `manifest_schema()` (type checks, required-key presence, and `additionalProperties: False` rejection of unknown top-level keys), returning a deterministic human-readable reason on failure in the same style as `validate_manifest_data_quality` (`manifest_schema.py:305-359`).
- [ ] Add `date_resolution` and `risk_proxy_summary` to `manifest_schema()` `properties` (both optional — NOT added to `required`), shaped to match what `_build_date_resolution_block` (`manifest.py:354-364`) and `_build_risk_proxy_summary` (referenced at `run.py:442`) actually emit, so `additionalProperties: False` stops rejecting valid runs.
- [ ] Invoke `validate_manifest` inside `ManifestBuilder.write` (`manifest.py:138-153`) BEFORE `path.write_text(...)` at `manifest.py:147`; on `(False, reason)` raise `ValueError(f"Manifest failed schema validation: {reason}")` so the existing `run.py:617-620` `pipeline_failed stage=manifest_write` handler reports it.
- [ ] Add `tests/pipeline/test_manifest_schema_conformance.py` (NOT named `test_run_pipeline_*` and NOT under `tests/integration` — those paths auto-acquire the `slow`/integration marker via `tests/pipeline/conftest.py:15-22` and `tests/conftest.py:11-22`) that constructs a manifest through `ManifestBuilder.build` exactly as `tests/test_manifest_paths.py:37-50` does, calls `validate_manifest`, and asserts `(True, None)`.
- [ ] In the same test, add a case that injects an un-schema'd top-level key (e.g. `manifest["__unknown__"] = 1`) and asserts `validate_manifest` returns `(False, <reason mentioning the key>)`.

<!-- auto-status-summary:end -->