### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.20
+RUFF_VERSION=0.15.22
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.1.0
+MYPY_VERSION=2.3.0
 PYTEST_VERSION=9.1.1
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.15.1
+COVERAGE_VERSION=7.15.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,9 @@ dev = [
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
     "pytest-regressions==2.11.0",
     "numpy>=2.0,<3",
-    "black>=26.5.1",
-    "ruff==0.15.20",
-    "mypy==2.1.0",
+    "black==26.5.1",
+    "ruff==0.15.22",
+    "mypy==2.3.0",
     "types-PyYAML==6.0.12.20260518",
     # Required by scripts/sync_test_dependencies.py when --fix is needed in CI
     "tomlkit>=0.14.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,7 +10,7 @@ anyio==4.14.1
     #   httpx
     #   langsmith
     #   openai
-ast-serialize==0.3.0
+ast-serialize==0.6.0
     # via mypy
 black==26.5.1
     # via counter-risk (pyproject.toml)
@@ -83,7 +83,7 @@ langchain-protocol==0.0.18
     # via langchain-core
 langsmith==0.9.8
     # via langchain-core
-librt==0.11.0 ; platform_python_implementation != 'PyPy'
+librt==0.13.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -32,7 +32,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   click
     #   pytest
     #   tqdm
-coverage==7.14.0
+coverage==7.15.2
     # via pytest-cov
 cryptography==49.0.0
     # via pdfminer-six
@@ -87,7 +87,7 @@ librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==2.1.0
+mypy==2.3.0
     # via counter-risk (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -198,7 +198,7 @@ requests==2.34.2
     #   tiktoken
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.15.20
+ruff==0.15.22
     # via counter-risk (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,7 +9,7 @@ anyio==4.12.1
     #   anthropic
     #   httpx
     #   openai
-ast-serialize==0.3.0
+ast-serialize==0.6.0
     # via mypy
 black==26.5.1
     # via counter-risk (pyproject.toml)
@@ -81,7 +81,7 @@ langchain-protocol==0.0.14
     # via langchain-core
 langsmith==0.7.9
     # via langchain-core
-librt==0.11.0 ; platform_python_implementation != 'PyPy'
+librt==0.13.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx

--- a/requirements.lock
+++ b/requirements.lock
@@ -31,7 +31,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   click
     #   pytest
     #   tqdm
-coverage==7.15.1
+coverage==7.15.2
     # via pytest-cov
 cryptography==49.0.0
     # via pdfminer-six
@@ -85,7 +85,7 @@ librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 lxml==6.0.2
     # via python-pptx
-mypy==2.1.0
+mypy==2.3.0
     # via counter-risk (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -196,7 +196,7 @@ requests==2.32.5
     #   tiktoken
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.15.20
+ruff==0.15.22
     # via counter-risk (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 9 version updates:
  - ruff: ==0.15.20 -> ==0.15.22
  - black: >=26.5.1 -> ==26.5.1
  - mypy: ==2.1.0 -> ==2.3.0
  - requirements.lock:coverage: 7.15.1 -> ==7.15.2
  - requirements.lock:mypy: 2.1.0 -> ==2.3.0
  - requirements.lock:ruff: 0.15.20 -> ==0.15.22
  - requirements-dev.lock:coverage: 7.14.0 -> ==7.15.2
  - requirements-dev.lock:mypy: 2.1.0 -> ==2.3.0
  - requirements-dev.lock:ruff: 0.15.20 -> ==0.15.22

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pinned development tooling versions: Black (26.5.1), Ruff (0.15.22), and Mypy (2.3.0).
  * Refreshed maintenance workflow tool pins to match the updated formatter/linter/type checker versions, including Coverage (7.15.2).
  * Added a new LangSmith fleet worker attempt record to improve automated execution tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->