### PR TITLE
Add segment concentration baseline checks

### DIFF
--- a/docs/reports/baseline-coverage.md
+++ b/docs/reports/baseline-coverage.md
@@ -1,7 +1,7 @@
 # Counter_Risk baseline coverage manifest
 
 - Input parameters: **9**
-- Exercised by a scenario: **3** (33.3%)
+- Exercised by a scenario: **5** (55.6%)
 - Observed read at runtime: **0**
 
 ## Priority parameters
@@ -9,3 +9,5 @@
 - [x] `all_programs.total.hhi`
 - [x] `all_programs.total.top5_share`
 - [x] `all_programs.total.top10_share`
+- [x] `all_programs.treasury.hhi`
+- [x] `all_programs.equity.hhi`

--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -72,6 +72,16 @@ scenarios:
     patch:
       - {op: zero_segment, segment: total}
 
+  # Concentrate the Treasury segment onto its largest counterparty.
+  - id: treasury_concentrated
+    patch:
+      - {op: set_notional, segment: treasury, counterparty: cp_a, value: 1000.0}
+
+  # Concentrate the Equity segment onto its largest counterparty.
+  - id: equity_concentrated
+    patch:
+      - {op: set_notional, segment: equity, counterparty: cp_a, value: 900.0}
+
 # ---------------------------------------------------------------------------
 # Directional checks: variant vs control (base) on a flat metric key.
 # direction is from baseline_kit.DIRECTIONS (left=variant, right=control).
@@ -121,6 +131,20 @@ directionals:
     metric: all_programs.total.hhi
     direction: increase
     enforce: true
+  # Concentrating Treasury mass raises Treasury HHI.
+  - id: treasury_concentrated_raises_hhi
+    scenario: treasury_concentrated
+    control: base
+    metric: all_programs.treasury.hhi
+    direction: increase
+    enforce: true
+  # Concentrating Equity mass raises Equity HHI.
+  - id: equity_concentrated_raises_hhi
+    scenario: equity_concentrated
+    control: base
+    metric: all_programs.equity.hhi
+    direction: increase
+    enforce: true
 
 # ---------------------------------------------------------------------------
 # Coverage manifest: every metric the surface produces must be exercised by a
@@ -130,3 +154,5 @@ priority_metrics:
   - all_programs.total.hhi
   - all_programs.total.top5_share
   - all_programs.total.top10_share
+  - all_programs.treasury.hhi
+  - all_programs.equity.hhi

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -13,6 +13,17 @@
 - **Post-open evidence:** `pr_opened` relay fired for #704. Cap-health at 2026-06-10T20:11:26Z classified #704 as `draining` with an active Gate run after the latest branch update; raw opener cap remained below 5.
 - **Next action:** wait_for_keepalive; keepalive owns CI/review, closer owns merge and verifier/source issue closure.
 
+## 2026-06-10T22:06Z - opener (codex) materialized issue #705
+
+- **Lane:** opener (Codex) from neutral Code workspace.
+- **Issue:** stranske/Counter_Risk#705 (priority:normal, repo-review-approved) - add directional baseline checks for treasury and equity concentration metric segments.
+- **Branch:** `codex/issue-705-directional-segment-baselines`; worktree `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/counter-risk-705-directional`.
+- **Cap/drain preflight:** raw opener cap below 5. Repaired stale blocker labels on existing opener-owned PR #704; post-repair cap-health classified #704 as draining with fresh Gate/keepalive evidence.
+- **Change:** added treasury/equity concentrated scenarios, enforced HHI directional checks, extended priority metrics with `all_programs.treasury.hhi` and `all_programs.equity.hhi`, and refreshed `docs/reports/baseline-coverage.md` from 3/9 (33.3%) to 5/9 (55.6%).
+- **Validation:** `pytest tests/baseline/test_directional.py tests/baseline/test_coverage_manifest.py::test_priority_metrics_covered tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q` passed (10 passed). `BASELINE_REFRESH_REPORT=1 pytest tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q` passed. `rg "enforce: true" tests/baseline/catalog.yaml | wc -l` returned 8. `git diff --check` passed.
+- **Deliberate break:** temporarily changed `treasury_concentrated_raises_hhi` direction to `decrease`; `pytest 'tests/baseline/test_directional.py::test_directional[treasury_concentrated_raises_hhi]' -q` failed with `Economically wrong direction -- treasury_concentrated_raises_hhi: all_programs.treasury.hhi variant=0.860254 decrease control=0.445 -> False`. Reverted before final validation.
+- **Next action:** commit/push branch, open ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`; then wait_for_keepalive.
+
 ## 2026-05-30T20:32Z - closer (codex) resolved PR #662 review threads
 
 - **Lane:** closer / complex review-thread recovery from neutral Code workspace. Target: [#662](https://github.com/stranske/Counter_Risk/pull/662) for issue [#651](https://github.com/stranske/Counter_Risk/issues/651), branch `codex/issue-651-evidence-provenance`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -17,12 +17,13 @@
 
 - **Lane:** opener (Codex) from neutral Code workspace.
 - **Issue:** stranske/Counter_Risk#705 (priority:normal, repo-review-approved) - add directional baseline checks for treasury and equity concentration metric segments.
-- **Branch:** `codex/issue-705-directional-segment-baselines`; worktree `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/counter-risk-705-directional`.
+- **Branch/PR:** `codex/issue-705-directional-segment-baselines`; PR #706 opened ready-for-review, non-draft, with `agent:codex`, `agents:keepalive`, `autofix`, `agent:retry`, `repo-review-approved`, and `priority:normal`. Worktree `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/counter-risk-705-directional`.
 - **Cap/drain preflight:** raw opener cap below 5. Repaired stale blocker labels on existing opener-owned PR #704; post-repair cap-health classified #704 as draining with fresh Gate/keepalive evidence.
 - **Change:** added treasury/equity concentrated scenarios, enforced HHI directional checks, extended priority metrics with `all_programs.treasury.hhi` and `all_programs.equity.hhi`, and refreshed `docs/reports/baseline-coverage.md` from 3/9 (33.3%) to 5/9 (55.6%).
 - **Validation:** `pytest tests/baseline/test_directional.py tests/baseline/test_coverage_manifest.py::test_priority_metrics_covered tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q` passed (10 passed). `BASELINE_REFRESH_REPORT=1 pytest tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q` passed. `rg "enforce: true" tests/baseline/catalog.yaml | wc -l` returned 8. `git diff --check` passed.
 - **Deliberate break:** temporarily changed `treasury_concentrated_raises_hhi` direction to `decrease`; `pytest 'tests/baseline/test_directional.py::test_directional[treasury_concentrated_raises_hhi]' -q` failed with `Economically wrong direction -- treasury_concentrated_raises_hhi: all_programs.treasury.hhi variant=0.860254 decrease control=0.445 -> False`. Reverted before final validation.
-- **Next action:** commit/push branch, open ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`; then wait_for_keepalive.
+- **Post-open routing:** initial cap-health saw #706 as `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Post-repair cap-health at `2026-06-10T22:08:58Z` classified #706 as `draining` with active Autofix/Gate/Gate Followups evidence. PR #704 also remained `draining`.
+- **Next action:** wait_for_keepalive; keepalive owns CI/review, closer owns merge and verifier/source issue closure.
 
 ## 2026-05-30T20:32Z - closer (codex) resolved PR #662 review threads
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,14 @@
 # Counter_Risk workloop state
 
+## 2026-06-10T22:31Z - closer (codex) rebased PR #706 and cleared stale human blocker
+
+- **Lane:** closer / complex needs-human audit from neutral Code workspace.
+- **PR:** #706 (`codex/issue-705-directional-segment-baselines`) for source issue #705.
+- **Audit:** PR was non-draft, issue-linked, review-thread clear, and latest checks were green before rebase. The `needs-human` label traced to stale automation around a cancelled Gate run and exhausted autofix attempts; the later Gate/Gate Followups evidence was successful and no concrete human decision remained.
+- **Action:** rebased the PR branch onto current `origin/main` after PR #704 merged. Resolved the only conflict in `workloop-state.md` by keeping both the #703 and #705 entries. Planned remote cleanup: remove stale `needs-human` after push.
+- **Validation:** `python -m pytest tests/baseline/test_directional.py tests/baseline/test_coverage_manifest.py::test_priority_metrics_covered tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q` passed (10 passed). `BASELINE_REFRESH_REPORT=1 python -m pytest tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q` passed. `git diff --check origin/main...HEAD` passed.
+- **Next action:** wait for fresh post-rebase CI on #706. If checks stay green and no new review threads appear, merge #706, apply `verify:compare`, and reopen #705 for verifier sequencing.
+
 ## 2026-06-10T20:09:49Z - opener (codex) materialized issue #703
 
 - **Lane:** opener (Codex) from neutral Code workspace.


### PR DESCRIPTION
Closes #705

## Summary
- add Treasury and Equity concentration scenarios to the baseline catalog
- enforce directional HHI checks for non-total concentration segments
- extend priority metrics and refresh baseline coverage to 5/9 (55.6%)

## Validation
- pytest tests/baseline/test_directional.py tests/baseline/test_coverage_manifest.py::test_priority_metrics_covered tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q
- BASELINE_REFRESH_REPORT=1 pytest tests/baseline/test_coverage_manifest.py::test_emit_coverage_report -q
- Deliberate break: flipped treasury_concentrated_raises_hhi to direction: decrease and confirmed test_directional[treasury_concentrated_raises_hhi] failed with Economically wrong direction
- rg "enforce: true" tests/baseline/catalog.yaml | wc -l -> 8
- git diff --check