### PR TITLE
fix(wal): guard the WAL denominator against signed near-cancellation

### DIFF
--- a/src/counter_risk/calculations/wal.py
+++ b/src/counter_risk/calculations/wal.py
@@ -16,6 +16,22 @@ there is no TIPS exposure to measure, so WAL is 0 (the parser returns no rows an
 this function returns 0.0). That is the expected value for June 2026 onward, not a
 data error.
 
+A return of 0.0 therefore means **no gross exposure**: every row total is zero, or
+there are no rows at all. It does NOT mean "the book nets to flat". A hedged-to-flat
+book -- one whose long and short legs cancel, exactly or nearly -- has real gross
+exposure and no meaningful weighted average life, so it RAISES ValueError rather
+than returning zero. Reporting 0.0 there would make a wound-down book and a hedged
+book indistinguishable in the output, and the report carries no other signal that
+the book was hedged.
+
+The denominator is a SIGNED sum, so a mixed-sign schedule can cancel down to a
+value near zero while remaining perfectly finite. Dividing by it produces an answer
+many orders of magnitude outside the schedule's own maturity span (a correct WAL is
+an exposure-weighted average of the row offsets, so it must lie between the earliest
+and latest of them). The guard below compares the signed total against the gross
+magnitude and refuses when the ratio falls below
+``_NEAR_CANCELLATION_RELATIVE_TOLERANCE``.
+
 NOTE: for months where TIPS is present, this deterministic method reproduces the
 historical hand-entered WAL values to within ~0.5 day but not exactly; the sub-day
 residual is not recoverable from the NISA source files and is left for the process
@@ -30,19 +46,44 @@ from pathlib import Path
 
 from counter_risk.parsers.exposure_maturity_schedule import parse_exposure_maturity_schedule
 
+#: Smallest ratio of |signed total| to gross magnitude that still yields a usable
+#: denominator. A relative tolerance rather than an absolute epsilon because notional
+#: magnitudes in this book span several orders of magnitude, so any fixed epsilon is
+#: either meaningless at the top of that range or trigger-happy at the bottom. Below
+#: 1e-6 the surviving net is under one part per million of the exposure that produced
+#: it: float64 cancellation has consumed most of the significant digits, and the
+#: quotient is no longer bounded by the schedule's own maturity span in any useful way.
+_NEAR_CANCELLATION_RELATIVE_TOLERANCE = 1e-6
+
 
 def calculate_wal(exposure_summary_path: Path | str, px_date: date | datetime | str) -> float:
-    """Calculate WAL (in days) from an exposure maturity summary workbook."""
+    """Calculate WAL (in days) from an exposure maturity summary workbook.
+
+    Returns 0.0 only when the schedule carries no gross exposure. Raises ValueError
+    when the signed total nets to a negligible fraction of the gross magnitude, which
+    is a hedged-to-flat book rather than an absent one.
+    """
 
     fallback_px = _coerce_px_date(px_date)
     schedule = parse_exposure_maturity_schedule(exposure_summary_path)
     px = schedule.px_date or fallback_px
 
     total_exposure = sum(row.total for row in schedule.rows)
+    gross_exposure = sum(abs(row.total) for row in schedule.rows)
     if not math.isfinite(total_exposure):
         raise ValueError("Total exposure is not finite")
-    if total_exposure == 0:
+    if gross_exposure == 0:
         return 0.0
+    if abs(total_exposure) < _NEAR_CANCELLATION_RELATIVE_TOLERANCE * gross_exposure:
+        raise ValueError(
+            "Signed total exposure nets to a negligible fraction of gross exposure: "
+            f"signed total {total_exposure!r}, gross magnitude {gross_exposure!r} "
+            f"(ratio {abs(total_exposure) / gross_exposure:.3e} is below the "
+            f"{_NEAR_CANCELLATION_RELATIVE_TOLERANCE:.0e} relative tolerance). "
+            "This schedule is hedged to flat and has no meaningful weighted average "
+            "life; dividing by the residual would report a value far outside the "
+            "schedule's own maturity span."
+        )
 
     weighted_days = sum((row.maturity_date - px).days * row.total for row in schedule.rows)
     return weighted_days / total_exposure

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -64,3 +64,86 @@ def test_calculate_wal_zero_when_all_totals_zero(tmp_path: Path) -> None:
 def test_calculate_wal_is_deterministic(tmp_path: Path) -> None:
     p = _write_schedule(tmp_path / "det.xlsx")
     assert calculate_wal(p, date(2025, 11, 30)) == calculate_wal(p, date(2025, 11, 30))
+
+
+# A long leg maturing in one year against an opposing short leg maturing in ten,
+# sized so the signed sum survives as one hundredth of a currency unit out of a
+# two-million gross book. Finite, so the isfinite guard passes; useless, because the
+# quotient lands nine orders of magnitude outside the schedule's own maturity span.
+_NEAR_CANCELLING_PX = datetime(2025, 11, 30)
+_NEAR_CANCELLING_ROWS = (
+    (datetime(2026, 11, 30), 1_000_000.00),  # 365 days
+    (datetime(2035, 11, 30), -999_999.99),  # 3652 days
+)
+
+
+def test_wal_raises_on_near_cancelling_signed_denominator(tmp_path: Path) -> None:
+    p = _write_schedule(
+        tmp_path / "near_cancelling.xlsx",
+        px=_NEAR_CANCELLING_PX,
+        rows=_NEAR_CANCELLING_ROWS,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        calculate_wal(p, _NEAR_CANCELLING_PX.date())
+    message = str(excinfo.value)
+    # The refusal has to name both totals, or the operator cannot tell a hedged book
+    # from a corrupt one.
+    assert "0.01" in message, message
+    assert "1999999.99" in message, message
+
+
+def test_wal_result_lies_within_the_schedule_maturity_span(tmp_path: Path) -> None:
+    # WAL is an exposure-weighted average of the row offsets, so every value this
+    # function returns must sit between the earliest and latest of them. A schedule
+    # that cannot honour that must raise instead of returning something.
+    px = _NEAR_CANCELLING_PX
+    schedules = {
+        "all_long": (
+            (datetime(2026, 11, 30), 1_000_000.00),
+            (datetime(2035, 11, 30), 250_000.00),
+        ),
+        "near_cancelling": _NEAR_CANCELLING_ROWS,
+    }
+    returned_a_value = False
+    for name, rows in schedules.items():
+        p = _write_schedule(tmp_path / f"span_{name}.xlsx", px=px, rows=rows)
+        offsets = [(maturity.date() - px.date()).days for maturity, _ in rows]
+        low, high = min(offsets), max(offsets)
+        try:
+            wal = calculate_wal(p, px.date())
+        except ValueError:
+            continue
+        returned_a_value = True
+        assert (
+            low <= wal <= high
+        ), f"WAL {wal:,.0f} days is outside the span [{low}, {high}] for schedule {name!r}"
+    assert returned_a_value, "no schedule returned a value; the span invariant was never exercised"
+
+
+def test_wal_returns_zero_only_for_empty_gross_exposure(tmp_path: Path) -> None:
+    # The wound-down book: the TIPS block is still on the sheet but carries no
+    # exposure. Gross magnitude is zero, so 0.0 is the honest answer. (The parser
+    # rejects a block with no maturity rows at all, so an all-zero block is the
+    # rowless case as it actually reaches this function.)
+    wound_down = _write_schedule(
+        tmp_path / "wound_down.xlsx",
+        px=_NEAR_CANCELLING_PX,
+        rows=(
+            (datetime(2026, 11, 30), 0.0),
+            (datetime(2035, 11, 30), 0.0),
+        ),
+    )
+    assert calculate_wal(wound_down, _NEAR_CANCELLING_PX.date()) == 0.0
+
+    # The hedged book: legs cancel to exactly zero, but two million of gross exposure
+    # is present. Returning 0.0 here would make it indistinguishable from the above.
+    hedged = _write_schedule(
+        tmp_path / "hedged_flat.xlsx",
+        px=_NEAR_CANCELLING_PX,
+        rows=(
+            (datetime(2026, 11, 30), 1_000_000.00),
+            (datetime(2035, 11, 30), -1_000_000.00),
+        ),
+    )
+    with pytest.raises(ValueError):
+        calculate_wal(hedged, _NEAR_CANCELLING_PX.date())


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:963 -->
> **Source:** Issue #963

Closes #963

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`calculate_wal` in `src/counter_risk/calculations/wal.py:44-48` divides by a **signed** sum of row
totals, guarded only against exact zero:

```python
total_exposure = sum(row.total for row in schedule.rows)
if not math.isfinite(total_exposure):
    raise ValueError("Total exposure is not finite")
if total_exposure == 0:
    return 0.0
weighted_days = sum((row.maturity_date - px).days * row.total for row in schedule.rows)
return weighted_days / total_exposure
```

The `math.isfinite` check added by the previous audit is present and passes — a near-cancelling
denominator is perfectly finite, just close to zero. Executed against `calculate_wal` with a long
1,000,000.00 leg maturing in one year and a short 999,999.99 leg maturing in ten years:

```
signed net exposure : 0.010000000009313226
WAL (days)          : -328,799,996,041
WAL (years)         : -900,205,328
```

WAL is defined by the module docstring as an exposure-weighted average time-to-maturity in days from
the Px Date, so any correct result must fall inside the span of the schedule's own maturity dates —
here `[365, 3653]` days. The returned value is nine orders of magnitude outside it and negative.

The exact-cancellation case is worse because it is silent. A fully-hedged TIPS book sums to exactly
zero and returns `0.0`, and the docstring at `src/counter_risk/calculations/wal.py:14-18` declares
`0.0` to mean "there is no TIPS exposure to measure … That is the expected value for June 2026
onward, not a data error". So a hedged book and a wound-down book are indistinguishable in the
output.

Both paths reach the historical workbook through `src/counter_risk/outputs/historical_workbook.py:89`.

No existing test can catch this: `tests/test_wal.py` is 66 lines and contains no negative total, no
mixed-sign schedule, and no near-zero denominator.

#### Tasks
- [ ] In `src/counter_risk/calculations/wal.py`, compute the gross magnitude `sum(abs(row.total) for row in schedule.rows)` alongside the existing signed total.
- [ ] Raise `ValueError` naming both the signed and gross totals when the gross magnitude is non-zero but the signed total is negligible relative to it, using a documented relative threshold rather than an exact-zero comparison.
- [ ] In `src/counter_risk/calculations/wal.py`, keep returning `0.0` only when the gross magnitude is itself zero, which is the genuine no-TIPS-exposure case the docstring describes.
- [ ] Update the module docstring in `src/counter_risk/calculations/wal.py` to state that `0.0` means no gross exposure, and that a hedged-to-flat book raises rather than returning zero.
- [ ] Add `test_wal_raises_on_near_cancelling_signed_denominator` to `tests/test_wal.py` using a long leg at one year and an opposing short leg at ten years.
- [ ] Add `test_wal_result_lies_within_the_schedule_maturity_span` to `tests/test_wal.py`, asserting the result falls between the earliest and latest row offsets for any schedule that returns a value.
- [ ] Add `test_wal_returns_zero_only_for_empty_gross_exposure` to `tests/test_wal.py`, distinguishing an empty schedule from an exactly-hedged one.

#### Acceptance criteria
- [ ] `tests/test_wal.py::test_wal_raises_on_near_cancelling_signed_denominator` passes.
- [ ] `tests/test_wal.py::test_wal_result_lies_within_the_schedule_maturity_span` passes.
- [ ] `tests/test_wal.py::test_wal_returns_zero_only_for_empty_gross_exposure` passes.
- [ ] **Deliberate-break demonstration.** Restore the bare `if total_exposure == 0: return 0.0` guard in `src/counter_risk/calculations/wal.py`, run `pytest tests/test_wal.py::test_wal_result_lies_within_the_schedule_maturity_span` and paste the FAILING output, which must show the out-of-span value and the span. Revert, re-run the same node id, and paste the PASSING output. Both must appear in the PR body.
- [ ] All pre-existing tests in `tests/test_wal.py` still pass unchanged.
- [ ] `ruff check .` and `black --check .` pass at the pinned versions (`ruff==0.16.4`, `black==26.5.1`).

**Head SHA:** 08608df24ad5a3d0f7857a1762cf82b20b36810d
**Latest Runs:** ❔ in progress — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/32805816465) |
| PR 46 Dependency Repair Contract | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/32805816687) |
<!-- auto-status-summary:end -->