### PR TITLE
Add manifest_schema_version + provenance to run manifest (#649)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A programmatic replacement for the MOSERS spreadsheet workflow used to evaluate 
 
 - Updated historical Excel workbooks (time series inputs for charts)
 - Updated monthly PowerPoint (screenshots replaced + chart links refreshed)
-- A run folder with a manifest (inputs, hashes, warnings, summaries)
+- A run folder with a manifest (inputs, hashes, warnings, summaries). The manifest carries a top-level `manifest_schema_version` (currently `"counter-risk-manifest/v1"`) so the contract can evolve safely, and a `provenance` block tying the run to the exact code that produced it: `tool`, `tool_version`, `git_sha` (best-effort; `null` outside a git checkout), `python_version`, and `platform`.
 - Registry-backed counterparty and clearing-house name matching (see [docs/name_registry.md](docs/name_registry.md))
 - A `DATA_QUALITY_SUMMARY.txt` and manifest `data_quality` object for green/yellow/red operator review (see [docs/data_quality.md](docs/data_quality.md))
 - A `concentration_metrics.csv` with Top 5/Top 10 share and HHI per `(variant, segment)` (see [docs/concentration_metrics.md](docs/concentration_metrics.md))

--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 import json
+import platform as platform_module
 import posixpath
+import subprocess
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+import counter_risk
 from counter_risk.config import WorkflowConfig
 from counter_risk.dates import DateResolution
 from counter_risk.pipeline.data_quality import build_data_quality
-from counter_risk.pipeline.manifest_schema import validate_manifest
+from counter_risk.pipeline.manifest_schema import MANIFEST_SCHEMA_VERSION, validate_manifest
 from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
 from counter_risk.pipeline.warnings import WarningsCollector
 
@@ -96,6 +99,8 @@ class ManifestBuilder:
             }
         )
         manifest: dict[str, Any] = {
+            "manifest_schema_version": MANIFEST_SCHEMA_VERSION,
+            "provenance": self._build_provenance(),
             "as_of_date": self.as_of_date.isoformat(),
             "run_date": self.run_date.isoformat(),
             "date_resolution": self._build_date_resolution_block(),
@@ -135,6 +140,45 @@ class ManifestBuilder:
         if repo_cash_summary is not None:
             manifest["repo_cash_summary"] = repo_cash_summary
         return manifest
+
+    def _build_provenance(self) -> dict[str, Any]:
+        """Capture the producing tool's identity so a run can be tied to its code.
+
+        Side-effect free: ``git_sha`` resolution is best-effort and returns
+        ``None`` (never raises) when the source is not a git checkout, so a run
+        from an installed wheel or archived tree still succeeds.
+        """
+        return {
+            "tool": "counter-risk",
+            "tool_version": counter_risk.__version__,
+            "git_sha": self._resolve_git_sha(),
+            "python_version": platform_module.python_version(),
+            "platform": platform_module.platform(),
+        }
+
+    @staticmethod
+    def _resolve_git_sha() -> str | None:
+        """Return the current commit SHA, or ``None`` if it cannot be determined.
+
+        Runs ``git rev-parse HEAD`` against the package's source tree. Any
+        failure (git absent, not a checkout, non-zero exit, timeout) is swallowed
+        so manifest construction never depends on a git environment.
+        """
+        repo_dir = Path(__file__).resolve().parent
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo_dir), "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        sha = result.stdout.strip()
+        return sha or None
 
     def write(self, *, run_dir: Path, manifest: dict[str, Any]) -> Path:
         summary_path = run_dir / _DATA_QUALITY_SUMMARY_FILENAME

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+# Contract version stamped onto every manifest via ``ManifestBuilder.build``.
+# Bump this (and the schema below) when the manifest contract changes in a way
+# consumers must branch on. Kept beside the schema so the version and the shape
+# it describes evolve together.
+MANIFEST_SCHEMA_VERSION = "counter-risk-manifest/v1"
+
 _PPT_OUTPUT_ENTRY_SCHEMA: dict[str, Any] = {
     "type": "object",
     "required": ["role", "status", "path", "generation_step"],
@@ -196,6 +202,23 @@ _RISK_PROXY_SUMMARY_SCHEMA: dict[str, Any] = {
     "additionalProperties": True,
 }
 
+# ``provenance`` block emitted unconditionally by ``ManifestBuilder._build_provenance``
+# (``src/counter_risk/pipeline/manifest.py``). Ties a run to the exact code that
+# produced it. ``git_sha`` is nullable because best-effort resolution must still
+# succeed outside a git checkout (installed wheel, archived source).
+_PROVENANCE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["tool", "tool_version", "git_sha", "python_version", "platform"],
+    "properties": {
+        "tool": {"type": "string", "minLength": 1},
+        "tool_version": {"type": "string", "minLength": 1},
+        "git_sha": {"type": ["string", "null"]},
+        "python_version": {"type": "string", "minLength": 1},
+        "platform": {"type": "string", "minLength": 1},
+    },
+    "additionalProperties": False,
+}
+
 
 def manifest_schema() -> dict[str, Any]:
     """Return the run manifest schema used by pipeline validation."""
@@ -203,6 +226,7 @@ def manifest_schema() -> dict[str, Any]:
     return {
         "type": "object",
         "required": [
+            "manifest_schema_version",
             "as_of_date",
             "run_date",
             "run_dir",
@@ -217,8 +241,11 @@ def manifest_schema() -> dict[str, Any]:
             "unmatched_mappings",
             "missing_inputs",
             "reconciliation_results",
+            "provenance",
         ],
         "properties": {
+            "manifest_schema_version": {"type": "string", "minLength": 1},
+            "provenance": _PROVENANCE_SCHEMA,
             "as_of_date": {"type": "string"},
             "run_date": {"type": "string"},
             "run_dir": {"type": "string"},

--- a/tests/pipeline/test_manifest_provenance.py
+++ b/tests/pipeline/test_manifest_provenance.py
@@ -1,0 +1,139 @@
+"""Provenance + schema-version contract for built run manifests (issue #649).
+
+``ManifestBuilder.build`` must stamp a top-level ``manifest_schema_version`` and a
+populated ``provenance`` block (tool / tool_version / git_sha / python_version /
+platform) so a replayed or compared run can be tied to the exact code that
+produced it. These tests construct a real manifest through ``ManifestBuilder.build``
+and validate it against ``manifest_schema()``; on the pre-issue code they FAIL
+(the keys are absent and, once required by the schema, rejected) and PASS once the
+builder emits real values and the schema accepts them.
+"""
+
+from __future__ import annotations
+
+import platform as platform_module
+from datetime import date
+from pathlib import Path
+
+import counter_risk
+from counter_risk.config import WorkflowConfig
+from counter_risk.pipeline.manifest import ManifestBuilder
+from counter_risk.pipeline.manifest_schema import (
+    MANIFEST_SCHEMA_VERSION,
+    manifest_schema,
+    validate_manifest,
+)
+
+
+def _make_config(tmp_path: Path) -> WorkflowConfig:
+    return WorkflowConfig(
+        as_of_date=date(2026, 2, 13),
+        mosers_all_programs_xlsx=tmp_path / "all.xlsx",
+        mosers_ex_trend_xlsx=tmp_path / "ex.xlsx",
+        mosers_trend_xlsx=tmp_path / "trend.xlsx",
+        hist_all_programs_3yr_xlsx=tmp_path / "hist-all.xlsx",
+        hist_ex_llc_3yr_xlsx=tmp_path / "hist-ex.xlsx",
+        hist_llc_3yr_xlsx=tmp_path / "hist-trend.xlsx",
+        monthly_pptx=tmp_path / "monthly.pptx",
+        output_root=tmp_path / "output-root",
+    )
+
+
+def _build_manifest(tmp_path: Path) -> dict:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    workbook_path = run_dir / "Historical Counterparty Risk Graphs - All Programs 3 Year.xlsx"
+    ppt_path = run_dir / "Monthly Counterparty Exposure Report.pptx"
+    workbook_path.write_bytes(b"hist")
+    ppt_path.write_bytes(b"ppt")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    return builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(workbook_path.name), Path(ppt_path.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+    )
+
+
+def test_manifest_carries_schema_version(tmp_path: Path) -> None:
+    """The built manifest stamps the contract version string."""
+
+    manifest = _build_manifest(tmp_path)
+
+    assert manifest["manifest_schema_version"] == "counter-risk-manifest/v1"
+    # The builder and schema must agree on the same version constant.
+    assert MANIFEST_SCHEMA_VERSION == "counter-risk-manifest/v1"
+
+
+def test_manifest_provenance_is_populated_with_real_values(tmp_path: Path) -> None:
+    """``provenance`` carries real tool/runtime values, not placeholders."""
+
+    manifest = _build_manifest(tmp_path)
+    provenance = manifest["provenance"]
+
+    assert provenance["tool"] == "counter-risk"
+    assert provenance["tool_version"] == counter_risk.__version__
+    assert provenance["python_version"] == platform_module.python_version()
+    assert provenance["platform"] == platform_module.platform()
+    # git_sha is best-effort: a 40-char hex SHA inside a checkout, else None.
+    git_sha = provenance["git_sha"]
+    assert git_sha is None or (isinstance(git_sha, str) and len(git_sha) == 40)
+    # Exactly the five contract keys, no extras.
+    assert set(provenance) == {
+        "tool",
+        "tool_version",
+        "git_sha",
+        "python_version",
+        "platform",
+    }
+
+
+def test_schema_requires_version_and_provenance() -> None:
+    """The schema treats both new keys as required, top-level properties."""
+
+    schema = manifest_schema()
+    assert "manifest_schema_version" in schema["required"]
+    assert "provenance" in schema["required"]
+    assert "manifest_schema_version" in schema["properties"]
+    assert "provenance" in schema["properties"]
+
+
+def test_built_manifest_with_provenance_conforms_to_schema(tmp_path: Path) -> None:
+    """A manifest emitting the new keys validates cleanly (no drift)."""
+
+    manifest = _build_manifest(tmp_path)
+
+    is_valid, reason = validate_manifest(manifest)
+    assert is_valid, reason
+    assert reason is None
+
+
+def test_schema_rejects_manifest_missing_provenance(tmp_path: Path) -> None:
+    """Dropping ``provenance`` is rejected with a reason naming the key."""
+
+    manifest = _build_manifest(tmp_path)
+    del manifest["provenance"]
+
+    is_valid, reason = validate_manifest(manifest)
+    assert is_valid is False
+    assert reason is not None
+    assert "provenance" in reason
+
+
+def test_schema_rejects_non_string_git_sha(tmp_path: Path) -> None:
+    """``git_sha`` is string-or-null; an integer must be rejected."""
+
+    manifest = _build_manifest(tmp_path)
+    manifest["provenance"]["git_sha"] = 12345
+
+    is_valid, reason = validate_manifest(manifest)
+    assert is_valid is False
+    assert reason is not None
+    assert "git_sha" in reason

--- a/tests/pipeline/test_manifest_provenance.py
+++ b/tests/pipeline/test_manifest_provenance.py
@@ -12,6 +12,7 @@ builder emits real values and the schema accepts them.
 from __future__ import annotations
 
 import platform as platform_module
+import subprocess
 from datetime import date
 from pathlib import Path
 
@@ -82,9 +83,15 @@ def test_manifest_provenance_is_populated_with_real_values(tmp_path: Path) -> No
     assert provenance["tool_version"] == counter_risk.__version__
     assert provenance["python_version"] == platform_module.python_version()
     assert provenance["platform"] == platform_module.platform()
-    # git_sha is best-effort: a 40-char hex SHA inside a checkout, else None.
+    # git_sha is best-effort: a hex object ID inside a checkout, else None. The
+    # length is not pinned to SHA-1 (40 chars) because SHA-256 repositories
+    # report a 64-char object ID, and the schema only promises a string-or-null.
     git_sha = provenance["git_sha"]
-    assert git_sha is None or (isinstance(git_sha, str) and len(git_sha) == 40)
+    assert git_sha is None or (
+        isinstance(git_sha, str)
+        and len(git_sha) in (40, 64)
+        and all(c in "0123456789abcdef" for c in git_sha)
+    )
     # Exactly the five contract keys, no extras.
     assert set(provenance) == {
         "tool",
@@ -137,3 +144,45 @@ def test_schema_rejects_non_string_git_sha(tmp_path: Path) -> None:
     assert is_valid is False
     assert reason is not None
     assert "git_sha" in reason
+
+
+def test_resolve_git_sha_returns_none_when_git_binary_absent(monkeypatch) -> None:
+    """Best-effort contract: an OSError (git not installed) is swallowed -> None.
+
+    Without this, runs from an installed wheel or archived source tree where
+    ``git`` is unavailable would raise instead of degrading to ``git_sha=None``.
+    """
+
+    def _raise_oserror(*_args, **_kwargs):
+        raise FileNotFoundError("git binary not on PATH")
+
+    monkeypatch.setattr("counter_risk.pipeline.manifest.subprocess.run", _raise_oserror)
+
+    assert ManifestBuilder._resolve_git_sha() is None
+
+
+def test_resolve_git_sha_returns_none_on_timeout(monkeypatch) -> None:
+    """A subprocess timeout is swallowed -> None (the contract never raises)."""
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+    monkeypatch.setattr("counter_risk.pipeline.manifest.subprocess.run", _raise_timeout)
+
+    assert ManifestBuilder._resolve_git_sha() is None
+
+
+def test_resolve_git_sha_returns_none_on_nonzero_exit(monkeypatch) -> None:
+    """A non-checkout (non-zero ``git`` exit) yields ``None``, not a blank SHA."""
+
+    def _nonzero(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["git", "rev-parse", "HEAD"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repository",
+        )
+
+    monkeypatch.setattr("counter_risk.pipeline.manifest.subprocess.run", _nonzero)
+
+    assert ManifestBuilder._resolve_git_sha() is None


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:649 -->
> **Source:** Issue #649

Closes #649

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
**Why.** The manifest captures input hashes (`run.py:586-588` via `_sha256_file`) and a full config snapshot (`manifest.py:380-390`), but omits the producing tool's version, git SHA, and Python/platform — so a replayed or compared run cannot be tied to the exact code that produced it. There is also no `manifest_schema_version` on the manifest to evolve the contract safely, even though the sibling LangSmith fleet record already carries a `schema_version` (`src/counter_risk/observability/langsmith_fleet.py`). Agent-ready checklist item 6 (provenance) is currently only Partial for exactly this reason. This blocks reproducible audit and safe cross-repo contract versioning.

**Scope.** Add (1) a top-level `manifest_schema_version` string and (2) a `provenance` object (`tool`, `tool_version`, `git_sha`, `python_version`, `platform`) to `ManifestBuilder.build` and to `manifest_schema()`. Populate side-effect-free.

**Non-Goals.**

#### Tasks
- [ ] Per-artifact output-file hashing (out of scope; inputs already hashed).
- [ ] Evidence-object/cell-level provenance (separate issue below).
- [ ] Scaffold-only is disallowed: adding the keys to the schema without populating real values in `build()`, or hardcoding a placeholder `git_sha="unknown"` unconditionally instead of a best-effort lookup, does NOT satisfy this issue.

#### Acceptance criteria
- [ ] Add `"manifest_schema_version": "counter-risk-manifest/v1"` to the manifest dict in `ManifestBuilder.build` (`manifest.py:97-120`), and add it to `manifest_schema()` `required` + `properties` as `{"type": "string"}`.
- [ ] Add a `_build_provenance()` helper to `ManifestBuilder` returning `{"tool": "counter-risk", "tool_version": <str>, "git_sha": <str | None>, "python_version": <str>, "platform": <str>}`; read `tool_version` from `counter_risk.__version__` (`src/counter_risk/__init__.py:3` = `"0.1.0"`), `python_version` from `platform.python_version()`, `platform` from `platform.platform()`.
- [ ] Implement best-effort `git_sha`: attempt `git rev-parse HEAD` (or read `.git/HEAD`) wrapped so any failure returns `None` — never raise. A run outside a git checkout must still succeed.
- [ ] Add `provenance` to `manifest_schema()` `properties` (object with the five keys; `git_sha` typed `["string", "null"]`) and to `required`.
- [ ] Document the `manifest_schema_version` and `provenance` block in the manifest section of `README.md` (the artifact list around `README.md:11-20`).

<!-- auto-status-summary:end -->