### PR TITLE
Add double-click GUI launcher

### DIFF
--- a/docs/gui_runner.md
+++ b/docs/gui_runner.md
@@ -21,6 +21,10 @@ fall back to `Runner.xlsm`.
 
 ## Launch
 
+Packaged Windows releases include `run_counter_risk_gui.cmd` at the release/root folder.
+Double-click it to open the GUI; if startup fails, the command window stays open so
+the visible error can be copied into a support request.
+
 ```bash
 counter-risk gui
 ```

--- a/run_counter_risk_gui.cmd
+++ b/run_counter_risk_gui.cmd
@@ -1,0 +1,75 @@
+@echo off
+setlocal
+
+rem Launch the Counter Risk Tkinter GUI from a double-clickable Windows shell.
+rem Keep this file at the repository/release root so %~dp0 resolves to the app folder.
+title Counter Risk GUI Launcher
+cd /d "%~dp0"
+
+set "COUNTER_RISK_EXIT=1"
+
+echo Starting Counter Risk GUI...
+echo.
+
+if exist "%~dp0dist\counter-risk\counter-risk.exe" (
+    "%~dp0dist\counter-risk\counter-risk.exe" gui
+    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    goto :after_run
+)
+
+if exist "%~dp0counter-risk.exe" (
+    "%~dp0counter-risk.exe" gui
+    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    goto :after_run
+)
+
+if exist "%~dp0.venv\Scripts\counter-risk.exe" (
+    "%~dp0.venv\Scripts\counter-risk.exe" gui
+    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    goto :after_run
+)
+
+where counter-risk >nul 2>nul
+if not errorlevel 1 (
+    counter-risk gui
+    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    goto :after_run
+)
+
+set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
+where py >nul 2>nul
+if not errorlevel 1 (
+    py -m counter_risk.cli gui
+    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    goto :after_run
+)
+
+where python >nul 2>nul
+if not errorlevel 1 (
+    python -m counter_risk.cli gui
+    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    goto :after_run
+)
+
+echo Could not find Counter Risk or Python.
+echo.
+echo Try one of these fixes:
+echo   1. Run this file from the Counter Risk release folder, or
+echo   2. Install the project so the counter-risk command is available, or
+echo   3. Ask support for a packaged Counter Risk release folder.
+set "COUNTER_RISK_EXIT=9009"
+goto :failure
+
+:after_run
+if "%COUNTER_RISK_EXIT%"=="0" goto :success
+
+:failure
+echo.
+echo Counter Risk GUI did not start or exited with error code %COUNTER_RISK_EXIT%.
+echo Leave this window open and copy the messages above when asking for help.
+echo.
+pause
+exit /b %COUNTER_RISK_EXIT%
+
+:success
+exit /b 0

--- a/tests/test_windows_gui_launcher.py
+++ b/tests/test_windows_gui_launcher.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_double_click_gui_launcher_exists_and_keeps_errors_visible() -> None:
+    launcher = Path(__file__).resolve().parent.parent / "run_counter_risk_gui.cmd"
+
+    text = launcher.read_text(encoding="utf-8")
+
+    assert "counter-risk.exe\" gui" in text
+    assert "counter-risk gui" in text
+    assert "py -m counter_risk.cli gui" in text
+    assert "python -m counter_risk.cli gui" in text
+    assert "PYTHONPATH=%~dp0src;%PYTHONPATH%" in text
+    assert "pause" in text.lower()
+    assert "copy the messages above" in text


### PR DESCRIPTION
### Motivation
- Operators double-clicking the Windows GUI would sometimes see the launcher window open and then immediately close, leaving no visible error to copy for support. 
- Provide a resilient, double-clickable entry that tries packaged, venv, installed, and source-tree entry points so the GUI can be started from typical release or developer setups. 
- Keep the console open on startup failures so visible errors can be copied into a support request. 

### Description
- Add a root-level Windows launcher `run_counter_risk_gui.cmd` that attempts, in order, `dist/counter-risk/counter-risk.exe`, `counter-risk.exe` at repo root, `.venv\Scripts\counter-risk.exe`, an installed `counter-risk` command, `py -m counter_risk.cli gui`, and `python -m counter_risk.cli gui`, and sets `PYTHONPATH` for the source-tree fallback. 
- Make the launcher pause and print an actionable message when startup fails so the operator can copy the error text instead of the window closing immediately. 
- Update `docs/gui_runner.md` to document that packaged Windows releases include the `run_counter_risk_gui.cmd` launcher and that double-click failures will leave visible output. 
- Add `tests/test_windows_gui_launcher.py` to assert the launcher text contains the expected invocation paths, `PYTHONPATH` behavior, and the `pause` / copy guidance. 

### Testing
- Ran `python -m pytest tests/test_windows_gui_launcher.py` and the new launcher regression test passed. 
- Ran `.venv/bin/python -m pytest tests/test_windows_gui_launcher.py tests/test_cli.py` and the combined tests passed in the repository virtualenv. 
- Ran a broader selection of GUI-related unit tests in the repo virtualenv (`.venv/bin/python -m pytest tests/test_cli.py tests/test_counter_risk_cli.py::test_gui_parser_accepts_headless_options tests/test_counter_risk_cli.py::test_main_gui_headless_reports_runner_exceptions tests/test_gui_runner.py::test_execute_gui_run_builds_run_args_and_writes_settings`) and they passed; running the same selection with the system Python failed due to missing `pydantic` in the system environment rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42d8fee3ec83319ba89d9370d911be)