### PR TITLE
Format date fallback warning after verifier report

### DIFF
--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -279,10 +279,7 @@ ScreenshotReplacer = Callable[[Path, Path, dict[str, Path]], None]
 
 
 def _date_resolution_fallback_warning(source: str) -> str:
-    return (
-        "date derivation fallback: as_of_date inferred from workbook headers "
-        f"(source={source})"
-    )
+    return f"date derivation fallback: as_of_date inferred from workbook headers (source={source})"
 
 
 def run_pipeline_with_config(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:745 -->
> **Source:** Issue #745

Closes #745

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/data_quality.md:28` places fallback date resolution in the `date` DQ category ("missing date header or fallback date resolution"), and `src/counter_risk/pipeline/data_quality.py:25` registers `DATE_RESOLUTION_FALLBACK` as `warn`-severity; `data_quality.py:50` assigns it to the `date` category. The classification logic at `data_quality.py:475–476` is already wired: any pipeline warning containing `"date derivation"` maps to `DATE_RESOLUTION_FALLBACK`. The pipeline, however, never emits such a string.

When `config.as_of_date` is `None`, `resolve_as_of_date()` (`src/counter_risk/dates.py:53–70`) falls back to CPRS workbook headers, returning a `DateResolution` with `source="cprs_header_mapping"` or `source="cprs_header_text"` (constants at `dates.py:29–30`). `run.py:412` captures `as_of_date_resolution`, but when the `warnings` list is initialized at `run.py:434`, `.source` is never inspected and no advisory is emitted. The only occurrence of `"date derivation"` in `src/` is the hard-failure `RuntimeError` at `run.py:419`, raised before `warnings` is created and never reaching `build_data_quality()`.

This is **latent fragility, not a current break**: a run that silently infers `as_of_date` from stale CPRS headers passes DQ green. Operators see a clean summary with no date advisory, with no mechanism to detect the silent fallback short of reading the manifest `date_resolution` block manually.

#### Tasks
- [ ] In `src/counter_risk/pipeline/run.py:43`, extend the import from `counter_risk.dates` to also include `AS_OF_SOURCE_CONFIG` (currently only `resolve_as_of_date` and `resolve_run_date` are imported).
- [ ] In `src/counter_risk/pipeline/run.py`, after `warnings: list[str] = []` at line 434, add: if `as_of_date_resolution.source != AS_OF_SOURCE_CONFIG`, append `f"date derivation fallback: as_of_date inferred from workbook headers (source={as_of_date_resolution.source})"` to `warnings`.
- [ ] Confirm the new warning string contains `"date derivation"` to satisfy the existing check at `src/counter_risk/pipeline/data_quality.py:475` without any modification to `data_quality.py`.
- [ ] In `tests/pipeline/test_manifest_data_quality.py`, add `test_manifest_build_date_resolution_fallback_produces_warn_finding` following the fixture pattern at lines 24–57: pass `warnings=["date derivation fallback: as_of_date inferred from workbook headers (source=cprs_header_mapping)"]` to `ManifestBuilder.build()` and assert `code="DATE_RESOLUTION_FALLBACK"`, `category="date"`, `severity="warn"` in `manifest["data_quality"]["findings"]`.
- [ ] Add `test_manifest_build_date_resolution_fallback_absent_when_config_provides_date` in the same file: pass no `"date derivation"` warning and assert `DATE_RESOLUTION_FALLBACK` is absent from findings.
- [ ] Run `pytest tests/pipeline/test_manifest_data_quality.py -v` and confirm all five tests pass (three existing plus two new).
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL output, then revert before requesting review.

#### Acceptance criteria
- [ ] `pytest tests/pipeline/test_manifest_data_quality.py::test_manifest_build_date_resolution_fallback_produces_warn_finding` passes with findings containing `code="DATE_RESOLUTION_FALLBACK"`, `category="date"`, `severity="warn"`.
- [ ] **Deliberate-break gate:** temporarily change the new warning string in `run.py` so it omits `"date derivation"` (e.g., rename to `"as_of_date fallback:"`). Running `pytest tests/pipeline/test_manifest_data_quality.py::test_manifest_build_date_resolution_fallback_produces_warn_finding` **must FAIL** — the finding is no longer classified as `DATE_RESOLUTION_FALLBACK`. Revert and confirm the test passes again. Capture both outputs in the PR.
- [ ] All three pre-existing tests in `tests/pipeline/test_manifest_data_quality.py` pass without modification (`test_manifest_build_populates_data_quality_from_warnings`, `test_manifest_build_data_quality_defaults_to_info_when_no_warnings`, `test_manifest_build_collects_data_quality_from_validation_context`).
- [ ] `rg "date derivation" src/` from the repo root returns exactly two hits: the new warning-append in `run.py` and the existing `RuntimeError` at `run.py:419`.
- [ ] PR cites `docs/data_quality.md:28` as the design source defining the `date` category and the `DATE_RESOLUTION_FALLBACK` contract.

<!-- auto-status-summary:end -->