### PR TITLE
Emit DATE_RESOLUTION_FALLBACK for inferred as_of_date

### DIFF
--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -40,7 +40,7 @@ from counter_risk.compute.rollups import (
     write_concentration_metrics_csv,
 )
 from counter_risk.config import WorkflowConfig, load_config
-from counter_risk.dates import resolve_as_of_date, resolve_run_date
+from counter_risk.dates import AS_OF_SOURCE_CONFIG, resolve_as_of_date, resolve_run_date
 from counter_risk.formatting import normalize_formatting_profile, resolve_formatting_policy
 from counter_risk.limits_config import load_limits_config
 from counter_risk.normalize import (
@@ -278,6 +278,13 @@ class LimitBreachEvaluation:
 ScreenshotReplacer = Callable[[Path, Path, dict[str, Path]], None]
 
 
+def _date_resolution_fallback_warning(source: str) -> str:
+    return (
+        "date derivation fallback: as_of_date inferred from workbook headers "
+        f"(source={source})"
+    )
+
+
 def run_pipeline_with_config(
     config: WorkflowConfig,
     *,
@@ -432,6 +439,8 @@ def run_pipeline(
         raise RuntimeError("Pipeline failed during run directory setup stage") from exc
 
     warnings: list[str] = []
+    if as_of_date_resolution.source != AS_OF_SOURCE_CONFIG:
+        warnings.append(_date_resolution_fallback_warning(as_of_date_resolution.source))
     resolved_formatting_profile = normalize_formatting_profile(formatting_profile)
     _append_missing_inputs_warnings(missing_inputs=missing_inputs, warnings=warnings)
     runtime_config = config

--- a/tests/pipeline/test_manifest_data_quality.py
+++ b/tests/pipeline/test_manifest_data_quality.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from counter_risk.config import WorkflowConfig
 from counter_risk.pipeline.manifest import ManifestBuilder
+from counter_risk.pipeline.run import _date_resolution_fallback_warning
 
 
 def _make_config(tmp_path: Path) -> WorkflowConfig:
@@ -139,6 +140,62 @@ def test_manifest_build_collects_data_quality_from_validation_context(tmp_path: 
     assert data_quality["counts"]["by_category"]["reconciliation"]["fail"] >= 1
     assert data_quality["counts"]["by_category"]["mapping"]["fail"] >= 1
     assert data_quality["counts"]["by_category"]["limits"]["warn"] >= 1
+
+
+def test_manifest_build_date_resolution_fallback_produces_warn_finding(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    artifact = run_dir / "output.csv"
+    artifact.write_text("ok\n", encoding="utf-8")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(artifact.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[_date_resolution_fallback_warning("cprs_header_mapping")],
+    )
+
+    findings = manifest["data_quality"]["findings"]
+    fallback_finding = next(
+        finding for finding in findings if finding["code"] == "DATE_RESOLUTION_FALLBACK"
+    )
+    assert fallback_finding["category"] == "date"
+    assert fallback_finding["severity"] == "warn"
+
+
+def test_manifest_build_date_resolution_fallback_absent_when_config_provides_date(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "runs" / "2026-02-13"
+    run_dir.mkdir(parents=True)
+    artifact = run_dir / "output.csv"
+    artifact.write_text("ok\n", encoding="utf-8")
+
+    builder = ManifestBuilder(
+        config=_make_config(tmp_path),
+        as_of_date=date(2026, 2, 13),
+        run_date=date(2026, 2, 14),
+    )
+    manifest = builder.build(
+        run_dir=run_dir,
+        input_hashes={"monthly_pptx": "abc123"},
+        output_paths=[Path(artifact.name)],
+        top_exposures={"all_programs": []},
+        top_changes_per_variant={"all_programs": []},
+        warnings=[],
+    )
+
+    finding_codes = {finding["code"] for finding in manifest["data_quality"]["findings"]}
+    assert "DATE_RESOLUTION_FALLBACK" not in finding_codes
 
 
 def test_manifest_build_marks_fail_limit_breaches_red(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:745 -->
> **Source:** Issue #745

Closes #745

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/data_quality.md:28` places fallback date resolution in the `date` DQ category ("missing date header or fallback date resolution"), and `src/counter_risk/pipeline/data_quality.py:25` registers `DATE_RESOLUTION_FALLBACK` as `warn`-severity; `data_quality.py:50` assigns it to the `date` category. The classification logic at `data_quality.py:475–476` is already wired: any pipeline warning containing `"date derivation"` maps to `DATE_RESOLUTION_FALLBACK`. The pipeline, however, never emits such a string.

When `config.as_of_date` is `None`, `resolve_as_of_date()` (`src/counter_risk/dates.py:53–70`) falls back to CPRS workbook headers, returning a `DateResolution` with `source="cprs_header_mapping"` or `source="cprs_header_text"` (constants at `dates.py:29–30`). `run.py:412` captures `as_of_date_resolution`, but when the `warnings` list is initialized at `run.py:434`, `.source` is never inspected and no advisory is emitted. The only occurrence of `"date derivation"` in `src/` is the hard-failure `RuntimeError` at `run.py:419`, raised before `warnings` is created and never reaching `build_data_quality()`.

This is **latent fragility, not a current break**: a run that silently infers `as_of_date` from stale CPRS headers passes DQ green. Operators see a clean summary with no date advisory, with no mechanism to detect the silent fallback short of reading the manifest `date_resolution` block manually.

#### Tasks
- [ ] In `src/counter_risk/pipeline/run.py:43`, extend the import from `counter_risk.dates` to also include `AS_OF_SOURCE_CONFIG` (currently only `resolve_as_of_date` and `resolve_run_date` are imported).
- [ ] In `src/counter_risk/pipeline/run.py`, after `warnings: list[str] = []` at line 434, add: if `as_of_date_resolution.source != AS_OF_SOURCE_CONFIG`, append `f"date derivation fallback: as_of_date inferred from workbook headers (source={as_of_date_resolution.source})"` to `warnings`.
- [ ] Confirm the new warning string contains `"date derivation"` to satisfy the existing check at `src/counter_risk/pipeline/data_quality.py:475` without any modification to `data_quality.py`.
- [ ] In `tests/pipeline/test_manifest_data_quality.py`, add `test_manifest_build_date_resolution_fallback_produces_warn_finding` following the fixture pattern at lines 24–57: pass `warnings=["date derivation fallback: as_of_date inferred from workbook headers (source=cprs_header_mapping)"]` to `ManifestBuilder.build()` and assert `code="DATE_RESOLUTION_FALLBACK"`, `category="date"`, `severity="warn"` in `manifest["data_quality"]["findings"]`.
- [ ] Add `test_manifest_build_date_resolution_fallback_absent_when_config_provides_date` in the same file: pass no `"date derivation"` warning and assert `DATE_RESOLUTION_FALLBACK` is absent from findings.
- [ ] Run `pytest tests/pipeline/test_manifest_data_quality.py -v` and confirm all five tests pass (three existing plus two new).
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL output, then revert before requesting review.

#### Acceptance criteria
- [ ] `pytest tests/pipeline/test_manifest_data_quality.py::test_manifest_build_date_resolution_fallback_produces_warn_finding` passes with findings containing `code="DATE_RESOLUTION_FALLBACK"`, `category="date"`, `severity="warn"`.
- [ ] **Deliberate-break gate:** temporarily change the new warning string in `run.py` so it omits `"date derivation"` (e.g., rename to `"as_of_date fallback:"`). Running `pytest tests/pipeline/test_manifest_data_quality.py::test_manifest_build_date_resolution_fallback_produces_warn_finding` **must FAIL** — the finding is no longer classified as `DATE_RESOLUTION_FALLBACK`. Revert and confirm the test passes again. Capture both outputs in the PR.
- [ ] All three pre-existing tests in `tests/pipeline/test_manifest_data_quality.py` pass without modification (`test_manifest_build_populates_data_quality_from_warnings`, `test_manifest_build_data_quality_defaults_to_info_when_no_warnings`, `test_manifest_build_collects_data_quality_from_validation_context`).
- [ ] `rg "date derivation" src/` from the repo root returns exactly two hits: the new warning-append in `run.py` and the existing `RuntimeError` at `run.py:419`.
- [ ] PR cites `docs/data_quality.md:28` as the design source defining the `date` category and the `DATE_RESOLUTION_FALLBACK` contract.

<!-- auto-status-summary:end -->