### PR TITLE
fix(windows): preserve launcher CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@ ci/autofix/history.json merge=ours linguist-generated
 # Agent ledger files are metadata, not reviewable code
 # Mark as generated to exclude from Copilot/Codex code reviews
 .agents/*.yml linguist-generated
+
+# Windows command launchers must retain CRLF on every checkout.
+*.cmd text eol=crlf


### PR DESCRIPTION
## Summary

- enforce CRLF checkout semantics for Windows `.cmd` launchers
- preserve the existing launcher source without a content rewrite

## Verification

- fresh worktree checkout reports 106 LF and 106 CRLF sequences
- `python -m pytest -q tests/test_windows_gui_launcher.py` passes

## Context

The Ruff 0.16.1 sync PR #896 exposed this pre-existing failure in both Python 3.12 and 3.13 Gate jobs. The dependency PR changed only dependency files; this bounded companion fixes the repository-local line-ending contract.