### PR TITLE
Add app behavior baseline kit (concentration metrics)

### DIFF
--- a/.project_modules.txt
+++ b/.project_modules.txt
@@ -1,0 +1,10 @@
+# Repo-specific first-party / vendored module names for scripts/sync_test_dependencies.py.
+# One module name per line; comments start with #.
+
+# app-baseline-kit ships the `baseline_kit` import (declared via the
+# app-baseline-kit git pin in pyproject [dev]); not a missing dependency.
+baseline_kit
+
+# tests/baseline/conftest.py is imported relatively ("from .conftest import ...");
+# the import scanner sees a bare `conftest` top-level name.
+conftest

--- a/docs/reports/baseline-coverage.md
+++ b/docs/reports/baseline-coverage.md
@@ -1,0 +1,11 @@
+# Counter_Risk baseline coverage manifest
+
+- Input parameters: **9**
+- Exercised by a scenario: **3** (33.3%)
+- Observed read at runtime: **0**
+
+## Priority parameters
+
+- [x] `all_programs.total.hhi`
+- [x] `all_programs.total.top5_share`
+- [x] `all_programs.total.top10_share`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-xdist==3.8.0",
     "pandas>=2.3,<4",
+    # Shared app behavior baseline harness (tests/baseline). Pulls
+    # pytest-regressions, which needs numpy + pandas for the num_regression
+    # fixture. Tracked as a git direct reference (latest on Workflows main).
+    "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
+    "pytest-regressions==2.11.0",
+    "numpy>=2.0,<3",
     "black==26.3.1",
     "ruff>=0.15.13",
     "mypy==2.1.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,6 +9,8 @@ anyio==4.12.1
     #   anthropic
     #   httpx
     #   openai
+app-baseline-kit @ git+https://github.com/stranske/Workflows.git@13f94883220bbfb0ca69a4666fb44a49e0ae8172#subdirectory=packages/app-baseline-kit
+    # via counter-risk (pyproject.toml)
 ast-serialize==0.3.0
     # via mypy
 black==26.3.1
@@ -86,7 +88,9 @@ mypy-extensions==1.1.0
     #   black
     #   mypy
 numpy==2.4.2
-    # via pandas
+    # via
+    #   counter-risk (pyproject.toml)
+    #   pandas
 openai==2.32.0
     # via langchain-openai
 openpyxl==3.1.5
@@ -130,10 +134,19 @@ pygments==2.19.2
 pytest==9.0.3
     # via
     #   counter-risk (pyproject.toml)
+    #   app-baseline-kit
     #   pytest-cov
+    #   pytest-datadir
+    #   pytest-regressions
     #   pytest-xdist
 pytest-cov==7.1.0
     # via counter-risk (pyproject.toml)
+pytest-datadir==1.8.0
+    # via pytest-regressions
+pytest-regressions==2.11.0
+    # via
+    #   counter-risk (pyproject.toml)
+    #   app-baseline-kit
 pytest-xdist==3.8.0
     # via counter-risk (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -142,10 +155,14 @@ python-pptx==1.0.2
     # via counter-risk (pyproject.toml)
 pytokens==0.4.1
     # via black
+pytz==2026.2
+    # via pandas
 pyyaml==6.0.3
     # via
     #   counter-risk (pyproject.toml)
+    #   app-baseline-kit
     #   langchain-core
+    #   pytest-regressions
 regex==2026.2.28
     # via tiktoken
 requests==2.32.5
@@ -187,7 +204,7 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.3 ; sys_platform == 'emscripten' or sys_platform == 'win32'
+tzdata==2025.3
     # via pandas
 urllib3==2.6.3
     # via requests

--- a/tests/baseline/README.md
+++ b/tests/baseline/README.md
@@ -1,0 +1,65 @@
+# Counter_Risk app behavior baseline kit
+
+Scenario-driven wiring / sensibility / regression tests built on the shared
+**`baseline_kit`** package. Only the app-specific pieces live here.
+
+## Requires
+
+`baseline_kit` (the shared core) must be importable. It lives in
+`stranske/Workflows` under `packages/app-baseline-kit`:
+
+```bash
+pip install "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit"
+```
+
+It is declared in this repo's `pyproject.toml` `[project.optional-dependencies]
+dev`, so `pip install -e ".[dev]"` pulls it (plus `pytest-regressions`, which
+needs `numpy` + `pandas`).
+
+## Target surface
+
+The **deterministic compute**
+`counter_risk.compute.rollups.compute_concentration_metrics` — reduces an
+exposure table to per-`(variant, segment)` concentration scalars
+(`top5_share`, `top10_share`, `hhi`) with no DB / network / LLM. Field
+definitions and the HHI scaling are in `docs/concentration_metrics.md`.
+
+## Layout
+
+```
+adapter.py                # exposure fixture + patch -> flat metrics dict (the only app glue)
+catalog.yaml              # base exposure table + scenario patches + directional checks
+invariants.py             # economic bounds -> baseline_kit.InvariantResult
+test_golden.py            # golden master of each scenario's flattened metrics
+test_directional.py       # metamorphic checks (concentrate -> HHI up, disperse -> down...)
+test_invariants.py        # invariants on base + every scenario
+test_coverage_manifest.py # metric-key coverage -> docs/reports/baseline-coverage.md
+```
+
+## Scenario model
+
+A *scenario* is the base exposure table (`catalog.yaml` `base.exposures`) with
+an optional ordered `patch` applied. The patch DSL (`adapter.apply_patch`)
+supports `set_notional`, `scale_notional`, `add_row`, `drop_counterparty`,
+`zero_segment`, `keep_only` — enough to make each variant directionally
+predictable (shift mass onto one name → more concentrated; spread it → more
+dispersed).
+
+## Running
+
+```bash
+pytest tests/baseline/                                   # full suite
+pytest tests/baseline/test_golden.py --force-regen       # re-bless after an intended change
+BASELINE_REFRESH_REPORT=1 pytest tests/baseline/test_coverage_manifest.py  # refresh report
+```
+
+## Invariants enforced
+
+For every `(variant, segment)` group, grounded in `docs/concentration_metrics.md`:
+
+- `0 <= top5_share <= 1`, `0 <= top10_share <= 1`, `0 <= hhi <= 1`
+- `top5_share <= top10_share` (top-10 window ⊇ top-5 window)
+- `hhi >= 1/N` for `N` positive-notional entities (1/N = perfect dispersion)
+- single positive-notional entity ⇒ all three = 1.0
+- ≤5 entities ⇒ `top5_share == 1.0`; ≤10 entities ⇒ `top10_share == 1.0`
+- zero-total group ⇒ all three = 0.0

--- a/tests/baseline/__init__.py
+++ b/tests/baseline/__init__.py
@@ -1,0 +1,12 @@
+"""Counter_Risk app behavior baseline kit.
+
+Built on the shared ``baseline_kit`` package -- this directory contains only the
+app-specific pieces (adapter, catalog, invariant bounds). The generic harness
+(directional engine, invariant assertion, golden glue, coverage manifest) is
+imported from ``baseline_kit``, the same core the TMP / PAEM / trip-planner
+kits use.
+
+Target surface: ``counter_risk.compute.rollups.compute_concentration_metrics``
+-- a deterministic compute (no DB, no network, no LLM) that reduces an exposure
+table to per-group concentration scalars (top5_share, top10_share, HHI).
+"""

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -61,9 +61,7 @@ GROUP_BY = ["variant", "segment"]
 def _matches(row: dict[str, Any], counterparty: str | None, segment: str | None) -> bool:
     if counterparty is not None and row.get("counterparty") != counterparty:
         return False
-    if segment is not None and row.get("segment") != segment:
-        return False
-    return True
+    return not (segment is not None and row.get("segment") != segment)
 
 
 def apply_patch(

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -1,0 +1,146 @@
+"""App-specific adapter for Counter_Risk concentration metrics.
+
+This is the ONLY app-specific piece the shared ``baseline_kit`` needs: a way to
+turn an input (here, an exposure-table fixture plus a scenario *patch*) into a
+flat dict of named scalar metrics. Everything else -- directional checks,
+invariants, golden masters, the coverage manifest -- is generic and lives in
+``baseline_kit``.
+
+The deterministic compute surface is
+``counter_risk.compute.rollups.compute_concentration_metrics`` (no DB, no
+network, no LLM), so baselines here are stable.
+
+Scenario model
+--------------
+The base exposure table lives in ``catalog.yaml`` under ``base.exposures``.
+Each *scenario* is the base table with an optional ``patch`` applied. A patch is
+an ordered list of operations -- the small DSL ``apply_patch`` understands:
+
+* ``{op: set_notional, counterparty: X, segment: S, value: V}`` -- overwrite the
+  notional of a single (segment, counterparty) row.
+* ``{op: scale_notional, counterparty: X, segment: S, factor: F}`` -- multiply.
+* ``{op: add_row, variant: ..., segment: ..., counterparty: ..., notional: ...}``
+  -- append a new exposure row.
+* ``{op: drop_counterparty, counterparty: X, segment: S}`` -- remove matching rows.
+* ``{op: zero_segment, segment: S}`` -- set every notional in a segment to 0.
+* ``{op: keep_only, counterparty: X, segment: S}`` -- keep only that row in the
+  segment (collapse to a single entity).
+
+This keeps the catalog declarative and the variants directionally predictable
+(shift mass onto one name -> more concentrated; spread it out -> more dispersed).
+
+Metric flattening
+-----------------
+``compute_concentration_metrics`` returns one row per ``(variant, segment)``
+group with ``top5_share``/``top10_share``/``hhi``. We flatten each group to keys
+``"<variant>.<segment>.<metric>"`` so the whole run is one flat ``dict[str,
+float]`` -- exactly what ``baseline_kit`` golden/directional/coverage machinery
+consumes.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The metric names this surface produces per group (the kit's coverage "input
+# parameter" space at the metric level).
+METRIC_NAMES = ("top5_share", "top10_share", "hhi")
+
+GROUP_BY = ["variant", "segment"]
+
+
+# ---------------------------------------------------------------------------
+# Patch DSL
+# ---------------------------------------------------------------------------
+
+
+def _matches(row: dict[str, Any], counterparty: str | None, segment: str | None) -> bool:
+    if counterparty is not None and row.get("counterparty") != counterparty:
+        return False
+    if segment is not None and row.get("segment") != segment:
+        return False
+    return True
+
+
+def apply_patch(
+    base_rows: list[dict[str, Any]], patch: list[dict[str, Any]] | None
+) -> list[dict[str, Any]]:
+    """Return a deep copy of ``base_rows`` with ``patch`` operations applied."""
+    rows = copy.deepcopy(base_rows)
+    for step in patch or []:
+        op = step["op"]
+        seg = step.get("segment")
+        cp = step.get("counterparty")
+        if op == "set_notional":
+            for r in rows:
+                if _matches(r, cp, seg):
+                    r["notional"] = float(step["value"])
+        elif op == "scale_notional":
+            factor = float(step["factor"])
+            for r in rows:
+                if _matches(r, cp, seg):
+                    r["notional"] = float(r["notional"]) * factor
+        elif op == "add_row":
+            rows.append(
+                {
+                    "variant": step["variant"],
+                    "segment": step["segment"],
+                    "counterparty": step["counterparty"],
+                    "notional": float(step["notional"]),
+                }
+            )
+        elif op == "drop_counterparty":
+            rows = [r for r in rows if not _matches(r, cp, seg)]
+        elif op == "zero_segment":
+            for r in rows:
+                if _matches(r, None, seg):
+                    r["notional"] = 0.0
+        elif op == "keep_only":
+            rows = [
+                r
+                for r in rows
+                if (seg is not None and r.get("segment") != seg) or _matches(r, cp, seg)
+            ]
+        else:  # pragma: no cover - guards against catalog typos
+            raise ValueError(f"unknown patch op: {op!r}")
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Compute + flatten
+# ---------------------------------------------------------------------------
+
+
+def _as_records(table: Any) -> list[dict[str, Any]]:
+    if hasattr(table, "to_dict"):
+        return list(table.to_dict(orient="records"))
+    return [dict(row) for row in table]
+
+
+def run_scenario(scenario: dict[str, Any], base_rows: list[dict[str, Any]]) -> dict[str, float]:
+    """Apply a scenario's patch to the base table, compute metrics, flatten.
+
+    Returns a flat ``dict`` keyed ``"<variant>.<segment>.<metric>"`` -> float.
+    Deterministic: ``compute_concentration_metrics`` sorts notionals and emits
+    groups in first-seen key order, so the flattened dict is stable.
+    """
+    from counter_risk.compute.rollups import compute_concentration_metrics
+
+    rows = apply_patch(base_rows, scenario.get("patch"))
+    result = compute_concentration_metrics(rows, group_by=list(GROUP_BY))
+
+    flat: dict[str, float] = {}
+    for rec in _as_records(result):
+        variant = rec["variant"]
+        segment = rec["segment"]
+        for metric in METRIC_NAMES:
+            flat[f"{variant}.{segment}.{metric}"] = float(rec[metric])
+    return flat
+
+
+def metric_names() -> list[str]:
+    return list(METRIC_NAMES)

--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -1,0 +1,132 @@
+# Counter_Risk scenario catalog -- concentration-metrics deterministic compute.
+#
+# Surface: counter_risk.compute.rollups.compute_concentration_metrics
+#   exposure rows -> per (variant, segment) group: top5_share, top10_share, hhi.
+#
+# Same shape as the TMP / trip-planner kits. Here a "scenario" is the BASE
+# exposure table with an optional `patch` applied (see adapter.apply_patch for
+# the patch DSL). Directional checks compare a variant scenario to `base` on a
+# named flat metric key "<variant>.<segment>.<metric>".
+
+# ---------------------------------------------------------------------------
+# Base exposure table.
+#
+# One pipeline variant ("all_programs"). Segments:
+#   * total    -- 6 counterparties, deliberately uneven so top5_share < 1.0
+#                 (6 entities means the 6th sits outside the top-5 window) and
+#                 HHI is comfortably inside (1/N, 1). This is the segment the
+#                 directional variants perturb.
+#   * treasury -- 3 counterparties (fewer than 5 -> top5/top10 == 1.0 always).
+#   * equity   -- 2 counterparties.
+# Notionals chosen so every group total is non-trivial and hand-checkable.
+# ---------------------------------------------------------------------------
+base:
+  exposures:
+    # total: 6 names, total notional = 1000
+    - {variant: all_programs, segment: total, counterparty: cp_a, notional: 400.0}
+    - {variant: all_programs, segment: total, counterparty: cp_b, notional: 250.0}
+    - {variant: all_programs, segment: total, counterparty: cp_c, notional: 150.0}
+    - {variant: all_programs, segment: total, counterparty: cp_d, notional: 100.0}
+    - {variant: all_programs, segment: total, counterparty: cp_e, notional: 60.0}
+    - {variant: all_programs, segment: total, counterparty: cp_f, notional: 40.0}
+    # treasury: 3 names, total = 200
+    - {variant: all_programs, segment: treasury, counterparty: cp_a, notional: 120.0}
+    - {variant: all_programs, segment: treasury, counterparty: cp_b, notional: 50.0}
+    - {variant: all_programs, segment: treasury, counterparty: cp_c, notional: 30.0}
+    # equity: 2 names, total = 100
+    - {variant: all_programs, segment: equity, counterparty: cp_a, notional: 70.0}
+    - {variant: all_programs, segment: equity, counterparty: cp_b, notional: 30.0}
+
+# ---------------------------------------------------------------------------
+# Scenarios (each = base + optional patch). `base` itself is implicit but we
+# also list it so golden/invariant tests parametrize over it explicitly.
+# ---------------------------------------------------------------------------
+scenarios:
+  - id: base
+    patch: []
+
+  # Pile additional mass onto the already-largest counterparty in `total`.
+  # Pure mass shift onto one name -> HHI up, top5_share up.
+  - id: more_concentrated
+    patch:
+      - {op: set_notional, segment: total, counterparty: cp_a, value: 2000.0}
+
+  # Add several small counterparties to `total`, spreading mass out. This pushes
+  # the group past 10 names, so the top-5 AND top-10 windows now exclude real
+  # mass -> HHI down, top5_share down, top10_share down (drops below 1.0).
+  - id: more_dispersed
+    patch:
+      - {op: add_row, variant: all_programs, segment: total, counterparty: cp_g, notional: 150.0}
+      - {op: add_row, variant: all_programs, segment: total, counterparty: cp_h, notional: 150.0}
+      - {op: add_row, variant: all_programs, segment: total, counterparty: cp_i, notional: 150.0}
+      - {op: add_row, variant: all_programs, segment: total, counterparty: cp_j, notional: 150.0}
+      - {op: add_row, variant: all_programs, segment: total, counterparty: cp_k, notional: 150.0}
+
+  # Collapse `total` to a single counterparty -> top5 = top10 = hhi = 1.0.
+  - id: single_entity
+    patch:
+      - {op: keep_only, segment: total, counterparty: cp_a}
+
+  # Zero every notional in `total` -> top5 = top10 = hhi = 0.0.
+  - id: zero_total
+    patch:
+      - {op: zero_segment, segment: total}
+
+# ---------------------------------------------------------------------------
+# Directional checks: variant vs control (base) on a flat metric key.
+# direction is from baseline_kit.DIRECTIONS (left=variant, right=control).
+# Each is grounded in the surface economics, not boilerplate.
+# ---------------------------------------------------------------------------
+directionals:
+  # Concentrating mass raises HHI.
+  - id: concentrated_raises_hhi
+    scenario: more_concentrated
+    control: base
+    metric: all_programs.total.hhi
+    direction: increase
+    enforce: true
+  # ...and raises the top-5 share.
+  - id: concentrated_raises_top5
+    scenario: more_concentrated
+    control: base
+    metric: all_programs.total.top5_share
+    direction: increase
+    enforce: true
+  # Dispersing mass lowers HHI.
+  - id: dispersed_lowers_hhi
+    scenario: more_dispersed
+    control: base
+    metric: all_programs.total.hhi
+    direction: decrease
+    enforce: true
+  # Dispersing across more names lowers the top-5 share of total.
+  - id: dispersed_lowers_top5
+    scenario: more_dispersed
+    control: base
+    metric: all_programs.total.top5_share
+    direction: decrease
+    enforce: true
+  # Dispersing past 10 names drops top-10 share below 1.0 (real mass now sits
+  # outside the top-10 window). In the base, total has 6 names so top10 == 1.0.
+  - id: dispersed_lowers_top10
+    scenario: more_dispersed
+    control: base
+    metric: all_programs.total.top10_share
+    direction: decrease
+    enforce: true
+  # Collapsing to one name maximizes HHI relative to the diversified base.
+  - id: single_entity_raises_hhi
+    scenario: single_entity
+    control: base
+    metric: all_programs.total.hhi
+    direction: increase
+    enforce: true
+
+# ---------------------------------------------------------------------------
+# Coverage manifest: every metric the surface produces must be exercised by a
+# directional check on at least one segment. Keys are flat metric keys.
+# ---------------------------------------------------------------------------
+priority_metrics:
+  - all_programs.total.hhi
+  - all_programs.total.top5_share
+  - all_programs.total.top10_share

--- a/tests/baseline/conftest.py
+++ b/tests/baseline/conftest.py
@@ -1,0 +1,40 @@
+"""Fixtures and catalog loading for the Counter_Risk baseline kit."""
+
+from __future__ import annotations
+
+import functools
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+CATALOG_PATH = HERE / "catalog.yaml"
+
+# Ensure the package is importable under pytest (mirrors pyproject pythonpath).
+for candidate in (SRC_ROOT, REPO_ROOT):
+    if candidate.exists() and str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+
+@functools.lru_cache(maxsize=1)
+def load_catalog_cached():
+    from baseline_kit import load_catalog
+
+    return load_catalog(CATALOG_PATH)
+
+
+def base_rows() -> list[dict]:
+    """The base exposure table from the catalog (fresh copy per call upstream)."""
+    return list(load_catalog_cached()["base"]["exposures"])
+
+
+def scenarios_by_id() -> dict[str, dict]:
+    return {s["id"]: s for s in load_catalog_cached()["scenarios"]}
+
+
+@pytest.fixture(scope="session")
+def catalog():
+    return load_catalog_cached()

--- a/tests/baseline/invariants.py
+++ b/tests/baseline/invariants.py
@@ -51,7 +51,9 @@ def _group_stats(rows: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, 
     return stats
 
 
-def check_scenario(scenario: dict[str, Any], base_rows: list[dict[str, Any]]) -> list[InvariantResult]:
+def check_scenario(
+    scenario: dict[str, Any], base_rows: list[dict[str, Any]]
+) -> list[InvariantResult]:
     """Run every invariant against one scenario's metrics."""
     rows = adapter.apply_patch(base_rows, scenario.get("patch"))
     metrics = adapter.run_scenario(scenario, base_rows)
@@ -85,9 +87,11 @@ def check_scenario(scenario: dict[str, Any], base_rows: list[dict[str, Any]]) ->
 
         if total <= 0:
             # Zero-total group: all three are 0.0 by definition.
-            add(f"{prefix}.zero_total_all_zero",
+            add(
+                f"{prefix}.zero_total_all_zero",
                 abs(top5) <= _EPS and abs(top10) <= _EPS and abs(hhi) <= _EPS,
-                f"top5={top5} top10={top10} hhi={hhi}")
+                f"top5={top5} top10={top10} hhi={hhi}",
+            )
         else:
             # HHI floor: with N positive-notional entities, hhi >= 1/N
             # (equality iff perfectly even). Use positive count since zero-notional
@@ -103,9 +107,7 @@ def check_scenario(scenario: dict[str, Any], base_rows: list[dict[str, Any]]) ->
                 # A single positive-notional entity owns the whole group.
                 add(
                     f"{prefix}.single_entity_all_one",
-                    abs(top5 - 1.0) <= _EPS
-                    and abs(top10 - 1.0) <= _EPS
-                    and abs(hhi - 1.0) <= _EPS,
+                    abs(top5 - 1.0) <= _EPS and abs(top10 - 1.0) <= _EPS and abs(hhi - 1.0) <= _EPS,
                     f"top5={top5} top10={top10} hhi={hhi}",
                 )
 

--- a/tests/baseline/invariants.py
+++ b/tests/baseline/invariants.py
@@ -1,0 +1,118 @@
+"""Counter_Risk concentration-metric economic invariants.
+
+These are properties that must hold for ANY exposure table, grounded in the
+definitions in ``docs/concentration_metrics.md`` -- NOT generic placeholders:
+
+  * shares are fractions:        0 <= top5_share <= 1, 0 <= top10_share <= 1
+  * window monotonicity:         top5_share <= top10_share
+                                 (the top-10 window is a superset of the top-5)
+  * HHI is a fraction:           0 <= hhi <= 1
+  * HHI floor for N positive
+    entities:                    hhi >= 1/N - eps   (1/N is perfect dispersion)
+  * single entity (or single
+    positive-notional entity):   top5 = top10 = hhi = 1.0
+  * zero-total group:            top5 = top10 = hhi = 0.0
+
+The result type and assertion helper are shared
+(``baseline_kit.InvariantResult`` / ``assert_invariants``).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from baseline_kit import InvariantResult
+
+from . import adapter
+
+_EPS = 1e-9
+
+
+def _group_stats(rows: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    """Per (variant, segment): list of notionals + derived counts/totals.
+
+    Mirrors the surface's grouping (str-strip key, notional alias resolution is
+    unnecessary here because the catalog uses the canonical ``notional`` key).
+    """
+    notionals: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for r in rows:
+        key = (str(r["variant"]).strip(), str(r["segment"]).strip())
+        notionals[key].append(float(r["notional"]))
+    stats: dict[tuple[str, str], dict[str, Any]] = {}
+    for key, vals in notionals.items():
+        total = sum(vals)
+        positive = [v for v in vals if v > 0]
+        stats[key] = {
+            "n_entities": len(vals),
+            "n_positive": len(positive),
+            "total": total,
+        }
+    return stats
+
+
+def check_scenario(scenario: dict[str, Any], base_rows: list[dict[str, Any]]) -> list[InvariantResult]:
+    """Run every invariant against one scenario's metrics."""
+    rows = adapter.apply_patch(base_rows, scenario.get("patch"))
+    metrics = adapter.run_scenario(scenario, base_rows)
+    stats = _group_stats(rows)
+
+    results: list[InvariantResult] = []
+
+    def add(name: str, ok: bool, detail: str, severity: str = "error") -> None:
+        results.append(InvariantResult(name, bool(ok), severity, detail))
+
+    for (variant, segment), s in stats.items():
+        prefix = f"{variant}.{segment}"
+        top5 = metrics[f"{prefix}.top5_share"]
+        top10 = metrics[f"{prefix}.top10_share"]
+        hhi = metrics[f"{prefix}.hhi"]
+        total = s["total"]
+        n_pos = s["n_positive"]
+
+        # Shares are fractions in [0, 1].
+        add(f"{prefix}.top5_in_unit_interval", -_EPS <= top5 <= 1.0 + _EPS, f"top5={top5}")
+        add(f"{prefix}.top10_in_unit_interval", -_EPS <= top10 <= 1.0 + _EPS, f"top10={top10}")
+        # HHI is a fraction in [0, 1] (share-fraction form, not DOJ 0-10000).
+        add(f"{prefix}.hhi_in_unit_interval", -_EPS <= hhi <= 1.0 + _EPS, f"hhi={hhi}")
+
+        # Window monotonicity: top-10 window contains the top-5 window.
+        add(
+            f"{prefix}.top5_le_top10",
+            top5 <= top10 + _EPS,
+            f"top5={top5} top10={top10}",
+        )
+
+        if total <= 0:
+            # Zero-total group: all three are 0.0 by definition.
+            add(f"{prefix}.zero_total_all_zero",
+                abs(top5) <= _EPS and abs(top10) <= _EPS and abs(hhi) <= _EPS,
+                f"top5={top5} top10={top10} hhi={hhi}")
+        else:
+            # HHI floor: with N positive-notional entities, hhi >= 1/N
+            # (equality iff perfectly even). Use positive count since zero-notional
+            # entities contribute 0 share and don't raise the floor.
+            floor = 1.0 / n_pos if n_pos else 0.0
+            add(
+                f"{prefix}.hhi_ge_one_over_n",
+                hhi >= floor - _EPS,
+                f"hhi={hhi} 1/N={floor} (N_positive={n_pos})",
+            )
+
+            if n_pos == 1:
+                # A single positive-notional entity owns the whole group.
+                add(
+                    f"{prefix}.single_entity_all_one",
+                    abs(top5 - 1.0) <= _EPS
+                    and abs(top10 - 1.0) <= _EPS
+                    and abs(hhi - 1.0) <= _EPS,
+                    f"top5={top5} top10={top10} hhi={hhi}",
+                )
+
+            if s["n_entities"] <= 5:
+                # Fewer than 5 entities -> the whole group fits the top-5 window.
+                add(f"{prefix}.few_entities_top5_one", abs(top5 - 1.0) <= _EPS, f"top5={top5}")
+            if s["n_entities"] <= 10:
+                add(f"{prefix}.few_entities_top10_one", abs(top10 - 1.0) <= _EPS, f"top10={top10}")
+
+    return results

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -1,0 +1,64 @@
+"""Coverage manifest -- which flat metric keys are exercised; emit a report.
+
+Uses the generic ``baseline_kit.CoverageManifest``. The app supplies the input
+space (every flat metric key the surface produces across all scenarios) and the
+touched set (metric keys referenced by at least one directional check).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from baseline_kit import CoverageManifest, load_catalog
+
+from . import adapter
+from .conftest import CATALOG_PATH, REPO_ROOT
+
+REPORT_PATH = REPO_ROOT / "docs" / "reports" / "baseline-coverage.md"
+
+
+def _all_metric_keys(catalog) -> set[str]:
+    base_rows = catalog["base"]["exposures"]
+    keys: set[str] = set()
+    for scenario in catalog["scenarios"]:
+        keys.update(adapter.run_scenario(scenario, base_rows).keys())
+    return keys
+
+
+def _build_manifest() -> CoverageManifest:
+    catalog = load_catalog(CATALOG_PATH)
+    touched = {d["metric"] for d in catalog.get("directionals", [])}
+    return CoverageManifest(
+        all_keys=_all_metric_keys(catalog),
+        touched_keys=touched,
+        priority_params=list(catalog.get("priority_metrics", [])),
+        title="Counter_Risk baseline coverage manifest",
+    )
+
+
+def test_directional_metrics_exist():
+    m = _build_manifest()
+    assert not m.unknown_catalog_keys, (
+        "Directional checks reference metric keys the adapter never produces: "
+        f"{sorted(m.unknown_catalog_keys)}"
+    )
+
+
+def test_priority_metrics_covered():
+    m = _build_manifest()
+    assert not m.priority_gaps, "Priority metrics with no directional check: " + ", ".join(
+        m.priority_gaps
+    )
+
+
+def test_emit_coverage_report(tmp_path: Path):
+    m = _build_manifest()
+    report_path = (
+        REPORT_PATH
+        if os.environ.get("BASELINE_REFRESH_REPORT") == "1"
+        else tmp_path / "baseline-coverage.md"
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(m.to_markdown())
+    assert report_path.exists()

--- a/tests/baseline/test_directional.py
+++ b/tests/baseline/test_directional.py
@@ -1,0 +1,39 @@
+"""Directional ("metamorphic") checks: variant vs control on a flat metric.
+
+Each catalog `directionals` entry asserts an economically-expected movement,
+e.g. concentrating mass raises HHI; dispersing it lowers HHI / top-share.
+"""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import evaluate_direction, load_catalog
+
+from . import adapter
+from .conftest import CATALOG_PATH
+
+_CATALOG = load_catalog(CATALOG_PATH)
+_BASE_ROWS = _CATALOG["base"]["exposures"]
+_SCENARIOS = {s["id"]: s for s in _CATALOG["scenarios"]}
+_DIRECTIONALS = _CATALOG["directionals"]
+
+
+def _metric(scenario_id: str, key: str) -> float:
+    return adapter.run_scenario(_SCENARIOS[scenario_id], _BASE_ROWS)[key]
+
+
+@pytest.mark.parametrize("scen", _DIRECTIONALS, ids=[s["id"] for s in _DIRECTIONALS])
+def test_directional(scen, record_property):
+    metric = scen["metric"]
+    variant = _metric(scen["scenario"], metric)
+    control = _metric(scen["control"], metric)
+    holds = evaluate_direction(scen["direction"], variant, control)
+    msg = (
+        f"{scen['id']}: {metric} variant={variant:.6g} "
+        f"{scen['direction']} control={control:.6g} -> {holds}"
+    )
+    record_property("directional", msg)
+    if scen.get("enforce"):
+        assert holds, "Economically wrong direction -- " + msg
+    elif not holds:
+        pytest.skip("[report-only] " + msg)

--- a/tests/baseline/test_golden.py
+++ b/tests/baseline/test_golden.py
@@ -1,0 +1,23 @@
+"""Golden masters of each scenario's flattened concentration metrics.
+
+Re-bless after an intended change:
+    pytest tests/baseline/test_golden.py --force-regen
+then review and commit the updated baseline CSVs under test_golden/.
+"""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import check_metrics, load_catalog
+
+from . import adapter
+from .conftest import CATALOG_PATH
+
+_CATALOG = load_catalog(CATALOG_PATH)
+_BASE_ROWS = _CATALOG["base"]["exposures"]
+_SCENARIOS = _CATALOG["scenarios"]
+
+
+@pytest.mark.parametrize("scenario", _SCENARIOS, ids=[s["id"] for s in _SCENARIOS])
+def test_concentration_metrics_golden(scenario, num_regression):
+    check_metrics(num_regression, adapter.run_scenario(scenario, _BASE_ROWS))

--- a/tests/baseline/test_golden/test_concentration_metrics_golden_base_.csv
+++ b/tests/baseline/test_golden/test_concentration_metrics_golden_base_.csv
@@ -1,0 +1,2 @@
+,all_programs.total.top5_share,all_programs.total.top10_share,all_programs.total.hhi,all_programs.treasury.top5_share,all_programs.treasury.top10_share,all_programs.treasury.hhi,all_programs.equity.top5_share,all_programs.equity.top10_share,all_programs.equity.hhi
+0,0.95999999999999996,1,0.26020000000000004,1,1,0.44500000000000001,1,1,0.57999999999999996

--- a/tests/baseline/test_golden/test_concentration_metrics_golden_more_concentrated_.csv
+++ b/tests/baseline/test_golden/test_concentration_metrics_golden_more_concentrated_.csv
@@ -1,0 +1,2 @@
+,all_programs.total.top5_share,all_programs.total.top10_share,all_programs.total.hhi,all_programs.treasury.top5_share,all_programs.treasury.top10_share,all_programs.treasury.hhi,all_programs.equity.top5_share,all_programs.equity.top10_share,all_programs.equity.hhi
+0,0.98461538461538467,1,0.60653846153846158,1,1,0.44500000000000001,1,1,0.57999999999999996

--- a/tests/baseline/test_golden/test_concentration_metrics_golden_more_dispersed_.csv
+++ b/tests/baseline/test_golden/test_concentration_metrics_golden_more_dispersed_.csv
@@ -1,0 +1,2 @@
+,all_programs.total.top5_share,all_programs.total.top10_share,all_programs.total.hhi,all_programs.treasury.top5_share,all_programs.treasury.top10_share,all_programs.treasury.hhi,all_programs.equity.top5_share,all_programs.equity.top10_share,all_programs.equity.hhi
+0,0.62857142857142856,0.97714285714285709,0.12169795918367346,1,1,0.44500000000000001,1,1,0.57999999999999996

--- a/tests/baseline/test_golden/test_concentration_metrics_golden_single_entity_.csv
+++ b/tests/baseline/test_golden/test_concentration_metrics_golden_single_entity_.csv
@@ -1,0 +1,2 @@
+,all_programs.total.top5_share,all_programs.total.top10_share,all_programs.total.hhi,all_programs.treasury.top5_share,all_programs.treasury.top10_share,all_programs.treasury.hhi,all_programs.equity.top5_share,all_programs.equity.top10_share,all_programs.equity.hhi
+0,1,1,1,1,1,0.44500000000000001,1,1,0.57999999999999996

--- a/tests/baseline/test_golden/test_concentration_metrics_golden_zero_total_.csv
+++ b/tests/baseline/test_golden/test_concentration_metrics_golden_zero_total_.csv
@@ -1,0 +1,2 @@
+,all_programs.total.top5_share,all_programs.total.top10_share,all_programs.total.hhi,all_programs.treasury.top5_share,all_programs.treasury.top10_share,all_programs.treasury.hhi,all_programs.equity.top5_share,all_programs.equity.top10_share,all_programs.equity.hhi
+0,0,0,0,1,1,0.44500000000000001,1,1,0.57999999999999996

--- a/tests/baseline/test_invariants.py
+++ b/tests/baseline/test_invariants.py
@@ -1,0 +1,21 @@
+"""Economic invariants on the base scenario and every catalog variant."""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import assert_invariants, load_catalog
+
+from . import invariants
+from .conftest import CATALOG_PATH
+
+_CATALOG = load_catalog(CATALOG_PATH)
+_BASE_ROWS = _CATALOG["base"]["exposures"]
+_SCENARIOS = _CATALOG["scenarios"]
+
+
+@pytest.mark.parametrize("scenario", _SCENARIOS, ids=[s["id"] for s in _SCENARIOS])
+def test_scenario_invariants(scenario):
+    assert_invariants(
+        invariants.check_scenario(scenario, _BASE_ROWS),
+        context=scenario["id"],
+    )

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -10,6 +10,11 @@ _OPERATORS = ("==", ">=", "<=", "~=", "!=", ">", "<", "===")
 
 def _split_spec(raw: str) -> str:
     entry = raw.strip().strip(",").strip('"')
+    # Direct references ("name @ git+https://...") declare the package name before
+    # the " @ "; there is no version operator to split on.
+    if " @ " in entry:
+        name, _ = entry.split(" @ ", 1)
+        return name.strip().split("[")[0]
     for operator in _OPERATORS:
         if operator in entry:
             name, _ = entry.split(operator, 1)
@@ -24,6 +29,12 @@ def _load_lock_versions(path: Path) -> dict[str, str]:
         if not stripped or stripped.startswith("#"):
             continue
         if stripped.startswith("--"):
+            continue
+        # Direct references in the lock ("name @ git+https://...") have no pinned
+        # "==" version; record them so the presence check still passes.
+        if " @ " in stripped:
+            name, _ = stripped.split(" @ ", 1)
+            versions[name.strip().lower()] = "<direct-reference>"
             continue
         if "==" not in stripped:
             continue


### PR DESCRIPTION
## Summary

Adopts the shared **`baseline_kit`** harness (from `stranske/Workflows`, `packages/app-baseline-kit`) for Counter_Risk's concentration-metrics surface, joining TMP / PAEM / trip-planner. Same structure as the trip-planner reference kit, adapted to this surface's economics.

**Surface:** `counter_risk.compute.rollups.compute_concentration_metrics(exposures_df, group_by=None)` — reduces an exposure table to per-`(variant, segment)` scalars `top5_share`, `top10_share`, `hhi` (share-fraction HHI, per `docs/concentration_metrics.md`). Deterministic: no DB / network / LLM.

## What's here (`tests/baseline/`)

- **`adapter.py`** — `run_scenario(scenario, base_rows)`: applies a scenario *patch* to the base exposure table via a small declarative DSL (`set_notional`, `scale_notional`, `add_row`, `drop_counterparty`, `zero_segment`, `keep_only`), calls the surface, and flattens each group to `"<variant>.<segment>.<metric>"` keys.
- **`catalog.yaml`** — base table (1 variant, 3 segments: `total` with 6 names, `treasury` 3, `equity` 2) + variants: `base`, `more_concentrated`, `more_dispersed`, `single_entity`, `zero_total`. Directional checks are patches whose effect is predictable from first principles.
- **`invariants.py`**, **`test_invariants.py`** — economic invariants on base + every scenario.
- **`test_golden.py`** + blessed CSVs — golden masters via pytest-regressions (hand-verified before blessing).
- **`test_directional.py`** — metamorphic variant-vs-control checks.
- **`test_coverage_manifest.py`** — coverage manifest → `docs/reports/baseline-coverage.md`.

## Invariants (per group, enforced)

- `0 <= top5_share <= 1`, `0 <= top10_share <= 1`, `0 <= hhi <= 1`
- `top5_share <= top10_share` (top-10 window ⊇ top-5 window)
- `hhi >= 1/N` for N positive-notional entities (1/N = perfect dispersion; floor uses the *positive*-notional count so zero rows don't distort it)
- single positive-notional entity ⇒ all three = 1.0
- ≤5 entities ⇒ `top5_share == 1.0`; ≤10 entities ⇒ `top10_share == 1.0`
- zero-total group ⇒ all three = 0.0

## Directional checks (variant → control → asserted direction)

| id | metric | direction | variant | control |
|----|--------|-----------|---------|---------|
| concentrated_raises_hhi | total.hhi | increase | 0.6065 | 0.2602 |
| concentrated_raises_top5 | total.top5_share | increase | 0.9846 | 0.9600 |
| dispersed_lowers_hhi | total.hhi | decrease | 0.1217 | 0.2602 |
| dispersed_lowers_top5 | total.top5_share | decrease | 0.6286 | 0.9600 |
| dispersed_lowers_top10 | total.top10_share | decrease | 0.9771 | 1.0000 |
| single_entity_raises_hhi | total.hhi | increase | 1.0000 | 0.2602 |

## Dependency / CI wiring

- `pyproject.toml` `[dev]`: `app-baseline-kit` (git direct ref), `pytest-regressions==2.11.0`, `numpy>=2.0,<3`.
- `requirements.lock` regenerated via `uv pip compile` (its original generator); records the `@ git+` direct reference.
- `tests/test_dependency_version_alignment.py`: now handles `@ git+` direct references (mirrors trip-planner) so `app-baseline-kit` passes the lock-presence check.
- `.project_modules.txt` (new): declares `baseline_kit` + `conftest` so `scripts/sync_test_dependencies.py --verify` passes (without it, those two are flagged as undeclared).

## Local results

`pytest tests/baseline -n0 -q` → **19 passed**. Existing `tests/compute/test_concentration_metrics.py` (35) and `tests/test_dependency_version_alignment.py` (1) still pass.

## Findings

No bugs found — `compute_concentration_metrics` behaved exactly per `docs/concentration_metrics.md`. All golden values are hand-reproducible (e.g. base `total` hhi = 0.4²+0.25²+0.15²+0.1²+0.06²+0.04² = 0.2602). One design note: `top10_share` only moves on a base where `total` exceeds 10 names, so `more_dispersed` deliberately pushes `total` to 11 counterparties to exercise it meaningfully (otherwise it is constant 1.0 and the directional would be vacuous).

Draft — not marking ready; awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)