### PR TITLE
chore: refresh consumer CI config (llm_slots bump + drop double-CI trigger)

### DIFF
--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -3,12 +3,12 @@
     {
       "name": "slot1",
       "provider": "openai",
-      "model": "gpt-5.2"
+      "model": "gpt-5.4"
     },
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-5-20250929"
+      "model": "claude-sonnet-4-6"
     },
     {
       "name": "slot3",


### PR DESCRIPTION
Fleet-hygiene fixes from the Workflows audit §4. Fixes applied: llm_slots(→gpt-5.4/sonnet-4-6). llm_slots was frozen at 2-gen-old models (create_only sync); the prohibited `pull_request:` trigger double-ran CI (the reusable Gate already covers PRs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only model ID updates with no auth or data-path changes; main risk is provider/API compatibility if new model names are wrong in a given environment.
> 
> **Overview**
> Updates **`config/llm_slots.json`** so consumer CI and LangChain tooling pick up current default models instead of two-generation-old IDs.
> 
> **slot1** (OpenAI) moves from `gpt-5.2` to **`gpt-5.4`**. **slot2** (Anthropic) moves from `claude-sonnet-4-5-20250929` to **`claude-sonnet-4-6`**. **slot3** (`github-models` / `codex-mini-latest`) is unchanged.
> 
> This file is the shared slot config for paths like `langchain_runtime` and `tools/langchain_client`; the change is configuration-only—no application logic in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392773ff5154b4647d7869a3b32448c6831a9cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->