### PR TITLE
test(baseline): commit missing golden CSVs for segment-concentration scenarios

### DIFF
--- a/tests/baseline/test_golden/test_concentration_metrics_golden_equity_concentrated_.csv
+++ b/tests/baseline/test_golden/test_concentration_metrics_golden_equity_concentrated_.csv
@@ -1,0 +1,2 @@
+,all_programs.total.top5_share,all_programs.total.top10_share,all_programs.total.hhi,all_programs.treasury.top5_share,all_programs.treasury.top10_share,all_programs.treasury.hhi,all_programs.equity.top5_share,all_programs.equity.top10_share,all_programs.equity.hhi
+0,0.95999999999999996,1,0.26020000000000004,1,1,0.44500000000000001,1,1,0.93756503642039557

--- a/tests/baseline/test_golden/test_concentration_metrics_golden_treasury_concentrated_.csv
+++ b/tests/baseline/test_golden/test_concentration_metrics_golden_treasury_concentrated_.csv
@@ -1,0 +1,2 @@
+,all_programs.total.top5_share,all_programs.total.top10_share,all_programs.total.hhi,all_programs.treasury.top5_share,all_programs.treasury.top10_share,all_programs.treasury.hhi,all_programs.equity.top5_share,all_programs.equity.top10_share,all_programs.equity.hhi
+0,0.95999999999999996,1,0.26020000000000004,1,1,0.86025377229080935,1,1,0.57999999999999996


### PR DESCRIPTION
## What

`main`'s Python CI (`python 3.12` / `python 3.13`) has been red on **every push for days**. Root cause: PR #706 ("Add segment concentration baseline checks") added the `treasury_concentrated` and `equity_concentrated` scenarios to `tests/baseline/catalog.yaml` but **never committed their golden master CSVs**.

`tests/baseline/test_golden.py::test_concentration_metrics_golden` is a `baseline_kit` `num_regression` golden test. With no committed CSV for these two cases, the helper materializes the file on first run and then **fails by design** ("File not found in data directory, created: …") so a human commits the baseline. That has been failing the run since 2026-06-10:

```
2 failed, 1290 passed, 1 skipped
FAILED ...test_concentration_metrics_golden[treasury_concentrated]
FAILED ...test_concentration_metrics_golden[equity_concentrated]
```

## Fix

Commit the two missing golden CSVs (test data only — no source or template changes). Generated by running the suite locally, then **verified by hand** against `docs/concentration_metrics.md` and the catalog's directional checks:

| scenario | patch | changed metric | base → golden |
|---|---|---|---|
| `treasury_concentrated` | treasury/cp_a 120 → 1000 | `all_programs.treasury.hhi` | 0.445 → **0.86025** |
| `equity_concentrated` | equity/cp_a 70 → 900 | `all_programs.equity.hhi` | 0.58 → **0.93757** |

Untouched segments retain their base values, and all baseline invariants hold (values in [0,1], `top5 ≤ top10`, `hhi ≥ 1/N`, ≤5 entities ⇒ `top5 = 1.0`). The concentrated-segment HHI increases, matching the `treasury_concentrated_raises_hhi` / `equity_concentrated_raises_hhi` directional tests.

## Verification (local)

```
$ pytest tests/baseline/ -n auto --dist loadscope -q
25 passed
```

The two target tests now pass; the full baseline suite is green.

## Scope

Counter_Risk-domain test-data fix only — **not** a Workflows/template change. This unblocks the red gate (and in turn the in-flight template-sync PR #714, whose only Python CI blocker is this same golden failure).

> Note: `main` also has a *separate, pre-existing* `lint-format` failure (6 unformatted `.py` files) that is **out of scope** here and is skipped on non-`.py` PRs like this one and #714. Flagging it for a separate fix.