### PR TITLE
Fix Windows GUI launcher diagnostics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,10 @@
 
 pr_body.md merge=ours
 
+# Windows command scripts need CRLF for cmd.exe label/call parsing.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
 # CI autofix history is append-only and branch-specific
 ci/autofix/history.json merge=ours linguist-generated
 

--- a/run_counter_risk_gui.cmd
+++ b/run_counter_risk_gui.cmd
@@ -26,12 +26,7 @@ if exist "%~dp0counter-risk.exe" (
     goto :after_run
 )
 
-if exist "%~dp0.venv\Scripts\counter-risk.exe" (
-    call :run_and_log "%~dp0.venv\Scripts\counter-risk.exe" gui
-    goto :after_run
-)
-
-rem Prefer the source tree next to this launcher before any stale global install.
+rem Prefer the source tree next to this launcher before any stale venv or global install.
 if exist "%~dp0src\counter_risk\cli\__init__.py" (
     set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
     if exist "%~dp0.venv\Scripts\python.exe" (
@@ -55,6 +50,11 @@ if exist "%~dp0src\counter_risk\cli\__init__.py" (
     )
 )
 
+if exist "%~dp0.venv\Scripts\counter-risk.exe" (
+    call :run_and_log "%~dp0.venv\Scripts\counter-risk.exe" gui
+    goto :after_run
+)
+
 where counter-risk >nul 2>nul
 if not errorlevel 1 (
     call :run_and_log counter-risk gui
@@ -75,7 +75,7 @@ goto :failure
 echo Command: %*
 >>"%COUNTER_RISK_LAUNCHER_LOG%" echo.
 >>"%COUNTER_RISK_LAUNCHER_LOG%" echo Command: %*
-%* 1>>"%COUNTER_RISK_LAUNCHER_LOG%" 2>>&1
+%* 1>>"%COUNTER_RISK_LAUNCHER_LOG%" 2>&1
 set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
 >>"%COUNTER_RISK_LAUNCHER_LOG%" echo Exit code: %COUNTER_RISK_EXIT%
 exit /b 0

--- a/run_counter_risk_gui.cmd
+++ b/run_counter_risk_gui.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal EnableExtensions
 
 rem Launch the Counter Risk Tkinter GUI from a double-clickable Windows shell.
 rem Keep this file at the repository/release root so %~dp0 resolves to the app folder.
@@ -7,47 +7,57 @@ title Counter Risk GUI Launcher
 cd /d "%~dp0"
 
 set "COUNTER_RISK_EXIT=1"
+set "COUNTER_RISK_LAUNCHER_LOG=%TEMP%\counter-risk-gui-launcher.log"
+
+>"%COUNTER_RISK_LAUNCHER_LOG%" echo Counter Risk GUI launcher started at %DATE% %TIME%
+>>"%COUNTER_RISK_LAUNCHER_LOG%" echo Launcher folder: %CD%
 
 echo Starting Counter Risk GUI...
+echo Launcher log: %COUNTER_RISK_LAUNCHER_LOG%
 echo.
 
 if exist "%~dp0dist\counter-risk\counter-risk.exe" (
-    "%~dp0dist\counter-risk\counter-risk.exe" gui
-    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    call :run_and_log "%~dp0dist\counter-risk\counter-risk.exe" gui
     goto :after_run
 )
 
 if exist "%~dp0counter-risk.exe" (
-    "%~dp0counter-risk.exe" gui
-    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    call :run_and_log "%~dp0counter-risk.exe" gui
     goto :after_run
 )
 
 if exist "%~dp0.venv\Scripts\counter-risk.exe" (
-    "%~dp0.venv\Scripts\counter-risk.exe" gui
-    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    call :run_and_log "%~dp0.venv\Scripts\counter-risk.exe" gui
     goto :after_run
+)
+
+rem Prefer the source tree next to this launcher before any stale global install.
+if exist "%~dp0src\counter_risk\cli\__init__.py" (
+    set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
+    if exist "%~dp0.venv\Scripts\python.exe" (
+        call :run_and_log "%~dp0.venv\Scripts\python.exe" -m counter_risk.cli gui
+        goto :after_run
+    )
+    where py >nul 2>nul
+    if not errorlevel 1 (
+        py -3.12 --version >nul 2>nul
+        if not errorlevel 1 (
+            call :run_and_log py -3.12 -m counter_risk.cli gui
+            goto :after_run
+        )
+        call :run_and_log py -m counter_risk.cli gui
+        goto :after_run
+    )
+    where python >nul 2>nul
+    if not errorlevel 1 (
+        call :run_and_log python -m counter_risk.cli gui
+        goto :after_run
+    )
 )
 
 where counter-risk >nul 2>nul
 if not errorlevel 1 (
-    counter-risk gui
-    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
-    goto :after_run
-)
-
-set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
-where py >nul 2>nul
-if not errorlevel 1 (
-    py -m counter_risk.cli gui
-    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
-    goto :after_run
-)
-
-where python >nul 2>nul
-if not errorlevel 1 (
-    python -m counter_risk.cli gui
-    set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+    call :run_and_log counter-risk gui
     goto :after_run
 )
 
@@ -57,8 +67,18 @@ echo Try one of these fixes:
 echo   1. Run this file from the Counter Risk release folder, or
 echo   2. Install the project so the counter-risk command is available, or
 echo   3. Ask support for a packaged Counter Risk release folder.
+>>"%COUNTER_RISK_LAUNCHER_LOG%" echo Could not find Counter Risk or Python.
 set "COUNTER_RISK_EXIT=9009"
 goto :failure
+
+:run_and_log
+echo Command: %*
+>>"%COUNTER_RISK_LAUNCHER_LOG%" echo.
+>>"%COUNTER_RISK_LAUNCHER_LOG%" echo Command: %*
+%* 1>>"%COUNTER_RISK_LAUNCHER_LOG%" 2>>&1
+set "COUNTER_RISK_EXIT=%ERRORLEVEL%"
+>>"%COUNTER_RISK_LAUNCHER_LOG%" echo Exit code: %COUNTER_RISK_EXIT%
+exit /b 0
 
 :after_run
 if "%COUNTER_RISK_EXIT%"=="0" goto :success
@@ -66,10 +86,21 @@ if "%COUNTER_RISK_EXIT%"=="0" goto :success
 :failure
 echo.
 echo Counter Risk GUI did not start or exited with error code %COUNTER_RISK_EXIT%.
+echo The launcher wrote details to:
+echo   %COUNTER_RISK_LAUNCHER_LOG%
+echo.
+echo Last launcher log lines:
+type "%COUNTER_RISK_LAUNCHER_LOG%"
+echo.
 echo Leave this window open and copy the messages above when asking for help.
 echo.
 pause
 exit /b %COUNTER_RISK_EXIT%
 
 :success
+echo.
+echo Counter Risk GUI closed normally.
+echo Launcher log: %COUNTER_RISK_LAUNCHER_LOG%
+echo.
+if /i not "%COUNTER_RISK_NO_PAUSE%"=="1" pause
 exit /b 0

--- a/tests/test_windows_gui_launcher.py
+++ b/tests/test_windows_gui_launcher.py
@@ -7,6 +7,7 @@ def test_double_click_gui_launcher_exists_and_keeps_errors_visible() -> None:
     launcher = Path(__file__).resolve().parent.parent / "run_counter_risk_gui.cmd"
 
     text = launcher.read_text(encoding="utf-8")
+    raw = launcher.read_bytes()
 
     assert "counter-risk.exe\" gui" in text
     assert "counter-risk gui" in text
@@ -18,4 +19,10 @@ def test_double_click_gui_launcher_exists_and_keeps_errors_visible() -> None:
     assert "pause" in text.lower()
     assert "copy the messages above" in text
     assert "COUNTER_RISK_NO_PAUSE" in text
-    assert "stale global install" in text
+    assert "stale venv or global install" in text
+    assert text.index(r'src\counter_risk\cli\__init__.py') < text.index(
+        r'.venv\Scripts\counter-risk.exe'
+    )
+    assert '1>>"%COUNTER_RISK_LAUNCHER_LOG%" 2>&1' in text
+    assert b"\r\n" in raw
+    assert raw.count(b"\n") == raw.count(b"\r\n")

--- a/tests/test_windows_gui_launcher.py
+++ b/tests/test_windows_gui_launcher.py
@@ -10,8 +10,12 @@ def test_double_click_gui_launcher_exists_and_keeps_errors_visible() -> None:
 
     assert "counter-risk.exe\" gui" in text
     assert "counter-risk gui" in text
+    assert "counter-risk-gui-launcher.log" in text
+    assert "py -3.12 -m counter_risk.cli gui" in text
     assert "py -m counter_risk.cli gui" in text
     assert "python -m counter_risk.cli gui" in text
     assert "PYTHONPATH=%~dp0src;%PYTHONPATH%" in text
     assert "pause" in text.lower()
     assert "copy the messages above" in text
+    assert "COUNTER_RISK_NO_PAUSE" in text
+    assert "stale global install" in text


### PR DESCRIPTION
### Motivation

- Double-clicking the Windows GUI launcher previously produced a brief flash with no persistent diagnostics, hiding Python tracebacks and dependency errors.  
- The launcher could invoke a stale globally-installed `counter-risk` instead of the local source tree, causing surprising behaviour after merges.  
- Operators need a reliable, visible record of what the launcher tried so support can diagnose failures without reproducing them locally.

### Description

- Add a launcher log at `%TEMP%\counter-risk-gui-launcher.log` and print the log path at startup so output and Python tracebacks are persisted.  
- Wrap each attempted launcher command with a `:run_and_log` helper that records the invoked command and captures stdout/stderr and exit codes into the launcher log.  
- Prefer the local repository/source tree (`%~dp0src`) when present before falling back to venv/global installs or the `counter-risk` command, and try `py -3.12` when available.  
- Print the last launcher log lines on failure and keep the console open after both failure and normal GUI exit unless `COUNTER_RISK_NO_PAUSE=1` is set, and extend the regression test to assert the new diagnostics and behavior in `run_counter_risk_gui.cmd`.

### Testing

- Ran `pytest -q tests/test_windows_gui_launcher.py` and the test passed.  
- Ran `git diff --check` (no whitespace errors reported).  
- Executed `PYTHONPATH=src python -m counter_risk.cli gui --headless --as-of-date 2025-12-31` in the container and it failed due to a missing `pydantic` dependency; this is the same class of hidden dependency error the launcher now logs and surfaces for operators.  
- The launcher changes were validated by the updated test which asserts the log filename, local-source preference, Python 3.12 invocation attempt, and `COUNTER_RISK_NO_PAUSE` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42f27fa5e48331b3c0acc76c0f44fe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Windows GUI launcher to create a log at startup and capture the executed command plus stdout/stderr and exit code for easier diagnosis.
  * Enhanced GUI/Python launch discovery order and fallback behavior, with clearer “entry not found” handling and consistent success/failure messaging.
  * Improved failure output by showing exit code, log location, and recent log lines; added configurable pause behavior.
* **Tests**
  * Strengthened launcher tests to verify command variants, Python invocation behavior, log redirection, and Windows CRLF line endings.
* **Chores**
  * Enforced CRLF line endings for Windows batch scripts to ensure correct `cmd.exe` parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- workflow-source:local_request -->
