### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -685,7 +685,7 @@ def _text_from_response_content(content: object) -> str | None:
             for block in content
             if isinstance(block, dict) and isinstance(block.get("text"), str)
         ]
-        if any(block.strip() for block in text_blocks):
+        if any(block and not block.isspace() for block in text_blocks):
             # Concatenate without a separator: a provider may split one JSON
             # document across blocks, and an inserted newline inside a string
             # literal would make the reassembled payload invalid JSON.

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -179,7 +179,7 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     unknown_overrides = sorted(set(raw_overrides) - set(required_categories))
     if unknown_overrides:
         raise ValueError(
-            "minimum_cases_per_category_overrides names categories that are not "
+            "approval_stage.minimum_cases_per_category_overrides names categories that are not "
             f"required: {unknown_overrides}"
         )
     noninferiority_margin = float(gates["paired_success_noninferiority_margin"])


### PR DESCRIPTION
## Sync Summary

### Files Updated
- pr_verifier.py: PR verifier - validates PR changes against acceptance criteria
- evaluate_model_benchmark.py: Deterministic paired model benchmark evaluator - computes confidence-bound quality gates and cost/latency ranking

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `c8e1cbcdbdd0535e390fe4389022edbe4d43fac6`
**Template hash:** `b19118ad9873`
**Consumer-sync plan ID:** `sha256:b19118ad98733c91cf7935afb1bf6d18a862d5dbe57efa341df2872166f9bb2b`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-b19118ad9873`
**Consumer repo:** `stranske/Counter_Risk`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Counter_Risk","source_repository":"stranske/Workflows","source_sha":"c8e1cbcdbdd0535e390fe4389022edbe4d43fac6","template_hash":"b19118ad9873","plan_id":"sha256:b19118ad98733c91cf7935afb1bf6d18a862d5dbe57efa341df2872166f9bb2b","sync_phase":"canary","sync_branch":"sync/workflows-b19118ad9873","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"30875760810","run_attempt":"1","changes_count":2} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:b19118ad98733c91cf7935afb1bf6d18a862d5dbe57efa341df2872166f9bb2b","generation":"b19118ad9873","repository":"stranske/Counter_Risk","desired_tree_hash":"3afe905cc3812af09678b6171d5e1b1ec59e04b0","source_commit":"c8e1cbcdbdd0535e390fe4389022edbe4d43fac6","lease_expires_at":"2026-08-07T03:49:33Z","predecessor_prs":[],"successor_prs":[]} -->