### PR TITLE
docs: document app-baseline-kit dependency pattern

### DIFF
--- a/docs/baseline-kit-dependency.md
+++ b/docs/baseline-kit-dependency.md
@@ -1,0 +1,3 @@
+# app-baseline-kit dependency
+
+Counter_Risk uses **Pattern A** (the fleet default). `app-baseline-kit` is declared unpinned `@main` in `pyproject.toml` `[project.optional-dependencies].dev` and excluded from `requirements.lock` via `[tool.uv.pip] no-emit-package = ["app-baseline-kit"]` (added in commit ec6b22b, refining the initial 6c2fd1b baseline_kit landing). The no-emit directive prevents the lock from freezing a commit SHA that would conflict with the unpinned pyproject URL the moment Workflows `main` advances. At test time the reusable CI installs via `pip install -e .[dev]`, resolving the package straight from `@main`; the dependency-alignment test was updated to skip no-emit packages. No change needed.


### PR DESCRIPTION
## Summary

Adds a repo-local justification doc at \`docs/baseline-kit-dependency.md\` explaining Counter_Risk's **Pattern A** (fleet default) usage of \`app-baseline-kit\`:

- Declared unpinned \`@main\` in \`pyproject.toml\` \`[project.optional-dependencies].dev\`.
- Excluded from \`requirements.lock\` via \`[tool.uv.pip] no-emit-package = ["app-baseline-kit"]\` (commit ec6b22b, refining the initial 6c2fd1b baseline_kit landing).
- The no-emit directive prevents the lock from freezing a commit SHA that would conflict with the unpinned pyproject URL the moment Workflows \`main\` advances.
- CI installs via \`pip install -e .[dev]\`, resolving straight from \`@main\`; the dependency-alignment test skips no-emit packages.

## Scope

Documentation only. The dependency pattern is justified and stays as-is; no \`pyproject.toml\` / \`requirements.lock\` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)