### PR TITLE
style: black-format 6 files to satisfy pinned Black 26.5.1 (lint-format)

### DIFF
--- a/src/counter_risk/gui/runner.py
+++ b/src/counter_risk/gui/runner.py
@@ -180,11 +180,7 @@ def execute_gui_run(
         settings_path=settings_path,
         dry_run_discovery=dry_run_discovery,
     )
-    output_dir = (
-        None
-        if dry_run_discovery
-        else Path(cli_args[cli_args.index("--output-dir") + 1])
-    )
+    output_dir = None if dry_run_discovery else Path(cli_args[cli_args.index("--output-dir") + 1])
     try:
         exit_code = int(runner(cli_args))
     finally:
@@ -334,7 +330,9 @@ def launch_gui(
 
     def _open_summary() -> None:
         current = _state_from_form()
-        _open_path((last_output_dir or _resolve_existing_output_dir(current)) / "DATA_QUALITY_SUMMARY.txt")
+        _open_path(
+            (last_output_dir or _resolve_existing_output_dir(current)) / "DATA_QUALITY_SUMMARY.txt"
+        )
 
     def _open_ppt() -> None:
         current = _state_from_form()

--- a/src/counter_risk/pipeline/evidence.py
+++ b/src/counter_risk/pipeline/evidence.py
@@ -20,7 +20,9 @@ def top_exposure_evidence(
 ) -> Evidence:
     """Build evidence for a top exposure row using the manifest input key namespace."""
 
-    source_id = "mosers_all_programs_xlsx" if variant == "all_programs" else f"mosers_{variant}_xlsx"
+    source_id = (
+        "mosers_all_programs_xlsx" if variant == "all_programs" else f"mosers_{variant}_xlsx"
+    )
     source_sheet = str(sheet).strip() if sheet is not None and str(sheet).strip() else None
     source_row = int(row) if isinstance(row, int) and row > 0 else None
     return {

--- a/tests/outputs/test_pdf_export.py
+++ b/tests/outputs/test_pdf_export.py
@@ -129,8 +129,9 @@ def test_pdf_export_generator_logs_failure_with_underlying_exception_message(
         pptx_to_pdf_exporter=_failing_export,
     )
 
-    with caplog.at_level("ERROR"), pytest.raises(
-        RuntimeError, match="PDF export failed: boom export"
+    with (
+        caplog.at_level("ERROR"),
+        pytest.raises(RuntimeError, match="PDF export failed: boom export"),
     ):
         generator.generate(context=context)
 

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -48,8 +48,7 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
     project = pyproject.get("project", {})
     uv_config = pyproject.get("tool", {}).get("uv", {}).get("pip", {})
     no_emit_packages = {
-        str(name).strip().lower().replace("_", "-")
-        for name in uv_config.get("no-emit-package", [])
+        str(name).strip().lower().replace("_", "-") for name in uv_config.get("no-emit-package", [])
     }
 
     declared = set()

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -10,9 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _project_metadata() -> dict[str, object]:
-    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
-        "project"
-    ]
+    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
 
 
 def test_project_metadata_is_counter_risk_specific() -> None:

--- a/tests/test_runner_vba_module.py
+++ b/tests/test_runner_vba_module.py
@@ -91,7 +91,9 @@ def test_runner_vba_open_output_folder_checks_directory_and_reports_missing_path
     module_source = _module_source()
 
     assert "Public Sub OpenOutputFolder_Click()" in module_source
-    assert "resolvedPath = ResolveExistingOutputDir(ResolveRepoRoot(), selectedDate)" in module_source
+    assert (
+        "resolvedPath = ResolveExistingOutputDir(ResolveRepoRoot(), selectedDate)" in module_source
+    )
     assert 'missingDirectoryMessage = "Directory not found" & " " & resolvedPath' in module_source
     assert 'missingDirectoryMessage = "Directory not found" & resolvedPath' not in module_source
     assert 'If Dir$(resolvedPath, vbDirectory) = "" Then' in module_source


### PR DESCRIPTION
## What

main's `lint-format` CI job runs **`black --check`** pinned to **26.5.1** (`.github/workflows/autofix-versions.env`). Six files predate that pin and were never reformatted against it, so the job has failed on **every full-scope CI run for days** — a breakage **independent of** the missing golden CSVs fixed in #717.

```
would reformat src/counter_risk/pipeline/evidence.py
would reformat src/counter_risk/gui/runner.py
would reformat tests/outputs/test_pdf_export.py
would reformat tests/test_dependency_version_alignment.py
would reformat tests/test_package_metadata.py
would reformat tests/test_runner_vba_module.py
6 files would be reformatted, 325 files would be left unchanged.
```

## Fix

Ran `black==26.5.1` on the six flagged files. The diff is **formatting-only** — line re-wrapping (collapsing ternaries that now fit) and Black 26.x parenthesized `with (...)` context managers. Black verifies AST equivalence, and the affected tests still pass locally (`22 passed`). After this, `black --check .` reports the whole repo clean.

No source logic or template changes.

## Relationship to #717

These are the **two independent** breakages on main:

| failure | CI job | fixed by |
|---|---|---|
| missing golden CSVs (`equity`/`treasury_concentrated`) | `python 3.12` / `3.13` | #717 |
| 6 unformatted files | `lint-format` (`black --check`) | **this PR** |

⚠️ **Merge order:** this PR's `python 3.12`/`3.13` jobs will stay red on the golden test until **#717 merges first** (this branch is off plain `main`, which doesn't yet carry the golden CSVs). The `lint-format` job here proves the Black fix passes. After #717 lands, a rebase / re-run turns this fully green. Recommend merging #717, then this.

> Side note: the `Makefile`'s `format-check` target uses `ruff format`, not Black — a real Makefile-vs-CI mismatch (ruff flags a *different* 17-file set). Out of scope here; worth aligning separately.