### PR TITLE
fix(deps): stop pinning app-baseline-kit in requirements.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,15 @@
 requires = ["setuptools>=75.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+# Do not emit app-baseline-kit into requirements.lock. It is consumed from the
+# Workflows monorepo via an unpinned `@main` git URL (see the project
+# dependencies), so freezing a commit SHA in the lock conflicts with that URL
+# the moment Workflows main advances ("conflicting URLs for package
+# app-baseline-kit" -> uv install aborts). Leaving it unpinned lets the editable
+# project install resolve it from main, with no lock to keep refreshed.
+[tool.uv.pip]
+no-emit-package = ["app-baseline-kit"]
+
 [project]
 name = "counter-risk"
 version = "0.1.0"

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,8 +9,6 @@ anyio==4.12.1
     #   anthropic
     #   httpx
     #   openai
-app-baseline-kit @ git+https://github.com/stranske/Workflows.git@13f94883220bbfb0ca69a4666fb44a49e0ae8172#subdirectory=packages/app-baseline-kit
-    # via counter-risk (pyproject.toml)
 ast-serialize==0.3.0
     # via mypy
 black==26.3.1
@@ -218,3 +216,6 @@ xxhash==3.6.0
     # via langsmith
 zstandard==0.25.0
     # via langsmith
+
+# The following packages were excluded from the output:
+# app-baseline-kit

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -55,6 +55,18 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
         for entry in group:
             declared.add(_split_spec(entry).lower())
 
+    # Packages intentionally excluded from the lock via uv's no-emit-package
+    # (monorepo deps consumed from an unpinned @main git URL, e.g.
+    # app-baseline-kit) are not expected to be pinned in requirements.lock.
+    no_emit = {
+        _split_spec(name).lower()
+        for name in pyproject.get("tool", {})
+        .get("uv", {})
+        .get("pip", {})
+        .get("no-emit-package", [])
+    }
+    declared -= no_emit
+
     lock_versions = _load_lock_versions(Path("requirements.lock"))
 
     missing = []

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -46,6 +46,11 @@ def _load_lock_versions(path: Path) -> dict[str, str]:
 def test_all_pyproject_dependencies_are_in_lock() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     project = pyproject.get("project", {})
+    uv_config = pyproject.get("tool", {}).get("uv", {}).get("pip", {})
+    no_emit_packages = {
+        str(name).strip().lower().replace("_", "-")
+        for name in uv_config.get("no-emit-package", [])
+    }
 
     declared = set()
     for entry in project.get("dependencies", []):
@@ -71,6 +76,8 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
 
     missing = []
     for dependency in sorted(declared):
+        if dependency in no_emit_packages:
+            continue
         normalised = dependency.replace("-", "_")
         if dependency not in lock_versions and normalised not in lock_versions:
             missing.append(dependency)


### PR DESCRIPTION
## Preventive fix for the app-baseline-kit lock/pin conflict class

`app-baseline-kit` is consumed via an unpinned `@main` git URL, but `uv pip compile` freezes it to a commit SHA in `requirements.lock`. CI installs the lock + the editable project together, so the package is declared both pinned and unpinned. They agree only until Workflows `main` advances — then uv aborts with `conflicting URLs for package app-baseline-kit`.

Counter_Risk's lock pin is currently fresh, so CI is green **today**, but it would break on the next Workflows `main` advance (this is exactly what hit trip-planner after Workflows #2204).

## Change

- `pyproject.toml`: `[tool.uv.pip] no-emit-package = ["app-baseline-kit"]`
- `requirements.lock`: regenerated — `app-baseline-kit` drops out; all other deps stay pinned

## Verification (uv 0.10.3, local)

- `uv pip install -r requirements.lock -e ".[app,dev]"` → **Resolved 74 packages, no conflict**
- Compile emits `# excluded from the output: app-baseline-kit`

Convention documented in Workflows `docs/ops/CONSUMER_REPO_MAINTENANCE.md` (companion PR). Matches the trip-planner fix.