### PR TITLE
fix(windows): resolve loader default config paths via runtime paths when frozen

### DIFF
--- a/src/counter_risk/limits_config.py
+++ b/src/counter_risk/limits_config.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import contextlib
+import sys
 from pathlib import Path
 from typing import Any, Literal, cast
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+from counter_risk.runtime_paths import RuntimePathResolutionError, resolve_runtime_path
 
 
 class _NoDuplicateSafeLoader(yaml.SafeLoader):
@@ -99,6 +103,12 @@ def load_limits_config(path: str | Path = Path("config/limits.yml")) -> LimitsCo
     """Load and validate a limits YAML configuration file from disk."""
 
     config_path = Path(path)
+    # In a frozen PyInstaller build a relative default like "config/..." is
+    # resolved against the bundle roots; in source mode resolve_runtime_path
+    # returns the path unchanged, preserving existing behavior.
+    if not config_path.is_absolute() and getattr(sys, "frozen", False):
+        with contextlib.suppress(RuntimePathResolutionError):
+            config_path = resolve_runtime_path(config_path)
     try:
         raw = yaml.load(config_path.read_text(encoding="utf-8"), Loader=_NoDuplicateSafeLoader)
     except OSError as exc:

--- a/src/counter_risk/name_registry.py
+++ b/src/counter_risk/name_registry.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import re
+import sys
 from pathlib import Path
 from typing import Any, Literal
 
@@ -10,6 +12,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from counter_risk.name_matching import canonicalize_match_key
+from counter_risk.runtime_paths import RuntimePathResolutionError, resolve_runtime_path
 
 _CANONICAL_KEY_PATTERN = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
 
@@ -160,6 +163,12 @@ def load_name_registry(path: str | Path = Path("config/name_registry.yml")) -> N
     """Load and validate a name registry YAML file from disk."""
 
     config_path = Path(path)
+    # In a frozen PyInstaller build a relative default like "config/..." is
+    # resolved against the bundle roots; in source mode resolve_runtime_path
+    # returns the path unchanged, preserving existing behavior.
+    if not config_path.is_absolute() and getattr(sys, "frozen", False):
+        with contextlib.suppress(RuntimePathResolutionError):
+            config_path = resolve_runtime_path(config_path)
     try:
         raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     except OSError as exc:

--- a/tests/pipeline/test_frozen_runtime_config.py
+++ b/tests/pipeline/test_frozen_runtime_config.py
@@ -82,3 +82,25 @@ def test_limit_breach_resolution_finds_bundled_limits_config(
     assert "limit_breaches_skipped" not in caplog.text
     # Sanity check the bundled file the run path now resolves is loadable.
     load_limits_config(frozen_bundle / "config" / "limits.yml")
+
+
+def test_load_name_registry_default_resolves_from_bundle_root(
+    frozen_bundle: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Run from a directory with no config/ so a bare relative default could only
+    # succeed by resolving against the bundle root, not the process cwd.
+    monkeypatch.chdir(tmp_path)
+
+    registry = load_name_registry()
+
+    assert registry.entries
+
+
+def test_load_limits_config_default_resolves_from_bundle_root(
+    frozen_bundle: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    config = load_limits_config()
+
+    assert config.schema_version == 1


### PR DESCRIPTION
## Context

Follow-up to #730. That PR routed the two *active* config call sites (reconciliation's `name_registry.yml` and run.py's `limits.yml`) through `resolve_runtime_path` for frozen PyInstaller builds. This PR closes the remaining loose end from that task's "also consider" note.

## Problem

`load_name_registry()` and `load_limits_config()` still default to bare CWD-relative paths:

- `name_registry.py` — `load_name_registry(path=Path("config/name_registry.yml"))`
- `limits_config.py` — `load_limits_config(path=Path("config/limits.yml"))`

No current caller relies on these defaults inside a frozen build (every production caller now passes an already-resolved path), so this is hardening rather than a live bug — but a future direct call would silently break the `.exe`.

## Fix

When the supplied path is relative **and** `sys.frozen` is set, resolve it through `resolve_runtime_path` (which searches `COUNTER_RISK_BUNDLE_ROOT` / `sys._MEIPASS` / the executable dir). If resolution fails, fall through to the original path so the loader's existing `ValueError` error contract is preserved.

Source mode is **unchanged**: the guard only fires under `sys.frozen`, and `resolve_runtime_path` returns relative paths verbatim when not frozen.

## Testing

Extended `tests/pipeline/test_frozen_runtime_config.py` with two cases that `chdir` to a config-less directory under simulated frozen mode and assert `load_name_registry()` / `load_limits_config()` (called with no args → bare defaults) resolve the bundled files from the bundle root rather than the cwd. Full frozen suite + `test_name_registry` + `test_limits` pass; lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files now correctly resolve when running from frozen or bundled application builds.
  
* **Tests**
  * Added regression tests ensuring configuration files load properly from bundle root in frozen execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->