### PR TITLE
chore: black-format seven files blocking main lint-format

### DIFF
--- a/src/counter_risk/pipeline/reconciliation.py
+++ b/src/counter_risk/pipeline/reconciliation.py
@@ -56,7 +56,7 @@ def reconcile_series_coverage(
     prior_populated_series_by_sheet: (
         Mapping[str, tuple[str, ...] | list[str] | set[str]] | None
     ) = None,
-    series_present_by_sheet: (Mapping[str, tuple[str, ...] | list[str] | set[str]] | None) = None,
+    series_present_by_sheet: Mapping[str, tuple[str, ...] | list[str] | set[str]] | None = None,
 ) -> dict[str, Any]:
     """Reconcile parsed series labels against historical workbook headers per sheet.
 

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -135,7 +135,7 @@ def reconcile_series_coverage(
     prior_populated_series_by_sheet: (
         Mapping[str, tuple[str, ...] | list[str] | set[str]] | None
     ) = None,
-    series_present_by_sheet: (Mapping[str, tuple[str, ...] | list[str] | set[str]] | None) = None,
+    series_present_by_sheet: Mapping[str, tuple[str, ...] | list[str] | set[str]] | None = None,
 ) -> dict[str, Any]:
     return _reconcile_series_coverage(
         parsed_data_by_sheet=parsed_data_by_sheet,

--- a/src/counter_risk/writers/historical_update.py
+++ b/src/counter_risk/writers/historical_update.py
@@ -792,9 +792,9 @@ def append_wal_row(
                 columns=tuple(range(1, preserve_through_column + 1)),
             )
 
-        worksheet.cell(
-            row=append_target.append_row, column=append_target.date_column
-        ).value = px_date
+        worksheet.cell(row=append_target.append_row, column=append_target.date_column).value = (
+            px_date
+        )
         worksheet.cell(row=append_target.append_row, column=append_target.wal_column).value = float(
             wal_value
         )

--- a/tests/parsers/test_numeric.py
+++ b/tests/parsers/test_numeric.py
@@ -73,24 +73,20 @@ def test_coerce_accounting_float_us_locale_assumption() -> None:
 
 
 def test_cell_value_concatenates_rich_inline_strings() -> None:
-    cell = ET.fromstring(
-        """
+    cell = ET.fromstring("""
         <c xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" t="inlineStr">
           <is><r><t>Alpha</t></r><r><t> Beta</t></r></is>
         </c>
-        """
-    )
+        """)
 
     assert cell_value(cell, []) == "Alpha Beta"
 
 
 def test_cell_value_rejects_negative_shared_string_indexes() -> None:
-    cell = ET.fromstring(
-        """
+    cell = ET.fromstring("""
         <c xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" t="s">
           <v>-1</v>
         </c>
-        """
-    )
+        """)
 
     assert cell_value(cell, ["should-not-wrap"]) is None

--- a/tests/test_fixtures_smoke.py
+++ b/tests/test_fixtures_smoke.py
@@ -54,9 +54,9 @@ def test_fixture_workbooks_and_presentations_open() -> None:
         and path.name not in already_validated_fixture_names
     )
     assert fixture_paths, f"No .pptx/.xlsx fixtures found under {fixtures_root}."
-    assert len(fixture_paths) >= 10, (
-        "Expected representative fixture inventory under tests/fixtures."
-    )
+    assert (
+        len(fixture_paths) >= 10
+    ), "Expected representative fixture inventory under tests/fixtures."
 
     workbook_fixtures = [path for path in fixture_paths if path.suffix.lower() == ".xlsx"]
     presentation_fixtures = [path for path in fixture_paths if path.suffix.lower() == ".pptx"]

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -56,9 +56,7 @@ def _write_fake_repo(root: Path) -> None:
     (root / "docs" / "remote_trigger_testing.md").write_text(
         "# Remote Trigger Testing\n", encoding="utf-8"
     )
-    (root / "run_counter_risk_gui.cmd").write_text(
-        "@echo off\necho gui\n", encoding="utf-8"
-    )
+    (root / "run_counter_risk_gui.cmd").write_text("@echo off\necho gui\n", encoding="utf-8")
 
 
 def _create_fake_built_executable(root: Path, executable_name: str) -> Path:

--- a/tests/test_windows_gui_launcher.py
+++ b/tests/test_windows_gui_launcher.py
@@ -9,7 +9,7 @@ def test_double_click_gui_launcher_exists_and_keeps_errors_visible() -> None:
     text = launcher.read_text(encoding="utf-8")
     raw = launcher.read_bytes()
 
-    assert "counter-risk.exe\" gui" in text
+    assert 'counter-risk.exe" gui' in text
     assert "counter-risk gui" in text
     assert "counter-risk-gui-launcher.log" in text
     assert "py -3.12 -m counter_risk.cli gui" in text
@@ -20,8 +20,8 @@ def test_double_click_gui_launcher_exists_and_keeps_errors_visible() -> None:
     assert "copy the messages above" in text
     assert "COUNTER_RISK_NO_PAUSE" in text
     assert "stale venv or global install" in text
-    assert text.index(r'src\counter_risk\cli\__init__.py') < text.index(
-        r'.venv\Scripts\counter-risk.exe'
+    assert text.index(r"src\counter_risk\cli\__init__.py") < text.index(
+        r".venv\Scripts\counter-risk.exe"
     )
     assert '1>>"%COUNTER_RISK_LAUNCHER_LOG%" 2>&1' in text
     assert b"\r\n" in raw


### PR DESCRIPTION
## Problem

`stranske/Counter_Risk` `main` has failed **Python CI / lint-format** on four consecutive commits:

| commit | CI run | result |
| --- | --- | --- |
| `c370c2d7` | 30645772410 | failure |
| `4a9aa32a` | 30646079534 | failure |
| `8f3f6a3f` | 30647496319 | failure |
| `17cb9ecd` (#895 merge) | [30648759673](https://github.com/stranske/Counter_Risk/actions/runs/30648759673) | failure |

Job `Python CI / lint-format` (91216635241) fails on the exact CI command:

```
black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .
```

> 7 files would be reformatted, 345 files would be left unchanged.

This is the concrete defect behind the `Agents Verifier` **CONCERNS** verdict on merged PR #895 (anthropic claude-sonnet-5: *"the ci.yml run on the merge commit shows an explicit job failure for 'lint-format'"*). That claim was audited against current `main` and confirmed real, not a stale pre-merge false positive.

## Change

Applies `black==26.5.1` (the version CI resolves) at `--line-length 100` to the seven affected files. Formatting only — no behavior change.

- `src/counter_risk/pipeline/reconciliation.py`
- `src/counter_risk/pipeline/run.py`
- `src/counter_risk/writers/historical_update.py`
- `tests/parsers/test_numeric.py`
- `tests/test_fixtures_smoke.py`
- `tests/test_release_bundle.py`
- `tests/test_windows_gui_launcher.py`

## Validation

- `black==26.5.1 --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .` — **352 files unchanged** (was: 7 would be reformatted).
- `ruff==0.16.1 check .` — **All checks passed**.
- **AST equivalence**: each of the seven files parses to a byte-identical `ast.dump()` before and after the reformat, so the change is provably semantics-preserving.
- The Windows launcher CRLF regression assertion in `tests/test_windows_gui_launcher.py` (`assert b"\r\n" in raw`) is untouched; only the surrounding string-literal quoting was normalized.

## Non-goals

- No source behavior, test logic, or launcher line-ending handling is modified.
- Does not address the openai verifier concern on #895 (missing launcher CRLF artifact); that work landed separately in merged PR #897 `fix(windows): preserve launcher CRLF line endings`.
