### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -842,12 +842,9 @@ def evaluate_pr_multiple(
 ) -> list[EvaluationResult]:
     change_type = _classify_change_type(_bounded_diff_for_classification(diff))
     runner = ComparisonRunner.from_environment(context, diff, model1, model2)
-    families = {_provider_family(provider) for _, provider, _ in runner.clients}
-    if len(runner.clients) < 2 or len(families) < 2:
-        result = _fallback_evaluation(
-            "unverified: compare mode requires two cross-family verifier judges; "
-            f"available families: {', '.join(sorted(families)) or 'none'}."
-        )
+    is_valid, error_message = _validate_comparison_clients(runner.clients)
+    if not is_valid:
+        result = _fallback_evaluation(error_message)
         result.change_type = change_type
         return [result]
     results: list[EvaluationResult] = []
@@ -867,6 +864,47 @@ def _provider_family(provider: str) -> str:
     if "anthropic" in label or "claude" in label:
         return "anthropic"
     return label.split("/", 1)[0].strip() or "unknown"
+
+
+def _get_provider_families(clients: list[tuple[object, str, str]]) -> set[str]:
+    """Extract the set of unique provider families from a list of clients.
+
+    Args:
+        clients: List of (client, provider, model) tuples.
+
+    Returns:
+        Set of provider family names (e.g., {"openai", "anthropic"}).
+    """
+    return {_provider_family(provider) for _, provider, _ in clients}
+
+
+def _validate_comparison_clients(clients: list[tuple[object, str, str]]) -> tuple[bool, str]:
+    """Validate that client list is sufficient for cross-family comparison.
+
+    Args:
+        clients: List of (client, provider, model) tuples.
+
+    Returns:
+        Tuple of (is_valid, error_message).
+        is_valid is True if there are >= 2 clients from >= 2 different provider families.
+        error_message describes the reason if validation fails.
+    """
+    families = _get_provider_families(clients)
+    if len(clients) < 2:
+        family_str = ", ".join(sorted(families)) or "none"
+        return (
+            False,
+            f"unverified: compare mode requires two cross-family verifier judges; "
+            f"available families: {family_str}.",
+        )
+    if len(families) < 2:
+        family_str = ", ".join(sorted(families)) or "none"
+        return (
+            False,
+            f"unverified: compare mode requires two cross-family verifier judges; "
+            f"available families: {family_str}.",
+        )
+    return True, ""
 
 
 def _normalize_text(text: str) -> str:

--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -261,6 +261,20 @@ def validate_envelope(
     return report
 
 
+def _find_participant(registry: dict[str, Any], repo: str) -> dict[str, Any] | None:
+    """Look up a participant by repo in the registry. Returns None if not found."""
+    return _find_entry(registry, repo)
+
+
+def _is_missing_envelope_a_failure(entry: dict[str, Any] | None) -> bool:
+    """Decide whether a missing envelope should fail (True) or skip (False).
+
+    An emitting or conformant participant MUST have an envelope; all others
+    (absent, candidate, none, planned) are opt-in skip.
+    """
+    return entry is not None and entry.get("status") in EMITTING_STATUSES
+
+
 def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path) -> Report:
     """Decide what a MISSING run envelope means for ``repo``.
 
@@ -274,10 +288,10 @@ def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path)
     is never failed just for lacking an envelope) without silencing a real
     regression in an active participant.
     """
-    entry = _find_entry(registry, repo)
+    entry = _find_participant(registry, repo)
     report = Report(repo=repo, role=entry.get("role", "") if entry else "")
-    is_active_participant = entry is not None and entry.get("status") in EMITTING_STATUSES
-    if is_active_participant:
+
+    if _is_missing_envelope_a_failure(entry):
         assert entry is not None
         report.fail(
             f"{repo} is an active backplane participant "
@@ -406,9 +420,11 @@ def _self_smoke(schema_dir: Path, registry_path: Path) -> int:
                     True,
                 )
             )
+        # Unsafe raw payload fixtures must fail without echoing sensitive values.
         for inv in (
             "missing_cost.json",
             "unsafe_rows_inline.json",
+            "unsafe_prompt_inline.json",
             "artifact_not_in_manifest.json",
             "bad_identity_ref.json",
         ):


### PR DESCRIPTION
## Sync Summary

### Files Updated
- pr_verifier.py: PR verifier - validates PR changes against acceptance criteria
- validate_run_contract.py: Validates a repo's emitted run-contract/v1 run envelope (producer/bridge) or ingested satellite object (consumer) against the canonical Workflows schemas + opt-in participant registry. Offline/deterministic; opt-in skip for non-participants. Synced so participants can validate locally and the reusable conformance gate can invoke it.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `c5cf4d71afd8ed4946c83214213c53d1d05ed6ee`
**Template hash:** `17c429d63604`
**Sync branch:** `sync/workflows-17c429d63604`
**Consumer repo:** `stranske/Counter_Risk`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Counter_Risk","source_repository":"stranske/Workflows","source_sha":"c5cf4d71afd8ed4946c83214213c53d1d05ed6ee","template_hash":"17c429d63604","sync_branch":"sync/workflows-17c429d63604","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28313796555","run_attempt":"1","changes_count":2} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compare-mode validation so invalid verifier setups are detected earlier and reported more consistently.
  * Refined missing-run-envelope handling to better distinguish real failures from expected non-emitting cases.
  * Expanded offline validation coverage for unsafe prompt payloads, helping catch more invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->