### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.3
+RUFF_VERSION=0.16.4
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     "pytest-regressions==2.11.0",
     "numpy>=2.0,<3",
     "black==26.5.1",
-    "ruff==0.16.3",
+    "ruff==0.16.4",
     "mypy==2.3.1",
     "types-PyYAML==6.0.12.20260724",
     # Required by scripts/sync_test_dependencies.py when --fix is needed in CI

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -198,7 +198,7 @@ requests==2.34.2
     #   tiktoken
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.16.3
+ruff==0.16.4
     # via counter-risk (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/requirements.lock
+++ b/requirements.lock
@@ -196,7 +196,7 @@ requests==2.32.5
     #   tiktoken
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.16.3
+ruff==0.16.4
     # via counter-risk (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 3 version updates:
  - ruff: ==0.16.3 -> ==0.16.4
  - requirements.lock:ruff: 0.16.3 -> ==0.16.4
  - requirements-dev.lock:ruff: 0.16.3 -> ==0.16.4

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`
**Settled source commit:** `bfcd3c6e87c7f64849b3b342e48539f27fb1568b`

<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"dev-tool-d0d1e2e78e43","generation":"d0d1e2e78e43","repository":"stranske/Counter_Risk","desired_tree_hash":"ccc376db61052fc45505bfc41eea050a47514393","source_commit":"bfcd3c6e87c7f64849b3b342e48539f27fb1568b","lease_expires_at":"2026-08-24T04:42:25Z","predecessor_prs":[],"successor_prs":[]} -->