### PR TITLE
Include GUI launcher in release bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
             "${BUNDLE}/manifest.json" \
             "${BUNDLE}/counter_risk_runner.xlsm" \
             "${BUNDLE}/run_counter_risk.cmd" \
+            "${BUNDLE}/run_counter_risk_gui.cmd" \
             "${BUNDLE}/request_counter_risk_remote.cmd" \
             "${BUNDLE}/process_counter_risk_remote.cmd" \
             "${BUNDLE}/remote_trigger_testing.md" \

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -30,6 +30,7 @@ This creates `release/<version>/...` including:
 - The bundled executable
 - `counter_risk_runner.xlsm` built from `assets/templates/counter_risk_template.xlsm`
   with version metadata injected
+- `run_counter_risk_gui.cmd` for double-click GUI launch
 - Remote trigger scripts and documentation
 - Config, templates, fixtures, and metadata files
 
@@ -43,6 +44,7 @@ test -f "${BUNDLE_DIR}/manifest.json"
 test -d "${BUNDLE_DIR}/templates"
 test -f "${BUNDLE_DIR}/config/fixture_replay.yml"
 test -f "${BUNDLE_DIR}/run_counter_risk.cmd"
+test -f "${BUNDLE_DIR}/run_counter_risk_gui.cmd"
 test -f "${BUNDLE_DIR}/counter_risk_runner.xlsm"
 test -f "${BUNDLE_DIR}/request_counter_risk_remote.cmd"
 test -f "${BUNDLE_DIR}/process_counter_risk_remote.cmd"
@@ -118,6 +120,7 @@ scripts/verify_release_workflow_dispatch.sh release.yml <branch-or-tag>
 
 - `bin/counter-risk` (or `bin/counter-risk.exe` on Windows)
 - `counter_risk_runner.xlsm` — operator Excel entrypoint (versioned)
+- `run_counter_risk_gui.cmd` — double-click macro-free GUI launcher
 - `run_counter_risk.cmd` — fallback CLI launcher
 - `request_counter_risk_remote.cmd` — remote request submission script
 - `process_counter_risk_remote.cmd` — remote request worker script

--- a/src/counter_risk/build/release.py
+++ b/src/counter_risk/build/release.py
@@ -142,6 +142,16 @@ def _copy_remote_scripts(root: Path, bundle_dir: Path) -> list[Path]:
     return copied
 
 
+def _copy_gui_launcher(root: Path, bundle_dir: Path) -> list[Path]:
+    src = root / "run_counter_risk_gui.cmd"
+    if not src.is_file():
+        LOGGER.warning("GUI launcher not found at '%s'; skipping.", src)
+        return []
+    dst = bundle_dir / "run_counter_risk_gui.cmd"
+    shutil.copy2(src, dst)
+    return [dst]
+
+
 def _create_runner_file(bundle_dir: Path) -> Path:
     runner_path = bundle_dir / "run_counter_risk.cmd"
     runner_path.write_text(
@@ -290,6 +300,9 @@ def _write_readme(bundle_dir: Path, version: str) -> Path:
                 "3. Open counter_risk_runner.xlsm and enable macros.",
                 "4. Select the as-of date and mode, then click Run.",
                 "",
+                "## GUI launcher",
+                "Double-click run_counter_risk_gui.cmd to open the macro-free GUI.",
+                "",
                 "## Fallback launcher",
                 "Double-click run_counter_risk.cmd to run via the command line.",
                 "",
@@ -366,6 +379,7 @@ def assemble_release(version: str, output_dir: Path, *, force: bool = False) -> 
 
     runner_file = _create_runner_file(bundle_dir)
     copied["runner"] = [runner_file]
+    copied["gui_launcher"] = _copy_gui_launcher(root, bundle_dir)
 
     copied["remote_scripts"] = _copy_remote_scripts(root, bundle_dir)
     copied["remote_trigger_doc"] = _copy_remote_trigger_doc(root, bundle_dir)

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -56,6 +56,9 @@ def _write_fake_repo(root: Path) -> None:
     (root / "docs" / "remote_trigger_testing.md").write_text(
         "# Remote Trigger Testing\n", encoding="utf-8"
     )
+    (root / "run_counter_risk_gui.cmd").write_text(
+        "@echo off\necho gui\n", encoding="utf-8"
+    )
 
 
 def _create_fake_built_executable(root: Path, executable_name: str) -> Path:
@@ -116,6 +119,7 @@ def test_assemble_release_creates_versioned_bundle_with_executable(
     assert list((bundle_dir / "templates").glob("*.xlsm"))
     assert list((bundle_dir / "fixtures").glob("*.xlsx"))
     assert (bundle_dir / "bin" / "counter-risk").is_file()
+    assert (bundle_dir / "run_counter_risk_gui.cmd").is_file()
     runner_text = (bundle_dir / "run_counter_risk.cmd").read_text(encoding="utf-8")
     assert _FORBIDDEN_RUNNER_ENTRYPOINT_PATTERN.search(runner_text) is None
     assert "%~dp0" in runner_text
@@ -127,6 +131,7 @@ def test_assemble_release_creates_versioned_bundle_with_executable(
     assert manifest["version"] == expected_version
     assert manifest["release_name"] == expected_version
     assert manifest["artifacts"]["executable"] == ["bin/counter-risk"]
+    assert manifest["artifacts"]["gui_launcher"] == ["run_counter_risk_gui.cmd"]
 
 
 def test_create_runner_file_directly_invokes_packaged_executable_only(tmp_path: Path) -> None:
@@ -485,9 +490,11 @@ def test_assemble_release_includes_runner_xlsm_and_remote_scripts(
     assert (bundle_dir / "request_counter_risk_remote.cmd").is_file()
     assert (bundle_dir / "process_counter_risk_remote.cmd").is_file()
     assert (bundle_dir / "remote_trigger_testing.md").is_file()
+    assert (bundle_dir / "run_counter_risk_gui.cmd").is_file()
 
     manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["artifacts"]["runner_xlsm"] == ["counter_risk_runner.xlsm"]
+    assert manifest["artifacts"]["gui_launcher"] == ["run_counter_risk_gui.cmd"]
     assert "request_counter_risk_remote.cmd" in manifest["artifacts"]["remote_scripts"][0]
     assert "process_counter_risk_remote.cmd" in manifest["artifacts"]["remote_scripts"][1]
 


### PR DESCRIPTION
### Motivation
- A previous change added `run_counter_risk_gui.cmd` to the repo but the release assembler did not package it into `release/<version>/`, so downloaded release bundles omitted the GUI launcher and it was not recorded in the manifest.
- The release docs and CI verification also needed to reflect the GUI launcher as an expected bundle artifact.

### Description
- Add `_copy_gui_launcher(root, bundle_dir)` to `src/counter_risk/build/release.py` and include its output under `gui_launcher` in the assembled bundle manifest.
- Update the generated operator README text in `_write_readme` to mention `run_counter_risk_gui.cmd` as the double-click GUI launcher.
- Extend `tests/test_release_bundle.py` to create a fake `run_counter_risk_gui.cmd`, assert it is copied into the bundle, and assert `manifest.json` lists `gui_launcher`.
- Update `.github/workflows/release.yml` and `docs/RELEASE_CHECKLIST.md` to verify and document `run_counter_risk_gui.cmd` as part of the expected bundle contents.

### Testing
- Ran `.venv/bin/python -m pytest tests/test_release_bundle.py tests/test_windows_gui_launcher.py` and the suite passed under the repo virtualenv (all tests green).
- Running `pytest tests/test_release_bundle.py tests/test_windows_gui_launcher.py` under the system Python failed due to a missing runtime dependency (`pydantic`) in that interpreter, not due to the change.
- Ran `git diff --check` to validate whitespace and diff hygiene, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42df8e64dc833181b487cf324b5a13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows release bundles can now include a GUI launcher script for easier double-click startup.
  * The bundled getting-started guide now explains how to launch the app through the GUI launcher.

* **Bug Fixes**
  * Release validation now checks that the GUI launcher is present in packaged builds, helping catch incomplete bundles before release.

* **Documentation**
  * Updated the release checklist and bundled instructions to reflect the new launcher file and expected bundle contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->