### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/agent-run-base/action.yml
+++ b/.github/actions/agent-run-base/action.yml
@@ -13,6 +13,13 @@ inputs:
     description: Git ref to check out for the target repository.
     required: false
     default: ''
+  target_checkout_ready:
+    description: >-
+      Set to true when the caller checked out the target repository before
+      loading this local action. This preserves the action directory for
+      post-job cleanup.
+    required: false
+    default: 'false'
   workflows_app_id:
     description: GitHub App ID used to mint the preferred write token.
     required: false
@@ -119,6 +126,7 @@ runs:
         printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
 
     - name: Checkout
+      if: inputs.target_checkout_ready != 'true'
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0

--- a/.github/actions/path-classifier/classify.js
+++ b/.github/actions/path-classifier/classify.js
@@ -3,7 +3,14 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const crypto = require('crypto');
 const vm = require('node:vm');
+
+// The first delivery to an older consumer may add this contract to a base
+// branch that does not contain it yet.  The classifier must never execute an
+// arbitrary module supplied by that PR: accept only the exact source contract
+// published by Workflows.  Subsequent deliveries read the trusted base copy.
+const BOOTSTRAP_DELIVERY_CONTRACT_SHA256 = 'b61558cca342ffffbdfc22453e585e252a7465a2d3407020e10e4bda73065023';
 
 const OUTPUT_NAMES = {
   'docs-only': 'is-docs-only',
@@ -235,7 +242,21 @@ function compileDeliveryContract(source, filename) {
 }
 
 function readContractAtRef(ref, contractPath) {
-  return runGit(['show', `${ref}:${contractPath}`]);
+  // Keep the object bytes intact: the bootstrap allowlist digest is calculated
+  // from the canonical tracked file, including its trailing newline.
+  return readGit(['show', `${ref}:${contractPath}`]);
+}
+
+function readGit(args) {
+  return execFileSync('git', args, {
+    cwd: process.env.GITHUB_WORKSPACE || process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function runGit(args) {
+  return readGit(args).trim();
 }
 
 function isAddOnlyContractDiff(diffText, contractPath) {
@@ -295,6 +316,10 @@ function loadDeliveryContract(
           return null;
         }
         const source = readBootstrapContract(headSha, relativeContractPath);
+        const digest = crypto.createHash('sha256').update(String(source)).digest('hex');
+        if (digest !== BOOTSTRAP_DELIVERY_CONTRACT_SHA256) {
+          return null;
+        }
         return compileDeliveryContract(source, `${headSha}:${relativeContractPath}`);
       } catch {
         return null;
@@ -307,14 +332,6 @@ function loadDeliveryContract(
     return null;
   }
   return require(contractPath);
-}
-
-function runGit(args) {
-  return execFileSync('git', args, {
-    cwd: process.env.GITHUB_WORKSPACE || process.cwd(),
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  }).trim();
 }
 
 function tryGit(args) {
@@ -339,16 +356,32 @@ function resolveBaseRef(inputBaseRef, githubContext) {
   return '';
 }
 
-function fetchBaseRef(baseRef, githubContext) {
+function fetchBaseRef(baseRef, githubContext, fetchGit = tryGit) {
   if (!baseRef || !baseRef.startsWith('origin/')) {
     return;
   }
   const branch = baseRef.slice('origin/'.length);
-  tryGit(['fetch', '--no-tags', '--depth=1', 'origin', branch]);
+  const refs = [branch];
   const prBaseSha = githubContext.event?.pull_request?.base?.sha;
   if (prBaseSha) {
-    tryGit(['fetch', '--no-tags', '--depth=1', 'origin', prBaseSha]);
+    refs.push(prBaseSha);
   }
+  // actions/checkout uses a depth-one synthetic merge commit for pull_request
+  // events, so the exact head object is not guaranteed to exist locally. The
+  // add-only first-delivery bootstrap compares and reads that exact head.
+  const pullRequest = githubContext.event?.pull_request;
+  const prHeadSha = pullRequest?.head?.sha;
+  const headRepository = pullRequest?.head?.repo?.full_name || '';
+  const baseRepository = pullRequest?.base?.repo?.full_name || '';
+  if (
+    isStableDeliveryPullRequest(githubContext)
+    && prHeadSha
+    && headRepository
+    && headRepository === baseRepository
+  ) {
+    refs.push(prHeadSha);
+  }
+  fetchGit(['fetch', '--no-tags', '--depth=1', 'origin', ...new Set(refs)]);
 }
 
 function listChangedFiles({
@@ -492,6 +525,7 @@ module.exports = {
   DEFAULT_CATEGORIES,
   OUTPUT_NAMES,
   classifyFiles,
+  fetchBaseRef,
   globToRegExp,
   isAddOnlyContractDiff,
   isStableDeliveryPullRequest,

--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -285,7 +285,8 @@ def _candidate_matches(text: str) -> list[tuple[int, int, str]]:
 
 _EXPLICIT_CREATE_PREFIX = re.compile(
     r"\b(?:create|add|introduce|scaffold|generate|write)\s+"
-    r"(?:(?:a|the)\s+)?(?:new\s+)?(?:files?\s+)?(?:at\s+|named\s+)?$",
+    r"(?:(?:a|the)\s+)?(?:new\s+)?(?:(?:files?|directories|directory|folders?)\s+)?"
+    r"(?:at\s+|named\s+)?$",
     re.I,
 )
 

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -3225,7 +3225,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
     if (migrateSummaryWriter) {
       core?.info?.(
         `Creating a trusted App-owned keepalive summary; existing writer ` +
-        `${existingSummaryAuthor || 'unknown'} is not ${trustedSummaryAuthor}.`,
+        `${existingSummaryAuthor || 'unknown'} is not ${trustedSummaryAuthor}; migrating known state.`,
       );
     }
 
@@ -4610,7 +4610,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
           try {
             const retryWorkflowId = normalise(
               inputs.retry_workflow_id ?? inputs.retryWorkflowId,
-            ) || 'agents-keepalive-loop.yml';
+            ) || 'agents-81-gate-followups.yml';
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -4779,12 +4779,33 @@ async function markAgentRunning({ github: rawGithub, context, core, inputs }) {
   const stateTrace = normalise(inputs.trace || inputs.keepalive_trace || '');
   const runUrl = normalise(inputs.run_url ?? inputs.runUrl);
 
-  const { state: previousState, commentId } = await loadKeepaliveState({
+  const {
+    state: previousState,
+    commentId,
+    commentAuthorLogin,
+    commentAuthorType,
+  } = await loadKeepaliveState({
     github,
     context,
     prNumber,
     trace: stateTrace,
   });
+  const trustedSummaryAuthor = normalise(
+    inputs.trusted_summary_author ?? inputs.trustedSummaryAuthor,
+  ).toLowerCase();
+  const existingSummaryAuthor = normalise(commentAuthorLogin).toLowerCase();
+  const existingSummaryAuthorType = normalise(commentAuthorType).toLowerCase();
+  const migrateSummaryWriter = Boolean(
+    commentId &&
+    trustedSummaryAuthor &&
+    (existingSummaryAuthor !== trustedSummaryAuthor || existingSummaryAuthorType !== 'bot'),
+  );
+  if (migrateSummaryWriter) {
+    core?.info?.(
+      `Creating a trusted App-owned running summary; existing writer ` +
+      `${existingSummaryAuthor || 'unknown'} is not ${trustedSummaryAuthor}; migrating known state.`,
+    );
+  }
   const prBody = await fetchPrBody({ github, context, prNumber, core });
   const focusSections = prBody ? normaliseChecklistSections(parseScopeTasksAcceptanceSections(prBody)) : {};
   const focusItems = extractChecklistItems(focusSections.tasks || focusSections.acceptance || '');
@@ -4842,7 +4863,7 @@ async function markAgentRunning({ github: rawGithub, context, core, inputs }) {
   summaryLines.push('', formatStateComment(preservedState));
   const body = summaryLines.join('\n');
 
-  if (commentId) {
+  if (commentId && !migrateSummaryWriter) {
     await github.rest.issues.updateComment({
       owner: context.repo.owner,
       repo: context.repo.repo,

--- a/.github/scripts/keepalive_state.js
+++ b/.github/scripts/keepalive_state.js
@@ -6,6 +6,19 @@ const STATE_MARKER = 'keepalive-state';
 const STATE_VERSION = 'v1';
 const STATE_REGEX = /<!--\s*keepalive-state(?::([\w.-]+))?\s+(.*?)\s*-->/s;
 const LOG_PREFIX = '[keepalive_state]';
+const TRUSTED_KEEPALIVE_STATE_AUTHORS = new Set([
+  'stranske-keepalive[bot]',
+  'agents-workflows-bot[bot]',
+  // Migration-only compatibility for summaries created before dedicated App
+  // tokens became mandatory. New workflows do not write state with this bot.
+  'github-actions[bot]',
+]);
+const TRUSTED_KEEPALIVE_STATE_PAT_AUTHORS = new Set([
+  // reusable-70-orchestrator-init.yml probes and enforces these exact
+  // identities before ACTIONS_BOT_PAT or SERVICE_BOT_PAT may write state.
+  'stranske',
+  'stranske-automation-bot',
+]);
 
 function logInfo(message) {
   console.info(`${LOG_PREFIX} ${message}`);
@@ -17,6 +30,13 @@ function normalise(value) {
 
 function normaliseLower(value) {
   return normalise(value).toLowerCase();
+}
+
+function isTrustedKeepaliveStateComment(comment) {
+  const type = normaliseLower(comment?.user?.type);
+  const login = normaliseLower(comment?.user?.login);
+  return (type === 'bot' && TRUSTED_KEEPALIVE_STATE_AUTHORS.has(login))
+    || (type === 'user' && TRUSTED_KEEPALIVE_STATE_PAT_AUTHORS.has(login));
 }
 
 function deepMerge(target, source) {
@@ -241,6 +261,9 @@ async function findStateComment({ github, owner, repo, prNumber, trace }) {
   let fallback = null;
   for (let index = comments.length - 1; index >= 0; index -= 1) {
     const comment = comments[index];
+    if (!isTrustedKeepaliveStateComment(comment)) {
+      continue;
+    }
     const parsed = parseStateComment(comment?.body);
     if (!parsed) {
       continue;
@@ -514,4 +537,5 @@ module.exports = {
   upsertStateCommentBody,
   deepMerge,
   formatTimestamp,
+  isTrustedKeepaliveStateComment,
 };

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -100,7 +100,20 @@ jobs:
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
         with:
-          secrets: ${{ toJSON(secrets) }}
+          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          actions_bot_pat: ${{ secrets.ACTIONS_BOT_PAT }}
+          owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}
+          agents_automation_pat: ${{ secrets.AGENTS_AUTOMATION_PAT }}
+          workflows_app_id: ${{ secrets.WORKFLOWS_APP_ID }}
+          workflows_app_private_key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          keepalive_app_id: ${{ secrets.KEEPALIVE_APP_ID }}
+          keepalive_app_private_key: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY }}
+          gh_app_id: ${{ secrets.GH_APP_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app_1_id: ${{ secrets.APP_1_ID }}
+          app_1_private_key: ${{ secrets.APP_1_PRIVATE_KEY }}
+          app_2_id: ${{ secrets.APP_2_ID }}
+          app_2_private_key: ${{ secrets.APP_2_PRIVATE_KEY }}
           github_token: ${{ github.token }}
 
       - name: Compute state fingerprint
@@ -465,13 +478,157 @@ jobs:
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
         with:
-          secrets: ${{ toJSON(secrets) }}
+          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          actions_bot_pat: ${{ secrets.ACTIONS_BOT_PAT }}
+          owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}
+          agents_automation_pat: ${{ secrets.AGENTS_AUTOMATION_PAT }}
+          workflows_app_id: ${{ secrets.WORKFLOWS_APP_ID }}
+          workflows_app_private_key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          keepalive_app_id: ${{ secrets.KEEPALIVE_APP_ID }}
+          keepalive_app_private_key: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY }}
+          gh_app_id: ${{ secrets.GH_APP_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app_1_id: ${{ secrets.APP_1_ID }}
+          app_1_private_key: ${{ secrets.APP_1_PRIVATE_KEY }}
+          app_2_id: ${{ secrets.APP_2_ID }}
+          app_2_private_key: ${{ secrets.APP_2_PRIVATE_KEY }}
           github_token: ${{ github.token }}
+
+      - name: Mint KEEPALIVE_APP running token
+        id: running_keepalive_app_token
+        if: ${{ env.KEEPALIVE_APP_ID != '' && env.KEEPALIVE_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        continue-on-error: true
+        env:
+          KEEPALIVE_APP_ID: ${{ secrets.KEEPALIVE_APP_ID || '' }}
+          KEEPALIVE_APP_PRIVATE_KEY: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY || '' }}
+        with:
+          app-id: ${{ env.KEEPALIVE_APP_ID }}
+          private-key: ${{ env.KEEPALIVE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-actions: write
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: read
+
+      - name: Mint WORKFLOWS_APP running token
+        id: running_workflows_app_token
+        if: |
+          steps.running_keepalive_app_token.outputs.token == '' &&
+          env.WORKFLOWS_APP_ID != '' &&
+          env.WORKFLOWS_APP_PRIVATE_KEY != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        env:
+          WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID || '' }}
+          WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || '' }}
+        with:
+          app-id: ${{ env.WORKFLOWS_APP_ID }}
+          private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-actions: write
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: read
+
+      - name: Select trusted keepalive running writer
+        id: running_token_writer
+        env:
+          KEEPALIVE_APP_TOKEN: ${{ steps.running_keepalive_app_token.outputs.token || '' }}
+          WORKFLOWS_APP_TOKEN: ${{ steps.running_workflows_app_token.outputs.token || '' }}
+          ACTIONS_TOKEN: ${{ secrets.ACTIONS_BOT_PAT || '' }}
+          SERVICE_TOKEN: ${{ secrets.SERVICE_BOT_PAT || '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "$KEEPALIVE_APP_TOKEN" ]; then
+            echo 'source=KEEPALIVE_APP_TOKEN' >>"$GITHUB_OUTPUT"
+          elif [ -n "$WORKFLOWS_APP_TOKEN" ]; then
+            echo 'source=WORKFLOWS_APP_TOKEN' >>"$GITHUB_OUTPUT"
+          elif [ -n "$ACTIONS_TOKEN" ]; then
+            echo 'source=ACTIONS_BOT_PAT' >>"$GITHUB_OUTPUT"
+          elif [ -n "$SERVICE_TOKEN" ]; then
+            echo 'source=SERVICE_BOT_PAT' >>"$GITHUB_OUTPUT"
+          else
+            echo 'source=none' >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Probe PAT keepalive running identity
+        if: >-
+          steps.running_token_writer.outputs.source == 'ACTIONS_BOT_PAT' ||
+          steps.running_token_writer.outputs.source == 'SERVICE_BOT_PAT'
+        id: running_pat_identity
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: >-
+            ${{
+              (steps.running_token_writer.outputs.source == 'ACTIONS_BOT_PAT' &&
+                secrets.ACTIONS_BOT_PAT) ||
+              secrets.SERVICE_BOT_PAT
+            }}
+          script: |
+            const { withRetry } = require('./.github/scripts/github-api-with-retry.js');
+            const { data } = await withRetry(() => github.rest.users.getAuthenticated());
+            const login = (data?.login || '').trim();
+            if (!login) {
+              core.setFailed('Unable to determine identity for the mark-running PAT.');
+              return;
+            }
+            core.setOutput('login', login);
+
+      - name: Enforce PAT keepalive running identity
+        if: >-
+          steps.running_token_writer.outputs.source == 'ACTIONS_BOT_PAT' ||
+          steps.running_token_writer.outputs.source == 'SERVICE_BOT_PAT'
+        env:
+          TOKEN_SOURCE: ${{ steps.running_token_writer.outputs.source }}
+          TOKEN_LOGIN: ${{ steps.running_pat_identity.outputs.login || '' }}
+        run: |
+          set -euo pipefail
+          case "$TOKEN_SOURCE:$TOKEN_LOGIN" in
+            'ACTIONS_BOT_PAT:stranske'|'SERVICE_BOT_PAT:stranske-automation-bot') ;;
+            *)
+              echo "::error::$TOKEN_SOURCE has unexpected identity '$TOKEN_LOGIN'."
+              exit 1 ;;
+          esac
+
+      - name: Require trusted keepalive running writer
+        env:
+          KEEPALIVE_RUNNING_TOKEN: >-
+            ${{
+              steps.running_keepalive_app_token.outputs.token ||
+              steps.running_workflows_app_token.outputs.token ||
+              secrets.ACTIONS_BOT_PAT ||
+              secrets.SERVICE_BOT_PAT ||
+              ''
+            }}
+        run: |
+          if [ -z "$KEEPALIVE_RUNNING_TOKEN" ]; then
+            echo "::error::A keepalive/Workflows App token or an approved PAT is required to mark the agent running."
+            exit 1
+          fi
 
       - name: Update summary with running status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          KEEPALIVE_RUNNING_WRITER: >-
+            ${{
+              steps.running_keepalive_app_token.outputs.token != '' &&
+              'stranske-keepalive[bot]' ||
+              steps.running_workflows_app_token.outputs.token != '' &&
+              'agents-workflows-bot[bot]' ||
+              steps.running_token_writer.outputs.source == 'ACTIONS_BOT_PAT' &&
+              'stranske' ||
+              'stranske-automation-bot'
+            }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: >-
+            ${{
+              steps.running_keepalive_app_token.outputs.token ||
+              steps.running_workflows_app_token.outputs.token ||
+              secrets.ACTIONS_BOT_PAT ||
+              secrets.SERVICE_BOT_PAT
+            }}
           script: |
             const { markAgentRunning } = require('./.github/scripts/keepalive_loop.js');
               const runUrl =
@@ -486,6 +643,7 @@ jobs:
               tasks_unchecked: '${{ needs.evaluate.outputs.tasks_unchecked }}',
               trace: '${{ needs.evaluate.outputs.trace }}',
               run_url: runUrl,
+              trusted_summary_author: process.env.KEEPALIVE_RUNNING_WRITER || '',
             };
             await markAgentRunning({ github, context, core, inputs });
 
@@ -628,7 +786,20 @@ jobs:
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
         with:
-          secrets: ${{ toJSON(secrets) }}
+          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          actions_bot_pat: ${{ secrets.ACTIONS_BOT_PAT }}
+          owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}
+          agents_automation_pat: ${{ secrets.AGENTS_AUTOMATION_PAT }}
+          workflows_app_id: ${{ secrets.WORKFLOWS_APP_ID }}
+          workflows_app_private_key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          keepalive_app_id: ${{ secrets.KEEPALIVE_APP_ID }}
+          keepalive_app_private_key: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY }}
+          gh_app_id: ${{ secrets.GH_APP_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app_1_id: ${{ secrets.APP_1_ID }}
+          app_1_private_key: ${{ secrets.APP_1_PRIVATE_KEY }}
+          app_2_id: ${{ secrets.APP_2_ID }}
+          app_2_private_key: ${{ secrets.APP_2_PRIVATE_KEY }}
           github_token: ${{ github.token }}
 
       - name: Emit keepalive metrics
@@ -1038,7 +1209,20 @@ jobs:
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
         with:
-          secrets: ${{ toJSON(secrets) }}
+          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          actions_bot_pat: ${{ secrets.ACTIONS_BOT_PAT }}
+          owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}
+          agents_automation_pat: ${{ secrets.AGENTS_AUTOMATION_PAT }}
+          workflows_app_id: ${{ secrets.WORKFLOWS_APP_ID }}
+          workflows_app_private_key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          keepalive_app_id: ${{ secrets.KEEPALIVE_APP_ID }}
+          keepalive_app_private_key: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY }}
+          gh_app_id: ${{ secrets.GH_APP_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app_1_id: ${{ secrets.APP_1_ID }}
+          app_1_private_key: ${{ secrets.APP_1_PRIVATE_KEY }}
+          app_2_id: ${{ secrets.APP_2_ID }}
+          app_2_private_key: ${{ secrets.APP_2_PRIVATE_KEY }}
           github_token: ${{ github.token }}
 
       - name: Security gate - prompt injection guard
@@ -1731,6 +1915,60 @@ jobs:
           name: agents-autofix-metrics
           path: autofix-metrics.ndjson
           retention-days: 30
+
+  generated-delivery-wakeup:
+    name: Wake generated delivery reconciler
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        (github.event.workflow_run.head_branch == 'sync/workflows-candidate' ||
+         github.event.workflow_run.head_branch == 'sync/workflows-delivery' ||
+         startsWith(github.event.workflow_run.head_branch, 'deps/sync-dev-versions-'))
+      }}
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch exact generated lane to Workflows
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ env.WRITE_TOKEN }}
+          script: |
+            const branch = String(context.payload.workflow_run?.head_branch || '');
+            const activeSyncHash = branch === 'sync/workflows-candidate'
+              ? 'candidate'
+              : branch === 'sync/workflows-delivery'
+                ? 'delivery'
+                : 'dev-tool';
+            const clientPayload = {
+              source_repository: `${context.repo.owner}/${context.repo.repo}`,
+              source_run_id: String(context.payload.workflow_run?.id || ''),
+            };
+            clientPayload.active_sync_hash = activeSyncHash;
+            const withRetry = async (operation) => {
+              let lastError;
+              for (let attempt = 0; attempt < 3; attempt += 1) {
+                try {
+                  return await operation();
+                } catch (error) {
+                  lastError = error;
+                  if (![429, 500, 502, 503, 504].includes(Number(error?.status))) throw error;
+                  await new Promise((resolve) => setTimeout(resolve, 1000 * (attempt + 1)));
+                }
+              }
+              core.setFailed(
+                `Generated-delivery wakeup failed: ${lastError?.message || lastError}`,
+              );
+              throw lastError;
+            };
+            await withRetry(() => github.rest.repos.createDispatchEvent({
+              owner: 'stranske',
+              repo: 'Workflows',
+              event_type: 'merge-sync-prs',
+              client_payload: clientPayload,
+            }));
+            core.notice(`Woke Maint 71 lane ${activeSyncHash} from ${branch}`);
 
   guarded-merge:
     name: Merge automerge-labelled agent PRs

--- a/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -78,12 +78,90 @@ jobs:
         if: steps.fingerprint.outputs.should_run == 'false'
         run: echo "Skipped - ${{ steps.fingerprint.outputs.reason }}"
 
+      - name: Mint KEEPALIVE_APP reporter token
+        id: reporter_keepalive_app_token
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          github.event.workflow_run.conclusion != 'success' &&
+          github.event.workflow_run.pull_requests[0].number &&
+          env.KEEPALIVE_APP_ID != '' &&
+          env.KEEPALIVE_APP_PRIVATE_KEY != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        continue-on-error: true
+        env:
+          KEEPALIVE_APP_ID: ${{ secrets.KEEPALIVE_APP_ID || '' }}
+          KEEPALIVE_APP_PRIVATE_KEY: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY || '' }}
+        with:
+          app-id: ${{ env.KEEPALIVE_APP_ID }}
+          private-key: ${{ env.KEEPALIVE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-actions: write
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: read
+
+      - name: Mint WORKFLOWS_APP reporter token
+        id: reporter_workflows_app_token
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          github.event.workflow_run.conclusion != 'success' &&
+          github.event.workflow_run.pull_requests[0].number &&
+          steps.reporter_keepalive_app_token.outputs.token == '' &&
+          env.WORKFLOWS_APP_ID != '' &&
+          env.WORKFLOWS_APP_PRIVATE_KEY != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        env:
+          WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID || '' }}
+          WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || '' }}
+        with:
+          app-id: ${{ env.WORKFLOWS_APP_ID }}
+          private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-actions: write
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: read
+
+      - name: Require trusted keepalive reporter writer
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          github.event.workflow_run.conclusion != 'success' &&
+          github.event.workflow_run.pull_requests[0].number
+        env:
+          KEEPALIVE_REPORTER_TOKEN: >-
+            ${{
+              steps.reporter_keepalive_app_token.outputs.token ||
+              steps.reporter_workflows_app_token.outputs.token ||
+              ''
+            }}
+        run: |
+          if [ -z "$KEEPALIVE_REPORTER_TOKEN" ]; then
+            echo "::error::A dedicated keepalive or Workflows App token is required to report trusted keepalive state."
+            exit 1
+          fi
+
       - name: Update summary for cancelled/failed runs
         id: update-summary
-        if: steps.fingerprint.outputs.should_run == 'true'
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          github.event.workflow_run.conclusion != 'success' &&
+          github.event.workflow_run.pull_requests[0].number
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          KEEPALIVE_SUMMARY_WRITER: >-
+            ${{
+              steps.reporter_keepalive_app_token.outputs.token != '' &&
+              'stranske-keepalive[bot]' ||
+              'agents-workflows-bot[bot]'
+            }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: >-
+            ${{
+              steps.reporter_keepalive_app_token.outputs.token ||
+              steps.reporter_workflows_app_token.outputs.token
+            }}
           script: |
             const run = context.payload?.workflow_run || {};
             const prNumber = Number(run.pull_requests?.[0]?.number || 0);
@@ -127,6 +205,7 @@ jobs:
               run_result: conclusion,
               run_url: run.html_url || '',
               rounds_without_task_completion: state.rounds_without_task_completion || 0,
+              trusted_summary_author: process.env.KEEPALIVE_SUMMARY_WRITER || '',
             };
 
             await updateKeepaliveLoopSummary({ github, context, core, inputs });

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -107,7 +107,20 @@ jobs:
         if: steps.eligibility.outputs.should-run == 'true'
         uses: ./.github/actions/setup-api-client
         with:
-          secrets: ${{ toJSON(secrets) }}
+          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          actions_bot_pat: ${{ secrets.ACTIONS_BOT_PAT }}
+          owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}
+          agents_automation_pat: ${{ secrets.AGENTS_AUTOMATION_PAT }}
+          workflows_app_id: ${{ secrets.WORKFLOWS_APP_ID }}
+          workflows_app_private_key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          keepalive_app_id: ${{ secrets.KEEPALIVE_APP_ID }}
+          keepalive_app_private_key: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY }}
+          gh_app_id: ${{ secrets.GH_APP_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app_1_id: ${{ secrets.APP_1_ID }}
+          app_1_private_key: ${{ secrets.APP_1_PRIVATE_KEY }}
+          app_2_id: ${{ secrets.APP_2_ID }}
+          app_2_private_key: ${{ secrets.APP_2_PRIVATE_KEY }}
           github_token: ${{ github.token }}
 
       - name: Resolve PR context

--- a/scripts/langchain/label_matcher.py
+++ b/scripts/langchain/label_matcher.py
@@ -347,7 +347,7 @@ def _token_matches_keyword(token: str, keyword: str) -> bool:
         return True
     # Only allow prefix matching for tokens >= 4 chars to avoid false positives
     # from short tokens like "d" matching "defect" or "a" matching "add"
-    if len(token) >= 4 and token.startswith(keyword):
+    if len(token) >= 4 and len(keyword) >= 4 and token.startswith(keyword):
         return True
     # Check if keyword starts with token (both must be >= 4 chars)
     return len(token) >= 4 and len(keyword) >= 4 and keyword.startswith(token)

--- a/scripts/langchain/structured_output.py
+++ b/scripts/langchain/structured_output.py
@@ -101,10 +101,16 @@ def build_repair_callback(
 
 
 def clamp_repair_attempts(max_repair_attempts: int) -> int:
-    return min(
-        MAX_REPAIR_ATTEMPTS,
-        max(MIN_REPAIR_ATTEMPTS, int(max_repair_attempts)),
-    )
+    if isinstance(max_repair_attempts, bool) or not isinstance(max_repair_attempts, int):
+        raise TypeError(
+            "max_repair_attempts must be an integer, got " f"{type(max_repair_attempts).__name__}"
+        )
+    if not MIN_REPAIR_ATTEMPTS <= max_repair_attempts <= MAX_REPAIR_ATTEMPTS:
+        raise ValueError(
+            f"max_repair_attempts must be between {MIN_REPAIR_ATTEMPTS} and "
+            f"{MAX_REPAIR_ATTEMPTS}, got {max_repair_attempts}"
+        )
+    return max_repair_attempts
 
 
 def _invoke_repair_loop[T: BaseModel](

--- a/scripts/langchain/verifier_config.py
+++ b/scripts/langchain/verifier_config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from scripts.langchain.issue_pr_context import DEFAULT_TOKEN_BUDGET
-from scripts.langchain.structured_output import MAX_REPAIR_ATTEMPTS
+from scripts.langchain.structured_output import MAX_REPAIR_ATTEMPTS, clamp_repair_attempts
 
 EVAL_PAIR_BUDGET_TOKENS = DEFAULT_TOKEN_BUDGET
 EVAL_SCHEMA_REPAIR_BUDGET_TOKENS = DEFAULT_TOKEN_BUDGET
@@ -47,6 +47,14 @@ class SchemaRepairPolicy:
 
     max_attempts: int = MAX_REPAIR_ATTEMPTS
     escalation_threshold: int = MAX_REPAIR_ATTEMPTS
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "max_attempts", clamp_repair_attempts(self.max_attempts))
+        object.__setattr__(
+            self,
+            "escalation_threshold",
+            clamp_repair_attempts(self.escalation_threshold),
+        )
 
     def terminal_decision(
         self,

--- a/scripts/sync_dev_dependencies.py
+++ b/scripts/sync_dev_dependencies.py
@@ -59,6 +59,7 @@ TOOL_MAPPING: dict[str, tuple[str, ...]] = {
 PRE_COMMIT_REPO_MAPPING = {
     "psf/black": "BLACK_VERSION",
     "astral-sh/ruff-pre-commit": "RUFF_VERSION",
+    "charliermarsh/ruff-pre-commit": "RUFF_VERSION",
     "pre-commit/mirrors-mypy": "MYPY_VERSION",
     "pycqa/isort": "ISORT_VERSION",
     "pycqa/docformatter": "DOCFORMATTER_VERSION",
@@ -420,11 +421,13 @@ def sync_pre_commit_config(
     lines = content.splitlines(keepends=True)
     changes: list[str] = []
     current_env_key: str | None = None
+    current_repo_name: str | None = None
 
     for index, line in enumerate(lines):
         repo_name = _pre_commit_repo_name(line)
         if repo_name is not None:
             current_env_key = PRE_COMMIT_REPO_MAPPING.get(repo_name)
+            current_repo_name = repo_name if current_env_key is not None else None
             continue
 
         if current_env_key is None or current_env_key not in pins:
@@ -446,12 +449,12 @@ def sync_pre_commit_config(
             target_value = f"v{target_value}"
         if current_value == target_value:
             current_env_key = None
+            current_repo_name = None
             continue
 
-        repo_name = next(
-            name for name, env_key in PRE_COMMIT_REPO_MAPPING.items() if env_key == current_env_key
+        changes.append(
+            f"{pre_commit_path.name}:{current_repo_name}: {current_value} -> {target_value}"
         )
-        changes.append(f"{pre_commit_path.name}:{repo_name}: {current_value} -> {target_value}")
         if apply:
             lines[index] = (
                 f"{rev_match.group('prefix')}{rev_match.group('quote')}{target_value}"
@@ -459,6 +462,7 @@ def sync_pre_commit_config(
                 f"{line_ending}"
             )
         current_env_key = None
+        current_repo_name = None
 
     if apply:
         updated = "".join(lines)

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -44,6 +44,22 @@ def _case_outcome(case: dict[str, Any]) -> tuple[str, str, bool]:
     return expected, actual, schema_valid
 
 
+def _required_nonnegative_metric(case: dict[str, Any], case_id: str, field: str) -> float:
+    """Return required finite telemetry without treating missing data as zero."""
+    if field not in case:
+        raise ValueError(f"case {case_id} is missing {field}")
+    raw = case[field]
+    if isinstance(raw, bool):
+        raise ValueError(f"case {case_id} has invalid {field}")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"case {case_id} has invalid {field}") from exc
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"case {case_id} has invalid {field}")
+    return value
+
+
 def _metrics(cases: list[dict[str, Any]], *, z: float = Z_95) -> dict[str, Any]:
     success = false_pass = false_fail = schema_error = 0
     expected_pass = expected_non_pass = 0
@@ -68,12 +84,8 @@ def _metrics(cases: list[dict[str, Any]], *, z: float = Z_95) -> dict[str, Any]:
         false_pass += int(expected == "NON_PASS" and actual == "PASS")
         false_fail += int(expected == "PASS" and actual == "NON_PASS")
         categories[category] = categories.get(category, 0) + 1
-        cost = float(case.get("total_cost_usd", 0.0))
-        latency = float(case.get("latency_ms", 0.0))
-        if not math.isfinite(cost) or cost < 0:
-            raise ValueError(f"case {case_id} has invalid total_cost_usd")
-        if not math.isfinite(latency) or latency < 0:
-            raise ValueError(f"case {case_id} has invalid latency_ms")
+        cost = _required_nonnegative_metric(case, case_id, "total_cost_usd")
+        latency = _required_nonnegative_metric(case, case_id, "latency_ms")
         total_cost += cost
         latencies.append(latency)
 

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import re
 from dataclasses import dataclass
 
 from tools import llm_registry as _llm_registry
@@ -150,7 +151,7 @@ def _is_reasoning_model(model: str) -> bool:
     # o-series reasoning models use an `o` prefix followed by digits with optional
     # hyphen-separated suffixes: o1, o1-preview, o1-preview-2024-09-12, o3, o3-mini,
     # o3-pro, o4-mini, o4-mini-deep-research.
-    return bool(__import__("re").fullmatch(r"o[0-9]+(?:-[a-z0-9]+)*", name))
+    return bool(re.fullmatch(r"o[0-9]+(?:-[a-z0-9]+)*", name))
 
 
 def _build_openai_client(

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -61,14 +61,17 @@ def _setup_langsmith_tracing() -> bool:
     if not api_key:
         return False
 
-    # Enable LangChain tracing v2
-    os.environ["LANGCHAIN_TRACING_V2"] = "true"
+    # Respect an explicit opt-out while defaulting enabled tracing for configured users.
+    os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
     os.environ.setdefault("LANGCHAIN_PROJECT", "workflows-agents")
     # LangSmith uses LANGSMITH_API_KEY directly, but LangChain expects LANGCHAIN_API_KEY
     os.environ.setdefault("LANGCHAIN_API_KEY", api_key)
     os.environ.setdefault("LANGSMITH_API_KEY", api_key)
 
     project = os.environ.get("LANGCHAIN_PROJECT")
+    if os.environ["LANGCHAIN_TRACING_V2"].strip().lower() == "false":
+        logger.info("LangSmith tracing explicitly disabled for project: %s", project)
+        return False
     logger.info(f"LangSmith tracing enabled for project: {project}")
     return True
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- autofix.yml: Autofix workflow - automatically fixes lint/format issues
- agents-81-gate-followups.yml: Gate followups hub - consolidates keepalive and autofix followups
- agents-keepalive-loop-reporter.yml: Keepalive reporter - posts summary when keepalive run fails or cancels
- sync_dev_dependencies.py: Syncs dev dependency versions from autofix-versions.env to pyproject.toml
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.
- keepalive_loop.js: Core keepalive loop logic
- keepalive_state.js: Keepalive state management
- structured_output.py: Shared structured output helpers for LangChain workflows
- verifier_config.py: Shared verifier prompt budgets, schema-repair policy, and terminal artifact validation
- label_matcher.py: Label matcher - suggests labels based on semantic matching
- llm_provider.py: LLM provider configuration - GitHub Models and OpenAI client setup
- langchain_client.py: LangChain client builder - multi-provider client with slot-based fallback and configuration
- evaluate_model_benchmark.py: Deterministic paired model benchmark evaluator - computes confidence-bound quality gates and cost/latency ranking
- agent-run-base/ (1 files): Shared agent runner setup action - required by reusable-codex-run.yml and reusable-claude-run.yml
- path-classifier/ (1 files): Classifies changed PR paths for path-aware expensive job gating

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `a5f221202e40249a08c038fa10db567216a6e793`
**Template hash:** `45420a01eae6`
**Consumer-sync plan ID:** `sha256:45420a01eae63dbb2a8f5635cdc179024e83beb23db47fb9689c0839574b2767`
**Plan scope:** `full`
**Scope base SHA:** `full`
**Sync phase:** `promote`
**Sync branch:** `sync/workflows-delivery`
**Consumer repo:** `stranske/Counter_Risk`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Counter_Risk","source_repository":"stranske/Workflows","source_sha":"a5f221202e40249a08c038fa10db567216a6e793","template_hash":"45420a01eae6","plan_id":"sha256:45420a01eae63dbb2a8f5635cdc179024e83beb23db47fb9689c0839574b2767","plan_scope":"full","scope_base_sha":"","source_commit":"a5f221202e40249a08c038fa10db567216a6e793","sync_phase":"promote","sync_branch":"sync/workflows-delivery","manifest":".github/sync-manifest.yml","lifecycle_state":"staging","run_id":"31903814326","run_attempt":"1","changes_count":15} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:45420a01eae63dbb2a8f5635cdc179024e83beb23db47fb9689c0839574b2767","generation":"45420a01eae6","repository":"stranske/Counter_Risk","desired_tree_hash":"bca8d5bb70d6050a3f4ab439f124b43cd9c333c9","source_commit":"a5f221202e40249a08c038fa10db567216a6e793","head_observed_sha":"6d4d0cff7631f1b85945175474d36938fcbe1c4d","head_observed_at":"2026-08-15T19:25:21Z","lease_expires_at":"2026-08-18T19:25:22Z","predecessor_prs":[],"successor_prs":[],"delivery_state":"sealed","review_started_at":"2026-08-15T19:33:57.766Z","sealed_at":"2026-08-15T19:49:53.112Z","sealed_head_sha":"6d4d0cff7631f1b85945175474d36938fcbe1c4d","review_evidence":{"policy_schema":"workflows.consumer-sync-review-policy/v1","reason":"review_timeout_degraded","degraded":true,"responded_reviewers":[],"unavailable_reviewers":["coderabbit"]},"terminal_disposition":""} -->

autofix: false