### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import configparser
 import re
 import sys
 import tomllib
@@ -32,6 +33,18 @@ else:
     TOMLKIT_ERROR = None
 
 PYPROJECT_FILE = Path("pyproject.toml")
+PYTEST_TOML_FILES = (
+    Path("pytest.toml"),
+    Path(".pytest.toml"),
+)
+PYTEST_INI_CONFIGS = (
+    (Path("pytest.ini"), ("pytest",)),
+    (Path(".pytest.ini"), ("pytest",)),
+)
+PYTEST_FALLBACK_INI_CONFIGS = (
+    (Path("tox.ini"), ("pytest",)),
+    (Path("setup.cfg"), ("tool:pytest", "pytest")),
+)
 DEV_EXTRA = "dev"
 
 # Stdlib modules that don't need to be installed. Prefer Python's runtime
@@ -184,8 +197,23 @@ def _detect_local_project_modules() -> set[str]:
 
     tests_dir = Path("tests")
     if tests_dir.is_dir():
+        tests_is_package = (tests_dir / "__init__.py").exists()
+        tests_on_pythonpath = _tests_dir_on_pythonpath() if tests_is_package else False
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
+                continue
+            if tests_is_package:
+                if item.name == "conftest.py":
+                    detected.add("conftest")
+                elif tests_on_pythonpath and item.is_dir() and (item / "__init__.py").exists():
+                    detected.add(item.name)
+                elif (
+                    tests_on_pythonpath
+                    and item.suffix == ".py"
+                    and not item.name.startswith("test_")
+                    and item.name != "__init__.py"
+                ):
+                    detected.add(item.stem)
                 continue
             if item.is_dir() and (item / "__init__.py").exists():
                 detected.add(item.name)
@@ -196,6 +224,108 @@ def _detect_local_project_modules() -> set[str]:
                     detected.add(item.stem)
 
     return detected
+
+
+def _pythonpath_has_tests(pythonpath: Any) -> bool:
+    if isinstance(pythonpath, str):
+        entries = pythonpath.split()
+    elif isinstance(pythonpath, list):
+        entries = [str(entry) for entry in pythonpath]
+    else:
+        entries = []
+
+    return any(
+        entry.strip().strip('"').strip("'").rstrip("/").removeprefix("./") == "tests"
+        for entry in entries
+    )
+
+
+def _config_root() -> Path:
+    return PYPROJECT_FILE.parent if PYPROJECT_FILE.is_absolute() else Path(".")
+
+
+def _resolve_config_path(path: Path) -> Path:
+    return path if path.is_absolute() else _config_root() / path
+
+
+def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
+    try:
+        with config_file.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+    pytest_options = data.get("pytest")
+    if not isinstance(pytest_options, dict):
+        return False
+
+    return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+
+
+def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
+    try:
+        with config_file.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return False
+    pytest_config = tool.get("pytest")
+    if not isinstance(pytest_config, dict):
+        return False
+    if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
+        return True
+    pytest_options = pytest_config.get("ini_options")
+    if isinstance(pytest_options, dict):
+        return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+
+    return False
+
+
+def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
+    config = configparser.ConfigParser()
+    try:
+        read_files = config.read(config_file, encoding="utf-8")
+    except (configparser.Error, OSError, UnicodeDecodeError):
+        return False
+    if not read_files:
+        return False
+
+    for section_name in section_names:
+        if config.has_option(section_name, "pythonpath") and _pythonpath_has_tests(
+            config.get(section_name, "pythonpath")
+        ):
+            return True
+
+    return False
+
+
+def _tests_dir_on_pythonpath() -> bool:
+    for config_file in PYTEST_TOML_FILES:
+        pytest_toml = _resolve_config_path(config_file)
+        if pytest_toml.exists():
+            return _tests_dir_on_pytest_toml_pythonpath(pytest_toml)
+
+    for config_file, section_names in PYTEST_INI_CONFIGS:
+        resolved_config = _resolve_config_path(config_file)
+        if resolved_config.exists():
+            return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
+
+    pyproject = _resolve_config_path(PYPROJECT_FILE)
+    if pyproject.exists():
+        return _tests_dir_on_pyproject_pythonpath(pyproject)
+
+    for config_file, section_names in PYTEST_FALLBACK_INI_CONFIGS:
+        resolved_config = _resolve_config_path(config_file)
+        if resolved_config.exists():
+            return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
+    return False
 
 
 def _read_local_modules() -> set[str]:


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `18892408ec48b75a020f49435add3abec4be57c0`
**Template hash:** `32e0d324db5a`
**Sync branch:** `sync/workflows-32e0d324db5a`
**Consumer repo:** `stranske/Counter_Risk`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Counter_Risk","source_repository":"stranske/Workflows","source_sha":"18892408ec48b75a020f49435add3abec4be57c0","template_hash":"32e0d324db5a","sync_branch":"sync/workflows-32e0d324db5a","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"26856540932","run_attempt":"1","changes_count":1} -->