### PR TITLE
perf(ci): line-only coverage on sys.monitoring backend (~halves main CI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,14 @@ markers = [
 
 [tool.coverage.run]
 source = ["src"]
-branch = true
+# Line coverage only (branch coverage dropped) so coverage can use CPython
+# 3.12+'s sys.monitoring backend below. The default C-trace (sys.settrace)
+# backend roughly doubled the coverage-enabled main-push CI run over the
+# numeric/pandas-heavy + full-pipeline tests; sysmon cuts that overhead, but
+# in coverage 7.14 sysmon cannot measure branches (it silently falls back to
+# C-trace when branch=true). Trade-off accepted: faster CI, line-only metric.
+branch = false
+core = "sysmon"
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
## What

`main`'s `Python CI` runs the full suite **with coverage** on every push (PRs run a fast `not slow and not release` gate without coverage). The coverage-enabled run takes **~36–42 min**. Investigation showed coverage's default **C-trace (`sys.settrace`)** backend roughly **doubles** the run over the numeric/pandas-heavy and full-pipeline tests:

| full-scope run | time |
|---|---|
| no coverage | 17:38 |
| coverage, C-trace (current) | **35:54** |

## Change

Switch coverage to CPython 3.12+'s **`sys.monitoring`** backend (`core = "sysmon"`). In coverage 7.14 sysmon **cannot measure branches** — with `branch = true` it silently falls back to C-trace (`CoverageWarning: no-sysmon`), which is why a naive `core = sysmon` is a no-op. So this also drops branch coverage (`branch = false`).

```toml
[tool.coverage.run]
source = ["src"]
branch = false
core = "sysmon"
```

**Trade-off (intentional):** faster CI in exchange for a **line-only** coverage metric (no branch coverage). `coverage-min` is now measured on lines.

## Verified — `workflow_dispatch` full+coverage run ([27548958753](https://github.com/stranske/Counter_Risk/actions/runs/27548958753))

| | before | after |
|---|---|---|
| python 3.12 | ~42 min | **18m23s** |
| python 3.13 | ~40 min | **17m38s** |
| pytest wall | 35:54 | **17:45** |
| coverage overhead | ~18 min | **~0** (matches no-cov floor) |

- ✅ `1345 passed, 5 skipped` — full suite unchanged
- ✅ `no-sysmon` fallback warnings: **0** (sysmon actually active)
- ✅ `COVERAGE_MIN_OUTCOME: success` — coverage stays enabled and the 80% gate still passes on the line-only metric

> Note: this PR's own `pull_request` checks run the reduced fast gate (no coverage), so they won't exercise the sysmon path — validation is the linked `workflow_dispatch` run, and it'll be confirmed on the first `main` push after merge.

Repo-local change only (coverage config in `pyproject.toml`); no Workflows/template change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code coverage configuration to use system monitoring infrastructure with branch coverage disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->