### PR TITLE
Issue #650: Preserve structured warning fields in the manifest

### DIFF
--- a/src/counter_risk/pipeline/manifest.py
+++ b/src/counter_risk/pipeline/manifest.py
@@ -18,7 +18,7 @@ from counter_risk.dates import DateResolution
 from counter_risk.pipeline.data_quality import build_data_quality
 from counter_risk.pipeline.manifest_schema import MANIFEST_SCHEMA_VERSION, validate_manifest
 from counter_risk.pipeline.ppt_naming import resolve_ppt_output_names
-from counter_risk.pipeline.warnings import WarningsCollector
+from counter_risk.pipeline.warnings import WarningsCollector, _is_blank_warning_value
 
 __all__ = ["ManifestBuilder", "WarningsCollector"]
 
@@ -75,6 +75,7 @@ class ManifestBuilder:
         self._validate_artifact_paths_exist(run_dir=run_dir, relative_paths=normalized_output_paths)
         config_snapshot = self._serialize_config_snapshot(self.config)
         normalized_warnings = self._normalize_warnings(warnings)
+        normalized_warnings_structured = self._normalize_warnings_structured(warnings)
         resolved_unmatched_mappings = (
             unmatched_mappings if unmatched_mappings is not None else {"count": 0, "by_variant": {}}
         )
@@ -112,6 +113,7 @@ class ManifestBuilder:
             "top_exposures": top_exposures,
             "top_changes_per_variant": top_changes_per_variant,
             "warnings": normalized_warnings,
+            "warnings_structured": normalized_warnings_structured,
             "data_quality": build_data_quality(
                 warnings,
                 unmatched_mappings=resolved_unmatched_mappings,
@@ -469,6 +471,45 @@ class ManifestBuilder:
             return None
         rendered = str(warning).strip()
         return rendered if rendered else None
+
+    def _normalize_warnings_structured(self, warnings: list[Any]) -> list[dict[str, Any]]:
+        normalized_structured: list[dict[str, Any]] = []
+        for warning in warnings:
+            normalized = self._normalize_warning_structured(warning)
+            if normalized is not None:
+                normalized_structured.append(normalized)
+        return normalized_structured
+
+    def _normalize_warning_structured(self, warning: Any) -> dict[str, Any] | None:
+        """Render a single warning as a structured object preserving discrete fields.
+
+        Mirrors :meth:`_normalize_warning` for the human ``message`` while keeping the
+        machine-readable ``code``, ``row_idx``, and any source extras as discrete keys
+        (dropping only ``None``/blank values, matching ``_is_blank_warning_value``).
+        Returns ``None`` for empty entries so the structured array stays in lockstep
+        with the legacy string array.
+        """
+        if warning is None:
+            return None
+        if isinstance(warning, Mapping):
+            message = str(warning.get("message", "")).strip()
+            extras = {
+                key: value
+                for key, value in warning.items()
+                if key != "message" and not _is_blank_warning_value(value)
+            }
+            if message:
+                return {"message": message, **extras}
+            # No discrete message: fall back to the legacy rendered string so the
+            # required ``message`` field stays populated, while still preserving extras.
+            rendered = self._normalize_warning(warning)
+            if rendered is None:
+                return None
+            return {"message": rendered, **extras}
+        rendered = self._normalize_warning(warning)
+        if rendered is None:
+            return None
+        return {"message": rendered}
 
     def _normalize_output_paths(self, *, run_dir: Path, output_paths: list[Path]) -> list[Path]:
         normalized_paths: list[Path] = []

--- a/src/counter_risk/pipeline/manifest_schema.py
+++ b/src/counter_risk/pipeline/manifest_schema.py
@@ -256,6 +256,19 @@ def manifest_schema() -> dict[str, Any]:
             "top_exposures": {"type": "object"},
             "top_changes_per_variant": {"type": "object"},
             "warnings": {"type": "array", "items": {"type": "string"}},
+            "warnings_structured": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["message"],
+                    "properties": {
+                        "message": {"type": "string"},
+                        "code": {"type": "string"},
+                        "row_idx": {"type": "integer"},
+                    },
+                    "additionalProperties": True,
+                },
+            },
             "data_quality": _DATA_QUALITY_SCHEMA,
             "unmatched_mappings": {
                 "type": "object",

--- a/tests/pipeline/test_manifest_structured_warnings.py
+++ b/tests/pipeline/test_manifest_structured_warnings.py
@@ -1,0 +1,160 @@
+"""Tests that structured warning fields survive into the written manifest.
+
+Issue #650: the manifest's top-level ``warnings`` array flattens every collector
+record to a single human string, losing the machine-readable ``code``, ``row_idx``,
+and source extras. ``warnings_structured`` preserves those discrete fields while the
+legacy ``warnings`` string array stays unchanged for backward compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from counter_risk.config import WorkflowConfig
+from counter_risk.pipeline.manifest import ManifestBuilder
+from counter_risk.pipeline.warnings import WarningsCollector
+
+
+def _make_config(tmp_path: Path) -> WorkflowConfig:
+    return WorkflowConfig(
+        as_of_date=date(2026, 2, 13),
+        mosers_all_programs_xlsx=tmp_path / "all.xlsx",
+        mosers_ex_trend_xlsx=tmp_path / "ex.xlsx",
+        mosers_trend_xlsx=tmp_path / "trend.xlsx",
+        hist_all_programs_3yr_xlsx=tmp_path / "hist-all.xlsx",
+        hist_ex_llc_3yr_xlsx=tmp_path / "hist-ex.xlsx",
+        hist_llc_3yr_xlsx=tmp_path / "hist-trend.xlsx",
+        monthly_pptx=tmp_path / "monthly.pptx",
+        output_root=tmp_path / "output-root",
+    )
+
+
+def _build_builder(tmp_path: Path) -> ManifestBuilder:
+    return ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+
+
+def _prepare_run_dir(tmp_path: Path) -> tuple[Path, Path]:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    artifact = run_dir / "output.csv"
+    artifact.write_text("ok\n", encoding="utf-8")
+    return run_dir, artifact
+
+
+def test_collector_structured_fields_survive_into_written_manifest(tmp_path: Path) -> None:
+    run_dir, artifact = _prepare_run_dir(tmp_path)
+    builder = _build_builder(tmp_path)
+
+    collector = WarningsCollector()
+    collector.warn(
+        "invalid row",
+        code="MISSING_DESCRIPTION",
+        row_idx="12",
+        description="TY Mar25",
+    )
+
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(artifact.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=collector.warnings,
+    )
+    builder.write(run_dir=run_dir, manifest=manifest)
+
+    reloaded = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+
+    structured = reloaded["warnings_structured"]
+    assert len(structured) == 1
+    entry = structured[0]
+    # Discrete fields, not substring-embedded in a single string.
+    assert entry["code"] == "MISSING_DESCRIPTION"
+    assert entry["row_idx"] == 12
+    assert entry["description"] == "TY Mar25"
+    assert entry["message"] == "invalid row"
+
+
+def test_legacy_warnings_string_array_is_unchanged(tmp_path: Path) -> None:
+    run_dir, artifact = _prepare_run_dir(tmp_path)
+    builder = _build_builder(tmp_path)
+
+    collector = WarningsCollector()
+    collector.warn(
+        "invalid row",
+        code="MISSING_DESCRIPTION",
+        row_idx="12",
+        description="TY Mar25",
+    )
+
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(artifact.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=collector.warnings,
+    )
+    # write() builds the DATA_QUALITY_SUMMARY and runs schema validation; it must not raise.
+    builder.write(run_dir=run_dir, manifest=manifest)
+
+    reloaded = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+
+    assert isinstance(reloaded["warnings"], list)
+    assert len(reloaded["warnings"]) == 1
+    rendered = reloaded["warnings"][0]
+    assert rendered.startswith("invalid row (")
+    assert "code=MISSING_DESCRIPTION" in rendered
+    assert "row_idx=12" in rendered
+    assert (run_dir / "DATA_QUALITY_SUMMARY.txt").exists()
+
+
+def test_plain_string_warnings_round_trip_as_message_only_objects(tmp_path: Path) -> None:
+    run_dir, artifact = _prepare_run_dir(tmp_path)
+    builder = _build_builder(tmp_path)
+
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(artifact.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[
+            "PPT links not refreshed; COM refresh skipped",
+            {"message": "Notional field missing", "code": "MISSING_NOTIONAL", "row_idx": 3},
+        ],
+    )
+    builder.write(run_dir=run_dir, manifest=manifest)
+
+    reloaded = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    structured = reloaded["warnings_structured"]
+
+    assert structured[0] == {"message": "PPT links not refreshed; COM refresh skipped"}
+    assert structured[1]["code"] == "MISSING_NOTIONAL"
+    assert structured[1]["row_idx"] == 3
+    assert structured[1]["message"] == "Notional field missing"
+
+
+def test_empty_warnings_produce_empty_structured_array(tmp_path: Path) -> None:
+    run_dir, artifact = _prepare_run_dir(tmp_path)
+    builder = _build_builder(tmp_path)
+
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(artifact.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+    )
+    builder.write(run_dir=run_dir, manifest=manifest)
+
+    reloaded = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert reloaded["warnings_structured"] == []
+    assert reloaded["warnings"] == []


### PR DESCRIPTION
## Summary

Closes #650.

The manifest's top-level `warnings` array flattened every collector record to a single human string (e.g. `"message (code=X, row_idx=7)"`) via `_normalize_warning`, and the schema typed it as `array of string`. Consumers reading `manifest["warnings"]` lost the machine-readable `code`, the `row_idx`, and any source pointer — even though `WarningsCollector` already captures them as discrete fields.

This adds a sibling `warnings_structured` array that preserves those discrete fields, while keeping the existing `warnings` string array byte-for-byte unchanged for backward compatibility and the `DATA_QUALITY_SUMMARY.txt` renderer.

## Tasks

- [x] In `ManifestBuilder.build` (`manifest.py`), add a `warnings_structured` array built from the raw `warnings` argument (the collector dicts), preserving `code`, `row_idx`, `message`, and any retained extras; keep the existing `warnings` string array unchanged for backward compatibility.
- [x] Add a `_normalize_warning_structured(warning)` helper alongside `_normalize_warning` that returns the dict form (dropping only `None`/blank values, mirroring `_is_blank_warning_value` semantics) or `None` for empty entries.
- [x] Add `warnings_structured` to `manifest_schema()` `properties` as an array of objects requiring `message` (string) and allowing `code`/`row_idx`/additional keys; left OUT of `required` for backward compatibility.
- [x] Add manifest-propagation assertions in `tests/pipeline/test_manifest_structured_warnings.py`: feed a `WarningsCollector` with `warn("invalid row", code="MISSING_DESCRIPTION", row_idx="12", description="TY Mar25")`, pass `collector.warnings` into `ManifestBuilder.build(... warnings=...)`, write, reload the JSON, and assert the structured fields are present as discrete keys.

## Acceptance Criteria

- [x] Concrete failing-then-passing test: asserts the written `manifest.json` has a `warnings_structured` entry where `entry["code"] == "MISSING_DESCRIPTION"`, `entry["row_idx"] == 12`, and `entry["description"] == "TY Mar25"` as DISCRETE fields (not substring-embedded in a string).
- [x] The legacy `warnings` string array is unchanged: `manifest["warnings"]` still contains the rendered `"... (code=MISSING_DESCRIPTION, ...)"` form, and `_build_data_quality_summary` renders without error.
- [x] The structured form passes `validate_manifest` (schema validation runs inside `write()`; all tests pass clean).

## Changes

- **`manifest.py`** — `ManifestBuilder.build` now emits `warnings_structured` alongside `warnings`, via new `_normalize_warnings_structured` / `_normalize_warning_structured` helpers that preserve `message`, `code`, `row_idx`, and any retained extras, dropping only `None`/blank values.
- **`manifest_schema.py`** — `manifest_schema()` declares `warnings_structured` as an array of objects requiring `message` (string), with `code` (string) / `row_idx` (integer) / additional extras allowed.
- **`tests/pipeline/test_manifest_structured_warnings.py`** — new test file with 4 tests covering structured field survival, legacy string array backward compatibility, plain-string round-trip, and empty-input handling.

## Validation

```
pytest tests/pipeline/test_manifest_structured_warnings.py tests/test_warnings_collector.py tests/pipeline/test_manifest_data_quality.py tests/pipeline/test_manifest_schema_conformance.py tests/test_manifest_paths.py → 34 passed
```

## Note for reviewers / possible follow-up

The production `run.py` call site currently passes a pre-flattened `list[str]` into `build(warnings=...)`. So in production, `warnings_structured` will hold `{"message": ...}` entries until those collector dicts are threaded through to the `build()` call site. That threading is a larger, separate change outside this issue's scope; this PR makes the manifest builder + schema dict-preserving and fully covered.
