### PR TITLE
Add GUI runner help and status cues

### DIFF
--- a/src/counter_risk/gui/runner.py
+++ b/src/counter_risk/gui/runner.py
@@ -41,6 +41,10 @@ _RUN_MODE_TO_CONFIG: dict[str, str] = {
 }
 
 _GUI_FIELD_HELP: dict[str, str] = {
+    "As-Of Date (YYYY-MM-DD)": (
+        "Reporting as-of date (YYYY-MM-DD); defaults to today. Change for restatements "
+        "or off-cycle runs."
+    ),
     "Mode": "Use All for the routine monthly run; Ex-Trend and Trend run only those report groups.",
     "Discovery Mode": (
         "Manual uses the normal saved input layout. Discover searches the selected input folder "
@@ -54,6 +58,11 @@ _GUI_FIELD_HELP: dict[str, str] = {
         "Use default for standard Counter Risk output. Other profiles apply known historical "
         "PowerPoint and PNG formatting variants."
     ),
+    "Input Root": (
+        "Folder containing this month's Counter Risk source workbooks/exports; use Browse... "
+        "to select it."
+    ),
+    "Output Root": "Existing folder where run reports and logs are written.",
 }
 
 
@@ -446,11 +455,12 @@ def launch_gui(
     format_var = tk.StringVar(value=state.formatting_profile)
     input_root_var = tk.StringVar(value=state.input_root)
     output_root_var = tk.StringVar(value=state.output_root)
-    status_var = tk.StringVar(value="Idle")
+    status_var = tk.StringVar(value="Ready")
     result_var = tk.StringVar(value="")
     quality_var = tk.StringVar(value="")
     limit_banner_var = tk.StringVar(value="None")
     path_feedback_var = tk.StringVar(value="")
+    input_root_hint_var = tk.StringVar(value="")
     last_output_dir: Path | None = None
     run_in_progress = False
     discovery_prompt_bridge = _DiscoveryPromptBridge(root, tk)
@@ -474,14 +484,24 @@ def launch_gui(
         run_button.configure(state=run_state)
         dry_run_button.configure(state=run_state)
         if active:
-            status_var.set("Running… this can take a few minutes")
+            status_var.set("Running... this can take a few minutes")
         _refresh_path_feedback()
 
     def _refresh_path_feedback() -> None:
         current = _state_from_form()
         valid, message = _validate_path_roots(current)
+        raw_input_root = current.input_root.strip()
+        input_root = Path(raw_input_root or "inputs")
+        show_launch_hint = (
+            not input_root.is_dir()
+            and _is_default_input_root(raw_input_root, input_root)
+            and not run_in_progress
+        )
+        input_root_hint_var.set(
+            _format_getting_started_input_root_message() if show_launch_hint else ""
+        )
         if run_in_progress:
-            path_feedback_var.set("Run in progress…")
+            path_feedback_var.set("Run in progress...")
             return
         if valid:
             path_feedback_var.set("Paths look good.")
@@ -499,7 +519,7 @@ def launch_gui(
     def _apply_run_result(result: GuiRunResult) -> None:
         nonlocal last_output_dir
         if result.exit_code == 0:
-            status_var.set("Complete")
+            status_var.set("Completed OK")
             result_var.set("Success")
             quality_var.set(result.data_quality_status or "UNAVAILABLE - Summary not found")
             if result.output_dir is not None:
@@ -507,7 +527,7 @@ def launch_gui(
                 limit_banner_var.set(_load_limit_breach_banner(result.output_dir) or "None")
             return
 
-        status_var.set("Error")
+        status_var.set("Failed - see message")
         result_var.set(result.error_message or f"Exit code {result.exit_code}")
         quality_var.set("")
         limit_banner_var.set("None")
@@ -686,6 +706,14 @@ def launch_gui(
                 text="Browse…",
                 command=_browse_command(var),
             ).grid(row=0, column=1, padx=(8, 0))
+            if field_kind == "input_root":
+                ttk.Label(path_row, textvariable=input_root_hint_var, wraplength=320).grid(
+                    row=1,
+                    column=0,
+                    columnspan=2,
+                    sticky="w",
+                    pady=(4, 0),
+                )
         else:
             ttk.Entry(root, textvariable=var, width=42).grid(
                 row=row_index,
@@ -731,7 +759,7 @@ def launch_gui(
         row=11, column=1, padx=8, pady=4, sticky="ew"
     )
 
-    ttk.Label(root, text="Status").grid(row=12, column=0, sticky="w", padx=8, pady=4)
+    ttk.Label(root, text="Run Status").grid(row=12, column=0, sticky="w", padx=8, pady=4)
     ttk.Label(root, textvariable=status_var).grid(row=12, column=1, sticky="w", padx=8, pady=4)
     ttk.Label(root, text="Result").grid(row=13, column=0, sticky="w", padx=8, pady=4)
     ttk.Label(root, textvariable=result_var).grid(row=13, column=1, sticky="w", padx=8, pady=4)

--- a/tests/test_gui_runner.py
+++ b/tests/test_gui_runner.py
@@ -344,7 +344,15 @@ def test_gui_runner_default_input_root_shows_getting_started_hint(tmp_path: Path
 def test_gui_runner_field_help() -> None:
     field_help = gui_runner.get_gui_field_help()
 
-    required_fields = ("Mode", "Discovery Mode", "Strict Policy", "Formatting Profile")
+    required_fields = (
+        "As-Of Date (YYYY-MM-DD)",
+        "Mode",
+        "Discovery Mode",
+        "Strict Policy",
+        "Formatting Profile",
+        "Input Root",
+        "Output Root",
+    )
     for field in required_fields:
         assert field_help[field].strip()
 
@@ -352,6 +360,9 @@ def test_gui_runner_field_help() -> None:
     assert "searches the selected input folder" in field_help["Discovery Mode"]
     assert "stops when a required policy check fails" in field_help["Strict Policy"]
     assert "PowerPoint" in field_help["Formatting Profile"]
+    assert "Reporting as-of date" in field_help["As-Of Date (YYYY-MM-DD)"]
+    assert "Browse..." in field_help["Input Root"]
+    assert "run reports and logs" in field_help["Output Root"]
 
 
 def test_headless_discover_resolution_never_calls_stdin_input(
@@ -512,6 +523,12 @@ def test_launch_gui_starts_tk_mainloop_with_headless_stubs(
         if isinstance(widget, _FakeWidget) and widget.kwargs.get("text") == "Open PPT Folder"
     ]
     assert len(ppt_buttons) == 1
+    status_labels = [
+        widget
+        for widget in widgets
+        if isinstance(widget, _FakeWidget) and widget.kwargs.get("text") == "Run Status"
+    ]
+    assert len(status_labels) == 1
 
     ppt_buttons[0].kwargs["command"]()
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:777 -->
> **Source:** Issue #777

Closes #777

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#775](https://github.com/stranske/Counter_Risk/issues/775)
- [#772](https://github.com/stranske/Counter_Risk/issues/772)
- [#773](https://github.com/stranske/Counter_Risk/issues/773)
- [#776](https://github.com/stranske/Counter_Risk/issues/776)
- [#771](https://github.com/stranske/Counter_Risk/issues/771)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] `src/counter_risk/gui/runner.py:44-57` — add `field_help` entries for "As-of Date", "Input Root", "Output Root" so the existing render path (`runner.py:697-698`) shows help uniformly. Suggested copy:
  - [ ] As-of Date: "Reporting as-of date (YYYY-MM-DD); defaults to today. Change for restatements or off-cycle runs."
  - [ ] Input Root: "Folder containing this month's Counter Risk source workbooks/exports; use Browse… to select it."
  - [ ] Output Root: "Folder where run reports and logs are written; created automatically if absent."
- [ ] On launch / on Input Root change, when the path does not exist, show the existing "Getting started" hint (`runner.py:225`) as a **passive one-line note below the field** — preserving the clean no-error launch (no blocking dialog).
- [ ] Add a persistent **run-status label** (e.g. Ready / Running… / Completed OK / Failed — see output) so the operator always knows the lifecycle state.
- [ ] (optional, cosmetic) Add help for the "Dry-Run Discovery" button clarifying when to use it vs Run for routine monthly processing.

#### Acceptance criteria
- [ ] Named test: extend `tests/test_gui_runner.py::test_gui_runner_field_help` — assert `get_gui_field_help()` returns non-empty help for "As-of Date", "Input Root", and "Output Root" (in addition to the existing four fields).
- [ ] Deliberate-break → revert: remove one of the three new help entries → confirm the test FAILS → revert.

<!-- auto-status-summary:end -->