### PR TITLE
fix(windows): resolve bundled config via runtime paths in frozen build

### DIFF
--- a/src/counter_risk/normalize.py
+++ b/src/counter_risk/normalize.py
@@ -14,6 +14,7 @@ normalize_clearing_house - Map a clearing house raw name to its workbook label.
 from __future__ import annotations
 
 import re
+import sys
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -21,6 +22,7 @@ from typing import Literal
 
 from counter_risk.name_matching import canonicalize_match_key
 from counter_risk.name_registry import NameRegistryConfig, SeriesIncludedFlags, load_name_registry
+from counter_risk.runtime_paths import RuntimePathResolutionError, resolve_runtime_path
 
 _DEFAULT_REGISTRY_RELATIVE_PATH = Path("config/name_registry.yml")
 _REPO_DEFAULT_REGISTRY_PATH = Path(__file__).resolve().parents[2] / _DEFAULT_REGISTRY_RELATIVE_PATH
@@ -121,6 +123,13 @@ def _resolve_registry_path(registry_path: str | Path) -> Path:
     if path.is_absolute():
         return path
     if path == _DEFAULT_REGISTRY_RELATIVE_PATH:
+        if getattr(sys, "frozen", False):
+            # In a frozen build the source-tree fallback below does not exist;
+            # search the bundle roots instead.
+            try:
+                return resolve_runtime_path(_DEFAULT_REGISTRY_RELATIVE_PATH)
+            except RuntimePathResolutionError:
+                return _REPO_DEFAULT_REGISTRY_PATH
         cwd_candidate = path.resolve()
         if cwd_candidate.exists():
             return cwd_candidate

--- a/src/counter_risk/pipeline/reconciliation.py
+++ b/src/counter_risk/pipeline/reconciliation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Literal
@@ -19,8 +20,22 @@ from counter_risk.pipeline.parsing_types import (
     UnmappedCounterpartyError,
 )
 from counter_risk.reports.mapping_diff import collect_mapping_diff_findings
+from counter_risk.runtime_paths import resolve_runtime_path
 
-_NAME_REGISTRY_PATH = Path(__file__).resolve().parents[3] / "config" / "name_registry.yml"
+
+def _name_registry_path() -> Path:
+    """Resolve the bundled name registry for both source and frozen runtimes.
+
+    Resolved lazily (not at import time) so that ``sys.frozen`` and the bundle
+    roots are evaluated when the file is actually loaded during a run. In a
+    PyInstaller build the source-tree ``parents[3]`` layout does not exist, so
+    search the bundle roots; in source mode keep the historical repo-relative
+    location (which does not depend on the process working directory).
+    """
+
+    if getattr(sys, "frozen", False):
+        return resolve_runtime_path("config/name_registry.yml")
+    return Path(__file__).resolve().parents[3] / "config" / "name_registry.yml"
 
 
 def reconcile_series_coverage(
@@ -103,7 +118,7 @@ def reconcile_series_coverage(
                     counterparty_included_for_variant(
                         raw_name,
                         variant,
-                        registry_path=_NAME_REGISTRY_PATH,
+                        registry_path=_name_registry_path(),
                     )
                     for raw_name in raw_names
                 )
@@ -144,7 +159,7 @@ def reconcile_series_coverage(
             expected_segments.difference(parsed_segments), key=str.casefold
         )
         mapping_diff_findings = collect_mapping_diff_findings(
-            _NAME_REGISTRY_PATH,
+            _name_registry_path(),
             {
                 "reconciliation": {
                     "counterparties_in_data": counterparties_in_data,

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -101,6 +101,7 @@ from counter_risk.reports import (
     write_change_attribution_csv,
     write_change_attribution_markdown,
 )
+from counter_risk.runtime_paths import resolve_runtime_path
 from counter_risk.writers import (
     fill_dropin_template,
     generate_mosers_workbook,
@@ -2262,7 +2263,13 @@ def _compute_and_write_limit_breaches(
 ) -> LimitBreachEvaluation:
     """Compute limit breaches and write limit_breaches.csv when breaches exist."""
 
-    limits_path = _resolve_repo_root() / "config" / "limits.yml"
+    # In a frozen PyInstaller build the source-tree repo-root layout does not
+    # exist, so search the bundle roots; in source mode keep resolving relative
+    # to the repository root (which tests monkeypatch via _resolve_repo_root).
+    if getattr(sys, "frozen", False):
+        limits_path = resolve_runtime_path("config/limits.yml")
+    else:
+        limits_path = _resolve_repo_root() / "config" / "limits.yml"
     if not limits_path.exists():
         LOGGER.info("limit_breaches_skipped missing_limits_config path=%s", limits_path)
         return LimitBreachEvaluation(csv_path=None, breach_count=0)

--- a/tests/pipeline/test_frozen_runtime_config.py
+++ b/tests/pipeline/test_frozen_runtime_config.py
@@ -1,0 +1,84 @@
+"""Frozen-build config resolution for reconciliation and limit-breach detection.
+
+Regression coverage for the PyInstaller one-dir build: bundled ``config`` files
+must be resolved through ``resolve_runtime_path`` (searching the bundle root)
+rather than the source-tree ``Path(__file__).resolve().parents[3]`` layout, which
+does not exist inside a frozen ``.exe``.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from counter_risk.limits_config import load_limits_config
+from counter_risk.name_registry import load_name_registry
+from counter_risk.normalize import _DEFAULT_REGISTRY_RELATIVE_PATH, _resolve_registry_path
+from counter_risk.pipeline import reconciliation
+from counter_risk.pipeline.run import _compute_and_write_limit_breaches
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REPO_CONFIG = _REPO_ROOT / "config"
+
+
+@pytest.fixture()
+def frozen_bundle(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Simulate a frozen one-dir build whose bundle root holds ``config/``."""
+
+    bundle_root = tmp_path / "bundle-root"
+    bundle_config = bundle_root / "config"
+    bundle_config.mkdir(parents=True)
+    for name in ("name_registry.yml", "limits.yml"):
+        shutil.copyfile(_REPO_CONFIG / name, bundle_config / name)
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setenv("COUNTER_RISK_BUNDLE_ROOT", str(bundle_root))
+    # Point the executable dir somewhere without a config/ so the env root is
+    # the only thing that can satisfy resolution.
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "dist" / "counter-risk"), raising=False)
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    return bundle_root
+
+
+def test_reconciliation_registry_resolves_from_bundle_root(frozen_bundle: Path) -> None:
+    resolved = reconciliation._name_registry_path()
+
+    assert resolved == frozen_bundle / "config" / "name_registry.yml"
+    assert resolved.exists()
+    # The file the reconciliation pass loads is valid and parses cleanly.
+    load_name_registry(resolved)
+
+
+def test_normalize_default_registry_resolves_from_bundle_root(frozen_bundle: Path) -> None:
+    resolved = _resolve_registry_path(_DEFAULT_REGISTRY_RELATIVE_PATH)
+
+    assert resolved == frozen_bundle / "config" / "name_registry.yml"
+    assert resolved.exists()
+
+
+def test_limit_breach_resolution_finds_bundled_limits_config(
+    frozen_bundle: Path,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    warnings: list[str] = []
+
+    with caplog.at_level(logging.INFO, logger="counter_risk.pipeline.run"):
+        evaluation = _compute_and_write_limit_breaches(
+            parsed_by_variant={},
+            run_dir=run_dir,
+            warnings=warnings,
+        )
+
+    # With no exposures there are no breaches, but the limits config must have
+    # been located: the silent "missing config" skip branch must NOT fire.
+    assert evaluation.csv_path is None
+    assert "limit_breaches_skipped" not in caplog.text
+    # Sanity check the bundled file the run path now resolves is loadable.
+    load_limits_config(frozen_bundle / "config" / "limits.yml")


### PR DESCRIPTION
## Problem

Two pipeline modules resolved bundled config files relative to the source-tree layout (`Path(__file__).resolve().parents[3] / "config" / ...`), which does **not** exist inside a PyInstaller frozen one-dir build:

1. **Reconciliation crash** — `reconciliation.py` resolved `name_registry.yml` via `parents[3]`; in a frozen build the file is missing, so `load_name_registry()` raised `ValueError` and the run crashed during reconciliation.
2. **Silent limit-breach skip** — `run.py` resolved `limits.yml` via `_resolve_repo_root()` (`parents[3]`); in a frozen build the missing-file guard then **silently skipped** limit-breach detection (no `limit_breaches.csv` produced).

## Fix

Route frozen-mode resolution through `counter_risk.runtime_paths.resolve_runtime_path(...)`, which searches `COUNTER_RISK_BUNDLE_ROOT` / `sys._MEIPASS` / the executable dir (the runtime hook sets `COUNTER_RISK_BUNDLE_ROOT`). Source-mode behavior is preserved unchanged:

- `reconciliation.py` — replaced the import-time `_NAME_REGISTRY_PATH` constant with a lazy `_name_registry_path()` helper (frozen → bundle roots; source → original `parents[3]`).
- `run.py` — `_compute_and_write_limit_breaches` uses `resolve_runtime_path` when `sys.frozen`, else the original `_resolve_repo_root() / "config" / "limits.yml"` (so the test `patch_repo_root` fixture still works).
- `normalize.py` — made the default-registry-path fallback frozen-aware as well.

## Testing

- New `tests/pipeline/test_frozen_runtime_config.py` simulates frozen mode (`sys.frozen=True` + `COUNTER_RISK_BUNDLE_ROOT` → temp dir with `config/`) and asserts reconciliation, normalize-default, and limit-breach resolution all find the bundled files.
- Built the real exe via `pyinstaller --clean -y release.spec` and drove a full pipeline run through the packaged `.exe` against the real fixtures: exit 0, full outputs produced, log shows limits.yml loaded (not skipped) and reconciliation completed without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime configuration file resolution for packaged (“frozen”) builds, ensuring `name_registry.yml` and `limits.yml` are correctly found and loaded from the bundle directory during reconciliation and limit-breach computation.

* **Tests**
  * Added regression tests that simulate a frozen runtime to verify bundled config discovery and parsing, including expected behavior when no exposures exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->