### PR TITLE
docs: seed UX Review log (docs/ux-review/REVIEW_LOG.md)

### DIFF
--- a/docs/ux-review/REVIEW_LOG.md
+++ b/docs/ux-review/REVIEW_LOG.md
@@ -1,0 +1,12 @@
+# UX Review Log — Counter_Risk
+
+Diff-anchored record of UX Review (`/ux-review`) passes. Each entry's commit SHA is the anchor the
+next review diffs against to focus on new + likely-affected functionality. Detailed artifacts live in
+`Orchestrator/ux_reviews/`.
+
+## 2026-06-22 — GUI runner (`counter-risk gui`) — commit `1648d13` — overall 7.0/10 (gate PASS)
+- **Coverage:** main window form rendered ✓; inline field help on Mode / Discovery Mode / Strict Policy / Formatting Profile ✓ (observed); first-launch clean state (no bare error) ✓. **NOT UI-driven** (Tk accessibility layer too sparse to click controls): Run → missing-root guidance (**function-verified**, not screencaptured); Browse… dialog; Dry-Run Discovery; post-run output display.
+- **Scores:** wired 8.0 / usability 7.0 / help_clarity 6.0 / workflow 7.0.
+- **Findings:** As-of Date / Input Root / Output Root lack inline help (usability+help, 4/4); missing-root guidance only surfaces on a Run attempt, not at launch (4/4); no persistent run-status indicator (3/4). → **filed #777**.
+- **Prior:** 2.5/10 — no help mechanism at all + error-on-launch dead-end (#771 input-root guidance via PRs #773/#776, #772 field help via PR #775 — now fixed).
+- **Next focus:** add a subprocess/AppleScript smoke harness that drives Run / Dry-Run / Browse and asserts the in-GUI guidance string (closes the Tk-automation coverage gap); re-check after #777.

--- a/docs/ux-review/REVIEW_LOG.md
+++ b/docs/ux-review/REVIEW_LOG.md
@@ -5,6 +5,7 @@ next review diffs against to focus on new + likely-affected functionality. Detai
 `Orchestrator/ux_reviews/`.
 
 ## 2026-06-22 — GUI runner (`counter-risk gui`) — commit `1648d13` — overall 7.0/10 (gate PASS)
+
 - **Coverage:** main window form rendered ✓; inline field help on Mode / Discovery Mode / Strict Policy / Formatting Profile ✓ (observed); first-launch clean state (no bare error) ✓. **NOT UI-driven** (Tk accessibility layer too sparse to click controls): Run → missing-root guidance (**function-verified**, not screencaptured); Browse… dialog; Dry-Run Discovery; post-run output display.
 - **Scores:** wired 8.0 / usability 7.0 / help_clarity 6.0 / workflow 7.0.
 - **Findings:** As-of Date / Input Root / Output Root lack inline help (usability+help, 4/4); missing-root guidance only surfaces on a Run attempt, not at launch (4/4); no persistent run-status indicator (3/4). → **filed #777**.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:777 -->
> **Source:** Issue #777

Closes #777

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#775](https://github.com/stranske/Counter_Risk/issues/775)
- [#772](https://github.com/stranske/Counter_Risk/issues/772)
- [#773](https://github.com/stranske/Counter_Risk/issues/773)
- [#776](https://github.com/stranske/Counter_Risk/issues/776)
- [#771](https://github.com/stranske/Counter_Risk/issues/771)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] `src/counter_risk/gui/runner.py:44-57` — add `field_help` entries for "As-of Date", "Input Root", "Output Root" so the existing render path (`runner.py:697-698`) shows help uniformly. Suggested copy:
  - [ ] As-of Date: "Reporting as-of date (YYYY-MM-DD); defaults to today. Change for restatements or off-cycle runs."
  - [ ] Input Root: "Folder containing this month's Counter Risk source workbooks/exports; use Browse… to select it."
  - [ ] Output Root: "Folder where run reports and logs are written; created automatically if absent."
- [ ] On launch / on Input Root change, when the path does not exist, show the existing "Getting started" hint (`runner.py:225`) as a **passive one-line note below the field** — preserving the clean no-error launch (no blocking dialog).
- [ ] Add a persistent **run-status label** (e.g. Ready / Running… / Completed OK / Failed — see output) so the operator always knows the lifecycle state.
- [ ] (optional, cosmetic) Add help for the "Dry-Run Discovery" button clarifying when to use it vs Run for routine monthly processing.

#### Acceptance criteria
- [ ] Named test: extend `tests/test_gui_runner.py::test_gui_runner_field_help` — assert `get_gui_field_help()` returns non-empty help for "As-of Date", "Input Root", and "Output Root" (in addition to the existing four fields).
- [ ] Deliberate-break → revert: remove one of the three new help entries → confirm the test FAILS → revert.

**Head SHA:** 366c9d3c34413ac76321a5b012f1b7dc56331037
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/27973140352) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/27972816801) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/27972817658) |
| Gate | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/27972817583) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Counter_Risk/actions/runs/27972817139) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a UX review log entry for the GUI runner, documenting a review pass, current coverage gaps (notably missing UI-driven interactions and guidance help), and a noted need for improved run-status visibility.  
  * Recorded next planned steps to strengthen automated smoke testing for Tk/GUI-driven guidance strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->