### PR TITLE
fix: reject non-finite rollup values

### DIFF
--- a/src/counter_risk/compute/rollups.py
+++ b/src/counter_risk/compute/rollups.py
@@ -119,11 +119,16 @@ def _find_numeric(
             break
 
         try:
-            return float(raw_value)
+            value = float(raw_value)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"Row value for {field!r} must be numeric") from exc
+        if not math.isfinite(value):
+            raise ValueError(f"Row value for {field!r} must be finite, got {raw_value!r}")
+        return value
 
     if default is not None:
+        if not math.isfinite(default):
+            raise ValueError(f"Default value for {field!r} must be finite, got {default!r}")
         return default
 
     raise ValueError(f"Row missing required numeric {field} column from aliases {keys}")

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -35,6 +35,7 @@ from counter_risk.compute.limits import (
     write_limit_breaches_csv,
 )
 from counter_risk.compute.rollups import (
+    _find_numeric,
     apply_repo_cash_to_totals,
     compute_concentration_metrics,
     write_concentration_metrics_csv,
@@ -1747,13 +1748,15 @@ def _compute_metrics(
 
         sorted_exposures = sorted(
             totals_records,
-            key=lambda record: abs(float(record.get("Notional", 0.0) or 0.0)),
+            key=lambda record: abs(
+                _find_numeric(record, ("Notional",), field="Notional", default=0.0)
+            ),
             reverse=True,
         )
         top_exposures[variant] = [
             {
                 "counterparty": str(record.get("counterparty", "")),
-                "notional": float(record.get("Notional", 0.0) or 0.0),
+                "notional": _find_numeric(record, ("Notional",), field="Notional", default=0.0),
                 "evidence": top_exposure_evidence(
                     variant=variant,
                     sheet=totals_evidence.get(str(record.get("counterparty", "")), {}).get("sheet"),
@@ -1775,13 +1778,17 @@ def _compute_metrics(
 
         sorted_changes = sorted(
             totals_records,
-            key=lambda record: abs(float(record.get(change_column, 0.0) or 0.0)),
+            key=lambda record: abs(
+                _find_numeric(record, (change_column,), field=change_column, default=0.0)
+            ),
             reverse=True,
         )
         top_changes_per_variant[variant] = [
             {
                 "counterparty": str(record.get("counterparty", "")),
-                "notional_change": float(record.get(change_column, 0.0) or 0.0),
+                "notional_change": _find_numeric(
+                    record, (change_column,), field=change_column, default=0.0
+                ),
             }
             for record in sorted_changes[:5]
         ]
@@ -2098,10 +2105,20 @@ def _infer_prior_rows_from_notional_change(
 def _rank_proxy_rows(
     *, variant: str, records: list[dict[str, Any]], proxy_column: str
 ) -> list[dict[str, Any]]:
+    def finite_proxy_value(record: Mapping[str, Any]) -> float:
+        raw_value = record.get(proxy_column)
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Risk proxy {proxy_column!r} must be numeric") from exc
+        if not math.isfinite(value):
+            raise ValueError(f"Risk proxy {proxy_column!r} must be finite, got {raw_value!r}")
+        return value
+
     ranked = sorted(
         records,
         key=lambda record: (
-            -abs(_to_float(record.get(proxy_column))),
+            -abs(finite_proxy_value(record)),
             _counterparty_canonical_sort_key(record),
         ),
     )
@@ -2113,7 +2130,7 @@ def _rank_proxy_rows(
                 "counterparty": str(record.get("counterparty", "")),
                 "proxy_name": proxy_column,
                 "formula": _RISK_PROXY_FORMULAS.get(proxy_column, ""),
-                "proxy_value": _to_float(record.get(proxy_column)),
+                "proxy_value": finite_proxy_value(record),
                 "rank": index,
             }
         )

--- a/src/counter_risk/pipeline/run.py
+++ b/src/counter_risk/pipeline/run.py
@@ -2107,6 +2107,8 @@ def _rank_proxy_rows(
 ) -> list[dict[str, Any]]:
     def finite_proxy_value(record: Mapping[str, Any]) -> float:
         raw_value = record.get(proxy_column)
+        if raw_value is None:
+            raise ValueError(f"Risk proxy {proxy_column!r} must be numeric")
         try:
             value = float(raw_value)
         except (TypeError, ValueError) as exc:

--- a/tests/compute/test_rollups.py
+++ b/tests/compute/test_rollups.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 
 from counter_risk.compute.rollups import (
+    _find_numeric,
     apply_repo_cash_to_totals,
     compute_notional_breakdown,
     compute_risk_proxies,
@@ -16,6 +17,7 @@ from counter_risk.compute.rollups import (
     top_exposures,
 )
 from counter_risk.parsers.cprs_fcm import parse_fcm_totals
+from counter_risk.pipeline.run import _compute_metrics, _rank_proxy_rows
 
 _FRACTION_TOLERANCE = 1e-9
 
@@ -28,6 +30,60 @@ def _as_records(table: Any) -> list[dict[str, Any]]:
 
 def _fixture(name: str) -> Path:
     return Path("tests/fixtures") / name
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_find_numeric_rejects_nan(value: float) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        _find_numeric({"Notional": value}, ("Notional",), field="Notional")
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf")])
+def test_find_numeric_rejects_infinity(value: float) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        _find_numeric({"Notional": value}, ("Notional",), field="Notional")
+
+
+def test_find_numeric_rejects_non_finite_default() -> None:
+    with pytest.raises(ValueError, match="Default value.*must be finite"):
+        _find_numeric({}, ("Notional",), field="Notional", default=float("nan"))
+
+
+def test_risk_ranking_is_order_independent() -> None:
+    records = [
+        {"counterparty": "ALPHA BANK", "risk_proxy": 10.0},
+        {"counterparty": "BETA BANK", "risk_proxy": -30.0},
+        {"counterparty": "GAMMA BANK", "risk_proxy": 20.0},
+    ]
+
+    rankings = [
+        _rank_proxy_rows(variant="all", records=order, proxy_column="risk_proxy")
+        for order in (records, list(reversed(records)), [records[1], records[0], records[2]])
+    ]
+
+    assert [[row["counterparty"] for row in ranking] for ranking in rankings] == [
+        ["BETA BANK", "GAMMA BANK", "ALPHA BANK"],
+        ["BETA BANK", "GAMMA BANK", "ALPHA BANK"],
+        ["BETA BANK", "GAMMA BANK", "ALPHA BANK"],
+    ]
+    with pytest.raises(ValueError, match="Risk proxy 'risk_proxy' must be finite"):
+        _rank_proxy_rows(
+            variant="all",
+            records=[{**records[0], "risk_proxy": float("nan")}, *records[1:]],
+            proxy_column="risk_proxy",
+        )
+    with pytest.raises(ValueError, match="Row value for 'Notional' must be finite"):
+        _compute_metrics(
+            {
+                "all": {
+                    "totals": [
+                        {"counterparty": "ALPHA BANK", "Notional": float("nan")},
+                        {"counterparty": "BETA BANK", "Notional": 30.0},
+                        {"counterparty": "GAMMA BANK", "Notional": 20.0},
+                    ]
+                }
+            }
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:962 -->
> **Source:** Issue #962

Closes #962

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`_find_numeric` in `src/counter_risk/compute/rollups.py:121` coerces a row value with a bare
`float(raw_value)` and no finite check:

```python
try:
    return float(raw_value)
except (TypeError, ValueError) as exc:
    raise ValueError(f"Row value for {field!r} must be numeric") from exc
```

`float("nan")` and `float("inf")` both succeed, so a non-finite value passes straight through. The
correct guard already exists thirty lines away in the same package, at
`src/counter_risk/compute/limits.py:92`, which raises `ValueError` on non-finite input — and
`rollups.py` already imports from that module.

Downstream, `src/counter_risk/pipeline/run.py:2101-2107` ranks counterparties with:

```python
ranked = sorted(records, key=lambda record: (-abs(_to_float(record.get(proxy_column))), ...))
```

NaN compares `False` against every value, so `sorted` cannot order it and the result depends on
input arrival order. Executed with three identical counterparty rows in three different orders, one
carrying a NaN proxy:

```
order 1 (NaN first) -> ['ALPHA BANK', 'GAMMA BANK', 'BETA BANK']
order 2 (NaN last)  -> ['GAMMA BANK', 'BETA BANK', 'ALPHA BANK']
order 3 (NaN mid)   -> ['BETA BANK', 'ALPHA BANK', 'GAMMA BANK']
control, same rows with the NaN replaced -> ['GAMMA BANK', 'BETA BANK', 'ALPHA BANK'] both orders
```

Three different answers to "which counterparty is our largest exposure", decided by row order. The
ranking is written to `risk_rankings.csv`, so a wrong and unreproducible number reaches the report.

The missing behavior is a `math.isfinite` check at the coercion boundary, matching the guard the
package already has.

No existing test can catch it: `tests/compute/test_rollups.py` is 338 lines and contains no `nan`, no `inf`,
and one negative value. The pipeline also hand-rolls the same coercion inline at
`src/counter_risk/pipeline/run.py:1731-1790` as `float(x or 0.0)`, where the `or 0.0` fallback is
inert because NaN is truthy.

#### Tasks
- [ ] In `src/counter_risk/compute/rollups.py`, add a `math.isfinite` check to `_find_numeric` and raise `ValueError` naming the field and the offending value when it fails.
- [ ] In `src/counter_risk/compute/rollups.py`, confirm the `default` branch of `_find_numeric` cannot itself return a non-finite value.
- [ ] In `src/counter_risk/pipeline/run.py`, replace the inline `float(x or 0.0)` coercion around lines 1731-1790 with a call to the guarded helper so both paths share one rule.
- [ ] In `src/counter_risk/pipeline/run.py`, make the ranking sort at lines 2101-2107 fail loudly rather than silently mis-order if a non-finite proxy value still reaches it.
- [ ] Add `test_find_numeric_rejects_nan` to `tests/compute/test_rollups.py`.
- [ ] Add `test_find_numeric_rejects_infinity` to `tests/compute/test_rollups.py`.
- [ ] Add `test_risk_ranking_is_order_independent` to `tests/compute/test_rollups.py`, ranking the same record set in three different input orders and asserting all three produce an identical ranking.

#### Acceptance criteria
- [ ] `tests/compute/test_rollups.py::test_find_numeric_rejects_nan` passes.
- [ ] `tests/compute/test_rollups.py::test_find_numeric_rejects_infinity` passes.
- [ ] `tests/compute/test_rollups.py::test_risk_ranking_is_order_independent` passes.
- [ ] **Deliberate-break demonstration.** Remove the `math.isfinite` check from `_find_numeric` in `src/counter_risk/compute/rollups.py`, run `pytest tests/compute/test_rollups.py::test_risk_ranking_is_order_independent` and paste the FAILING output showing at least two differing rankings. Restore the check, re-run the same node id, and paste the PASSING output. Both must appear in the PR body.
- [ ] All pre-existing tests in `tests/compute/test_rollups.py` still pass unchanged.
- [ ] `ruff check .` and `black --check .` pass at the pinned versions (`ruff==0.16.4`, `black==26.5.1`).

<!-- auto-status-summary:end -->