### PR TITLE
Follow up GUI input root first-run hint

### DIFF
--- a/src/counter_risk/gui/runner.py
+++ b/src/counter_risk/gui/runner.py
@@ -196,21 +196,42 @@ def _build_cli_args(
 
 
 def _validate_path_roots(state: GuiRunState) -> tuple[bool, str]:
-    input_root = Path(state.input_root.strip() or "inputs")
+    raw_input_root = state.input_root.strip()
+    input_root = Path(raw_input_root or "inputs")
     output_root = Path(state.output_root.strip() or "runs")
     if not input_root.is_dir():
+        if _is_default_input_root(raw_input_root, input_root):
+            return False, _format_getting_started_input_root_message()
         return False, _format_missing_input_root_message(input_root)
     if not output_root.is_dir():
         return False, f"Output Root not found: {output_root}"
     return True, ""
 
 
+def _is_default_input_root(raw_input_root: str, input_root: Path) -> bool:
+    return raw_input_root in {"", "inputs"} and input_root == Path("inputs")
+
+
+def _input_root_layout_hint() -> str:
+    return (
+        "Expected inputs include this month's Counter Risk source workbooks or exports, "
+        "with exposure, collateral, counterparty, and policy/reference files in the "
+        "normal runner input layout."
+    )
+
+
+def _format_getting_started_input_root_message() -> str:
+    return (
+        "Getting started: use Browse... to select this month's input folder before running. "
+        f"{_input_root_layout_hint()}"
+    )
+
+
 def _format_missing_input_root_message(input_root: Path) -> str:
     return (
         f"Input Root not found: {input_root}\n"
         "Use Browse... to select this month's input folder. "
-        "The folder should contain the Counter Risk source workbooks or exports "
-        "for the selected as-of month, using the normal input layout processed by the runner."
+        f"{_input_root_layout_hint()}"
     )
 
 

--- a/tests/test_gui_runner.py
+++ b/tests/test_gui_runner.py
@@ -323,7 +323,22 @@ def test_gui_runner_input_guidance(tmp_path: Path) -> None:
     assert f"Input Root not found: {missing_inputs}" in message
     assert "Browse..." in message
     assert "select this month's input folder" in message
-    assert "source workbooks or exports" in message
+    assert "exposure, collateral, counterparty, and policy/reference files" in message
+
+
+def test_gui_runner_default_input_root_shows_getting_started_hint(tmp_path: Path) -> None:
+    runs = tmp_path / "runs"
+    runs.mkdir()
+
+    valid, message = gui_runner._validate_path_roots(
+        GuiRunState(as_of_date="2025-12-31", input_root="inputs", output_root=str(runs))
+    )
+
+    assert valid is False
+    assert message.startswith("Getting started:")
+    assert "Input Root not found" not in message
+    assert "Browse..." in message
+    assert "exposure, collateral, counterparty, and policy/reference files" in message
 
 
 def test_gui_runner_field_help() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:771 -->
> **Source:** Issue #771

Closes #771

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] `src/counter_risk/gui/runner.py:178-181` (and the status surface that renders it) — when Input Root is missing/unset, replace/augment the bare `Input Root not found: {path}` with **actionable guidance**: what files Input Root must contain, the expected layout, and that the operator should use `Browse...` to select this month's input folder.
- [ ] Give the operator a non-error starting point: a sensible first-run default OR a one-line "Getting started" hint shown until a valid Input Root is set, so launch does not land on a bare error.

#### Acceptance criteria
- [ ] Named test: `tests/test_gui_runner_input_guidance` (new) — calls the runner's input-validation/status helper (the function at `src/counter_risk/gui/runner.py:178-183`) with a non-existent Input Root and asserts the returned message includes operator guidance (e.g. contains "Browse" or "select the folder" or names the expected inputs), not only `not found: <path>`.
- [ ] Deliberate-break → revert: restore the bare `f"Input Root not found: {input_root}"` with no guidance → confirm `test_gui_runner_input_guidance` FAILS → revert.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Getting started" guidance messages for users configuring input folders on initial setup
  * Enhanced input validation error messages to clearly specify required file types (exposure, collateral, counterparty, and policy/reference files)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->