### PR TITLE
fix: preserve Windows launcher CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@ ci/autofix/history.json merge=ours linguist-generated
 # Agent ledger files are metadata, not reviewable code
 # Mark as generated to exclude from Copilot/Codex code reviews
 .agents/*.yml linguist-generated
+
+# Windows launchers must retain CRLF on Linux CI runners as well as Windows.
+*.cmd text eol=crlf


### PR DESCRIPTION
Preserves CRLF checkout semantics for Windows command launchers so the existing launcher invariant passes on Linux CI runners. This unblocks the generated dev-tool sync PR #857 once the fix is merged and Maint 52 is rerun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository settings to preserve Windows launcher script line endings across different environments.
  * Prevented unnecessary line-ending changes during automated builds and development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->