### PR TITLE
Consume shared PDF text baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,7 @@ ci/autofix/history.json merge=ours linguist-generated
 # Agent ledger files are metadata, not reviewable code
 # Mark as generated to exclude from Copilot/Codex code reviews
 .agents/*.yml linguist-generated
+
+# Windows launchers must keep CRLF line endings for double-click use.
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "pandas>=2.3,<4",
     "langchain-openai>=1.1.14,<2",
     "langchain-anthropic>=1.4.2,<2",
+    "stranske-pdf-extract[baseline,ocr] @ git+https://github.com/stranske/Workflows.git@a0ee3aa25c08d4eeb8e96dc6c8d7791930cd2d9a#subdirectory=packages/stranske_pdf_extract",
     "pywin32>=306; sys_platform == 'win32'",
 ]
 
@@ -195,6 +196,13 @@ module = [
     "pdf2image",
     "pdfplumber",
     "pytesseract",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = [
+    "stranske_pdf_extract",
+    "stranske_pdf_extract.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -2,24 +2,87 @@
 #    uv pip compile pyproject.toml --extra dev --universal --output-file requirements-dev.lock
 annotated-types==0.7.0
     # via pydantic
+anthropic==0.116.0
+    # via langchain-anthropic
+anyio==4.14.1
+    # via
+    #   anthropic
+    #   httpx
+    #   langsmith
+    #   openai
 ast-serialize==0.3.0
     # via mypy
-black==26.3.1
+black==26.5.1
     # via counter-risk (pyproject.toml)
+certifi==2026.6.17
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.1.0 ; platform_python_implementation != 'PyPy'
+    # via cryptography
+charset-normalizer==3.4.7
+    # via
+    #   pdfminer-six
+    #   requests
 click==8.3.1
     # via black
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
     #   pytest
+    #   tqdm
 coverage==7.14.0
     # via pytest-cov
+cryptography==49.0.0
+    # via pdfminer-six
+distro==1.9.0
+    # via
+    #   anthropic
+    #   langsmith
+    #   openai
+docstring-parser==0.18.0
+    # via anthropic
 et-xmlfile==2.0.0
     # via openpyxl
 execnet==2.1.2
     # via pytest-xdist
+h11==0.16.0
+    # via httpcore
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via
+    #   anthropic
+    #   langsmith
+    #   openai
+idna==3.18
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 iniconfig==2.3.0
     # via pytest
+jiter==0.16.0
+    # via
+    #   anthropic
+    #   openai
+jsonpatch==1.33
+    # via langchain-core
+jsonpointer==3.1.1
+    # via jsonpatch
+langchain-anthropic==1.4.8
+    # via counter-risk (pyproject.toml)
+langchain-core==1.4.8
+    # via
+    #   langchain-anthropic
+    #   langchain-openai
+langchain-openai==1.3.3
+    # via counter-risk (pyproject.toml)
+langchain-protocol==0.0.18
+    # via langchain-core
+langsmith==0.9.8
+    # via langchain-core
 librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
@@ -31,12 +94,21 @@ mypy-extensions==1.1.0
     #   black
     #   mypy
 numpy==2.4.2
-    # via pandas
+    # via
+    #   counter-risk (pyproject.toml)
+    #   pandas
+openai==2.44.0
+    # via langchain-openai
 openpyxl==3.1.5
     # via counter-risk (pyproject.toml)
+orjson==3.11.9 ; platform_python_implementation != 'PyPy'
+    # via langsmith
 packaging==25.0
     # via
     #   black
+    #   langchain-core
+    #   langsmith
+    #   pytesseract
     #   pytest
 pandas==2.3.0
     # via counter-risk (pyproject.toml)
@@ -44,27 +116,61 @@ pathspec==1.0.4
     # via
     #   black
     #   mypy
+pdf2image==1.17.0
+    # via stranske-pdf-extract
+pdfminer-six==20260107
+    # via pdfplumber
+pdfplumber==0.11.10
+    # via stranske-pdf-extract
 pillow==12.2.0
-    # via python-pptx
+    # via
+    #   counter-risk (pyproject.toml)
+    #   pdf2image
+    #   pdfplumber
+    #   pytesseract
+    #   python-pptx
 platformdirs==4.9.1
     # via black
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pydantic==2.7.4
-    # via counter-risk (pyproject.toml)
-pydantic-core==2.18.4
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
+    # via cffi
+pydantic==2.13.4
+    # via
+    #   counter-risk (pyproject.toml)
+    #   anthropic
+    #   langchain-anthropic
+    #   langchain-core
+    #   langsmith
+    #   openai
+pydantic-core==2.46.4
     # via pydantic
 pygments==2.19.2
     # via pytest
-pytest==9.0.3
+pypdf==6.14.2
+    # via stranske-pdf-extract
+pypdfium2==5.11.0
+    # via pdfplumber
+pytesseract==0.3.13
+    # via stranske-pdf-extract
+pytest==9.1.1
     # via
     #   counter-risk (pyproject.toml)
+    #   app-baseline-kit
     #   pytest-cov
+    #   pytest-datadir
+    #   pytest-regressions
     #   pytest-xdist
 pytest-cov==7.1.0
     # via counter-risk (pyproject.toml)
+pytest-datadir==1.8.0
+    # via pytest-regressions
+pytest-regressions==2.11.0
+    # via
+    #   counter-risk (pyproject.toml)
+    #   app-baseline-kit
 pytest-xdist==3.8.0
     # via counter-risk (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -78,20 +184,72 @@ pytz==2025.2
 pywin32==306 ; sys_platform == 'win32'
     # via counter-risk (pyproject.toml)
 pyyaml==6.0.3
-    # via counter-risk (pyproject.toml)
-ruff==0.15.13
+    # via
+    #   counter-risk (pyproject.toml)
+    #   app-baseline-kit
+    #   langchain-core
+    #   pytest-regressions
+regex==2026.6.28
+    # via tiktoken
+requests==2.34.2
+    # via
+    #   langsmith
+    #   requests-toolbelt
+    #   tiktoken
+requests-toolbelt==1.0.0
+    # via langsmith
+ruff==0.15.20
     # via counter-risk (pyproject.toml)
 six==1.17.0
     # via python-dateutil
+sniffio==1.3.1
+    # via
+    #   anthropic
+    #   langsmith
+    #   openai
+stranske-pdf-extract @ git+https://github.com/stranske/Workflows.git@a0ee3aa25c08d4eeb8e96dc6c8d7791930cd2d9a#subdirectory=packages/stranske_pdf_extract
+    # via counter-risk (pyproject.toml)
+tenacity==9.1.4
+    # via langchain-core
+tiktoken==0.13.0
+    # via langchain-openai
 tomlkit==0.14.0
+    # via counter-risk (pyproject.toml)
+tqdm==4.68.4
+    # via openai
+types-pyyaml==6.0.12.20260518
     # via counter-risk (pyproject.toml)
 typing-extensions==4.15.0
     # via
+    #   anthropic
+    #   anyio
+    #   langchain-core
+    #   langchain-protocol
+    #   langsmith
     #   mypy
+    #   openai
     #   pydantic
     #   pydantic-core
     #   python-pptx
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
 tzdata==2025.3
     # via pandas
+urllib3==2.7.0
+    # via requests
+uuid-utils==0.16.2
+    # via
+    #   langchain-core
+    #   langsmith
+websockets==16.0
+    # via langsmith
 xlsxwriter==3.2.9
     # via python-pptx
+xxhash==3.8.1
+    # via langsmith
+zstandard==0.25.0
+    # via langsmith
+
+# The following packages were excluded from the output:
+# app-baseline-kit

--- a/requirements.lock
+++ b/requirements.lock
@@ -18,8 +18,12 @@ certifi==2026.2.25
     #   httpcore
     #   httpx
     #   requests
+cffi==2.1.0 ; platform_python_implementation != 'PyPy'
+    # via cryptography
 charset-normalizer==3.4.4
-    # via requests
+    # via
+    #   pdfminer-six
+    #   requests
 click==8.3.1
     # via black
 colorama==0.4.6 ; sys_platform == 'win32'
@@ -29,6 +33,8 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   tqdm
 coverage==7.15.0
     # via pytest-cov
+cryptography==49.0.0
+    # via pdfminer-six
 distro==1.9.0
     # via
     #   anthropic
@@ -100,6 +106,7 @@ packaging==25.0
     #   black
     #   langchain-core
     #   langsmith
+    #   pytesseract
     #   pytest
 pandas==2.3.0
     # via counter-risk (pyproject.toml)
@@ -107,9 +114,18 @@ pathspec==1.0.4
     # via
     #   black
     #   mypy
+pdf2image==1.17.0
+    # via stranske-pdf-extract
+pdfminer-six==20260107
+    # via pdfplumber
+pdfplumber==0.11.10
+    # via stranske-pdf-extract
 pillow==12.2.0
     # via
     #   counter-risk (pyproject.toml)
+    #   pdf2image
+    #   pdfplumber
+    #   pytesseract
     #   python-pptx
 platformdirs==4.9.1
     # via black
@@ -117,6 +133,8 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
+    # via cffi
 pydantic==2.13.3
     # via
     #   counter-risk (pyproject.toml)
@@ -129,6 +147,12 @@ pydantic-core==2.46.3
     # via pydantic
 pygments==2.19.2
     # via pytest
+pypdf==6.14.2
+    # via stranske-pdf-extract
+pypdfium2==5.11.0
+    # via pdfplumber
+pytesseract==0.3.13
+    # via stranske-pdf-extract
 pytest==9.1.1
     # via
     #   counter-risk (pyproject.toml)
@@ -180,6 +204,8 @@ sniffio==1.3.1
     # via
     #   anthropic
     #   openai
+stranske-pdf-extract @ git+https://github.com/stranske/Workflows.git@a0ee3aa25c08d4eeb8e96dc6c8d7791930cd2d9a#subdirectory=packages/stranske_pdf_extract
+    # via counter-risk (pyproject.toml)
 tenacity==9.1.4
     # via langchain-core
 tiktoken==0.12.0

--- a/src/counter_risk/parsers/daily_holdings_pdf.py
+++ b/src/counter_risk/parsers/daily_holdings_pdf.py
@@ -6,7 +6,10 @@ import logging
 import math
 import re
 from collections import defaultdict
+from collections.abc import Sequence
 from pathlib import Path
+
+from stranske_pdf_extract.providers.text_baseline import TextBaselineProvider
 
 from counter_risk.normalize import canonicalize_name
 from counter_risk.parsers._xlsx_reader import coerce_accounting_float
@@ -79,91 +82,32 @@ def expected_repo_counterparties() -> tuple[str, ...]:
 
 
 def _extract_text(path: Path) -> str:
-    pdfplumber_text = _extract_text_with_pdfplumber(path)
-    if pdfplumber_text:
-        return pdfplumber_text
-
-    pypdf_text = _extract_text_with_pypdf(path)
-    if pypdf_text:
-        return pypdf_text
-
-    ocr_text = _extract_text_with_ocr(path)
-    if ocr_text:
-        return ocr_text
-
-    # Test fixtures may be sanitized text files with .pdf extension.
-    raw = path.read_bytes()
-    return raw.decode("utf-8", errors="ignore")
+    output = TextBaselineProvider(ocr_extract=_tesseract_ocr_extract).extract_modalities(
+        path.name,
+        path.read_bytes(),
+    )
+    return "\n".join(block.text for block in output.text_blocks if block.text.strip())
 
 
-def _extract_text_with_pdfplumber(path: Path) -> str:
-    try:
-        import pdfplumber
-    except ImportError:
-        _log.debug("pdfplumber not installed, skipping")
-        return ""
-
-    lines: list[str] = []
-    try:
-        with pdfplumber.open(path) as pdf:
-            for page in pdf.pages:
-                page_text = page.extract_text() or ""
-                if page_text:
-                    lines.append(page_text)
-                for table in page.extract_tables() or []:
-                    for row in table:
-                        if not row:
-                            continue
-                        pieces = [str(cell).strip() for cell in row if cell not in (None, "")]
-                        if pieces:
-                            lines.append(" ".join(pieces))
-    except Exception:
-        _log.warning("pdfplumber failed to extract text from %s", path, exc_info=True)
-        return ""
-
-    return "\n".join(lines)
-
-
-def _extract_text_with_pypdf(path: Path) -> str:
-    try:
-        from pypdf import PdfReader
-    except ImportError:
-        _log.debug("pypdf not installed, skipping")
-        return ""
-
-    lines: list[str] = []
-    try:
-        reader = PdfReader(str(path))
-        for page in reader.pages:
-            page_text = page.extract_text() or ""
-            if page_text:
-                lines.append(page_text)
-    except Exception:
-        _log.warning("pypdf failed to extract text from %s", path, exc_info=True)
-        return ""
-
-    return "\n".join(lines)
-
-
-def _extract_text_with_ocr(path: Path) -> str:
+def _tesseract_ocr_extract(content: bytes) -> Sequence[str]:
     try:
         import pytesseract
-        from pdf2image import convert_from_path
+        from pdf2image import convert_from_bytes
     except ImportError:
         _log.debug("pytesseract/pdf2image not installed, skipping OCR")
-        return ""
+        return ()
 
     lines: list[str] = []
     try:
-        for image in convert_from_path(str(path)):
+        for image in convert_from_bytes(content):
             text = pytesseract.image_to_string(image) or ""
             if text:
                 lines.append(text)
     except Exception:
-        _log.warning("OCR extraction failed for %s", path, exc_info=True)
-        return ""
+        _log.warning("OCR extraction failed", exc_info=True)
+        return ()
 
-    return "\n".join(lines)
+    return tuple(lines)
 
 
 def _extract_repo_cash_values(text: str) -> dict[str, float]:


### PR DESCRIPTION
Closes stranske/Workflows#2714

## Summary
- Replace Counter_Risk private Daily Holdings pdfplumber -> pypdf -> OCR ladder with stranske_pdf_extract TextBaselineProvider.
- Keep Counter_Risk domain parsing for repo cash values and counterparty aliases local.
- Add the pinned shared package with baseline/OCR extras and refresh lock files.

## Validation
- uv run --extra dev pytest tests/parsers/test_daily_holdings_pdf.py -q
- deliberate break: forced the provider path to return empty text; the named fixture-total gate failed with DailyHoldingsPdfError, then reverted
- uv run --extra dev ruff check src/counter_risk/parsers/daily_holdings_pdf.py tests/parsers/test_daily_holdings_pdf.py
- uv run --extra dev black --check src/counter_risk/parsers/daily_holdings_pdf.py tests/parsers/test_daily_holdings_pdf.py
- uv run --extra dev mypy src/counter_risk/parsers/daily_holdings_pdf.py
- rg -n "_extract_text_with_" src (no hits)
- uv run --extra dev python scripts/sync_test_dependencies.py --verify
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved PDF text extraction for daily holdings, including better fallback handling when documents need OCR.
  - Added support for a new PDF extraction dependency to improve readability of complex files.

- **Bug Fixes**
  - Windows launcher scripts now use the correct line endings, helping them open properly with double-click.

- **Chores**
  - Updated type-checking settings to avoid warnings for the new PDF extraction integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->