### PR TITLE
Issue #647: Fix formatting-profile CLI help

### DIFF
--- a/src/counter_risk/cli/__init__.py
+++ b/src/counter_risk/cli/__init__.py
@@ -105,7 +105,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--formatting-profile",
         type=str,
         default=None,
-        help="Reserved runtime formatting profile selector (stored for follow-on workflows).",
+        help=(
+            "Numeric formatting profile (default, currency, accounting, plain) applied "
+            "to historical append rows and CPRS-CH/CPRS-FCM table PNG renderers."
+        ),
     )
     run_parser.add_argument(
         "--settings",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import tomllib
+from argparse import ArgumentParser, _SubParsersAction
 from pathlib import Path
 
 
@@ -63,3 +64,35 @@ def test_cli_help_exits_zero() -> None:
 
     assert result.returncode == 0
     assert "usage:" in result.stdout.lower()
+
+
+def test_formatting_profile_help_describes_real_scope() -> None:
+    src_path = str(Path("src").resolve())
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+    from counter_risk.cli import build_parser
+
+    parser = build_parser()
+    run_parser = _subparser(parser, "run")
+    help_text = _argument_help(run_parser, "--formatting-profile")
+
+    assert "Reserved" not in help_text
+    assert "stored for follow-on workflows" not in help_text
+    assert "historical" in help_text.lower()
+    assert "PNG" in help_text
+    assert "renderer" in help_text.lower()
+
+
+def _subparser(parser: ArgumentParser, name: str) -> ArgumentParser:
+    for action in parser._actions:
+        if isinstance(action, _SubParsersAction):
+            return action.choices[name]
+    raise AssertionError(f"subparser not found: {name}")
+
+
+def _argument_help(parser: ArgumentParser, option: str) -> str:
+    for action in parser._actions:
+        if option in action.option_strings:
+            return str(action.help)
+    raise AssertionError(f"option not found: {option}")


### PR DESCRIPTION
Closes #647

## Summary
- update the `run --formatting-profile` help text so it describes the actual historical append-row and CPRS table PNG renderer scope
- add a parser regression test that rejects the old reserved/follow-on wording and pins the real output paths

## Validation
- `python -m pytest tests/test_cli.py::test_formatting_profile_help_describes_real_scope tests/test_formatting.py tests/test_table_png.py::test_render_cprs_fcm_png_and_ch_png_route_through_shared_internal_helper -q`
- `python -m ruff check src/counter_risk/cli/__init__.py tests/test_cli.py`