### PR TITLE
Add operator help for GUI runner fields

### DIFF
--- a/src/counter_risk/gui/runner.py
+++ b/src/counter_risk/gui/runner.py
@@ -40,6 +40,27 @@ _RUN_MODE_TO_CONFIG: dict[str, str] = {
     "trend": "config/trend.yml",
 }
 
+_GUI_FIELD_HELP: dict[str, str] = {
+    "Mode": "Use All for the routine monthly run; Ex-Trend and Trend run only those report groups.",
+    "Discovery Mode": (
+        "Manual uses the normal saved input layout. Discover searches the selected input folder "
+        "for matching files when names vary."
+    ),
+    "Strict Policy": (
+        "Warn lets the run finish while flagging policy issues. Strict stops when a required "
+        "policy check fails."
+    ),
+    "Formatting Profile": (
+        "Use default for standard Counter Risk output. Other profiles apply known historical "
+        "PowerPoint and PNG formatting variants."
+    ),
+}
+
+
+def get_gui_field_help() -> dict[str, str]:
+    """Return operator-facing help text for non-obvious GUI fields."""
+    return dict(_GUI_FIELD_HELP)
+
 
 @dataclass(frozen=True)
 class GuiRunState:
@@ -610,6 +631,7 @@ def launch_gui(
         ("Input Root", input_root_var, "input_root"),
         ("Output Root", output_root_var, "output_root"),
     )
+    field_help = get_gui_field_help()
     for row_index, (label, var, field_kind) in enumerate(labels):
         ttk.Label(root, text=label).grid(row=row_index, column=0, sticky="w", padx=8, pady=4)
         if field_kind == "mode":
@@ -649,6 +671,14 @@ def launch_gui(
                 column=1,
                 sticky="ew",
                 padx=8,
+                pady=4,
+            )
+        if label in field_help:
+            ttk.Label(root, text=field_help[label], wraplength=240).grid(
+                row=row_index,
+                column=2,
+                sticky="w",
+                padx=(0, 8),
                 pady=4,
             )
 

--- a/tests/test_gui_runner.py
+++ b/tests/test_gui_runner.py
@@ -326,6 +326,19 @@ def test_gui_runner_input_guidance(tmp_path: Path) -> None:
     assert "source workbooks or exports" in message
 
 
+def test_gui_runner_field_help() -> None:
+    field_help = gui_runner.get_gui_field_help()
+
+    required_fields = ("Mode", "Discovery Mode", "Strict Policy", "Formatting Profile")
+    for field in required_fields:
+        assert field_help[field].strip()
+
+    assert "routine monthly run" in field_help["Mode"]
+    assert "searches the selected input folder" in field_help["Discovery Mode"]
+    assert "stops when a required policy check fails" in field_help["Strict Policy"]
+    assert "PowerPoint" in field_help["Formatting Profile"]
+
+
 def test_headless_discover_resolution_never_calls_stdin_input(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:772 -->
> **Source:** Issue #772

Closes #772

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] `src/counter_risk/gui/runner.py:596-601` — add concise inline help / tooltips for each non-obvious field (at minimum `Discovery Mode`, `Strict Policy`, `Formatting Profile`, `Mode`), each explaining in plain language what the field does and the recommended default for a routine monthly run.

#### Acceptance criteria
- [ ] Named test: `tests/test_gui_runner_field_help` (new) — asserts that each of `Discovery Mode`, `Strict Policy`, `Formatting Profile` has associated non-empty help/tooltip text registered for the field.
- [ ] Deliberate-break → revert: remove the help text for one of those fields → confirm `test_gui_runner_field_help` FAILS → revert.

<!-- auto-status-summary:end -->