### PR TITLE
Add Orchestrator AGENTS playbook export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,11 @@ If yes:
 ## Agent-Specific Note
 
 This file is the agent-generic contract. Keep it materially aligned with `CLAUDE.md`; differences between the two should only be agent-specific execution notes, not different repository rules.
+
+<!-- ORCHESTRATOR_REPO_KNOWLEDGE_START -->
+<!-- exported by repo_knowledge.py; owner: Orchestrator; freshness owner: keepalive -->
+## Orchestrator Repo Playbook (stranske/Counter_Risk)
+- Summary: Counter_Risk has repo-specific formatting expectations.
+### Known Gotchas
+- Use Black for formatting checks; do not substitute ruff format unless the repo config explicitly changes. (tasks: mechanical, implement, testgen)
+<!-- ORCHESTRATOR_REPO_KNOWLEDGE_END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,15 @@ If yes:
 
 This file is the agent-generic contract. Keep it materially aligned with `CLAUDE.md`; differences between the two should only be agent-specific execution notes, not different repository rules.
 
-<!-- ORCHESTRATOR_REPO_KNOWLEDGE_START -->
+<!-- BEGIN orch-playbook -->
 <!-- exported by repo_knowledge.py; owner: Orchestrator; freshness owner: keepalive -->
+
 ## Orchestrator Repo Playbook (stranske/Counter_Risk)
+
 - Summary: Counter_Risk has repo-specific formatting expectations.
+
 ### Known Gotchas
+
 - Use Black for formatting checks; do not substitute ruff format unless the repo config explicitly changes. (tasks: mechanical, implement, testgen)
-<!-- ORCHESTRATOR_REPO_KNOWLEDGE_END -->
+
+<!-- END orch-playbook -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,19 @@ If yes:
 - `stranske/Workflows/docs/keepalive/Agents.md`
 - `stranske/Travel-Plan-Permission` as a reference consumer
 
+<!-- BEGIN orch-playbook -->
+<!-- exported by repo_knowledge.py; owner: Orchestrator; freshness owner: keepalive -->
+
+## Orchestrator Repo Playbook (stranske/Counter_Risk)
+
+- Summary: Counter_Risk has repo-specific formatting expectations.
+
+### Known Gotchas
+
+- Use Black for formatting checks; do not substitute ruff format unless the repo config explicitly changes. (tasks: mechanical, implement, testgen)
+
+<!-- END orch-playbook -->
+
 ## Claude-Specific Note
 
 Keep this file materially aligned with `AGENTS.md`. Differences between the two should only be agent-specific execution notes, not different repository rules.


### PR DESCRIPTION
Adds the managed Orchestrator repo-playbook section exported from the approved local repo_knowledge registry.

This dogfoods the new Orchestrator AGENTS.md export path. The managed block is intentionally small and only records the Counter_Risk Black-formatting gotcha from the approved registry; existing human AGENTS.md content is preserved.

Validation:
- python3 -B /Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Orchestrator/repo_knowledge.py --validate-agents-md /tmp/counter-agents-export-20260620 --repo stranske/Counter_Risk --json
- python3 -B /Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Orchestrator/repo_knowledge.py --export-agents-md stranske/Counter_Risk --repo-path /tmp/counter-agents-export-20260620 --json
- git diff --check

<!-- workflow-source:local_request -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-specific “Orchestrator Repo Playbook” guidance covering expected development practices.
  * Included a “Known Gotchas” note clarifying that formatting checks should use **Black**, and `ruff format` should only be used if the repo configuration explicitly changes.
  * Expanded agent-related documentation with updated begin/end playbook sections for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->