### PR TITLE
fix(tests): make the PyInstaller skip-guard ask about importability, not symlinks

### DIFF
--- a/tests/integration/test_packaged_executable_assets.py
+++ b/tests/integration/test_packaged_executable_assets.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -29,7 +29,7 @@ def _build_packaged_output(tmp_path: Path) -> Path:
     pyinstaller = shutil.which("pyinstaller")
     if pyinstaller is None:
         pytest.skip("PyInstaller is not installed in this environment.")
-    if Path(pyinstaller).resolve().parent != Path(sys.executable).resolve().parent:
+    if importlib.util.find_spec("PyInstaller") is None:
         pytest.skip("PyInstaller is not installed in the active test environment.")
 
     repo_root = Path(__file__).resolve().parents[2]

--- a/tests/test_pyinstaller_guard.py
+++ b/tests/test_pyinstaller_guard.py
@@ -1,0 +1,143 @@
+"""Regression gates for the PyInstaller availability guard in the release tests.
+
+Two release tests decide whether PyInstaller is usable before invoking it. They used
+to do that by comparing resolved interpreter directories::
+
+    if Path(pyinstaller).resolve().parent != Path(sys.executable).resolve().parent:
+        pytest.skip("PyInstaller is not installed in the active test environment.")
+
+``Path.resolve()`` follows symlinks, and a virtualenv's ``bin/python`` is a symlink to
+the base interpreter, so both operands collapse onto the base interpreter's ``bin``
+directory and the comparison is equal no matter what is installed in the active
+environment. The skip therefore never fired, the tests invoked a foreign PyInstaller
+against the active environment's code, and the failure surfaced as an opaque
+``CalledProcessError`` naming ``release.spec`` -- misdirecting exactly the person most
+likely to hit it, someone setting the repository up for the first time.
+
+The guard now asks the question its own skip message claims to ask: is ``PyInstaller``
+importable in the running interpreter?
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_GUARD_FILES = (
+    _REPO_ROOT / "tests" / "test_release_spec.py",
+    _REPO_ROOT / "tests" / "integration" / "test_packaged_executable_assets.py",
+)
+
+# The distinctive half of the defective comparison. Whitespace is stripped from both
+# needle and haystack before searching, so reformatting the call across lines cannot
+# hide a resurrected guard -- and no legitimate use of this expression exists in
+# either file.
+_DEFECTIVE_FRAGMENT = "Path(sys.executable).resolve().parent"
+
+_RELEASE_NODE_ID = (
+    "tests/test_release_spec.py::test_release_spec_pyinstaller_build_outputs_expected_executable"
+)
+
+_EXPECTED_SKIP_REASON = "PyInstaller is not installed in the active test environment."
+
+# Imported into the subprocess before collection. It makes PyInstaller unimportable and
+# points `shutil.which` at a path inside the RESOLVED interpreter directory -- which is
+# precisely the collapse that defeated the old guard, so the old guard would decline to
+# skip and the test would go on to invoke a binary that is not there.
+_FORCING_PLUGIN = """
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+
+_ABSENT = Path(sys.executable).resolve().parent / "pyinstaller-absent-for-guard-test"
+_real_find_spec = importlib.util.find_spec
+_real_which = shutil.which
+
+
+def _find_spec(name, package=None):
+    if name == "PyInstaller" or name.startswith("PyInstaller."):
+        return None
+    return _real_find_spec(name, package)
+
+
+def _which(cmd, *args, **kwargs):
+    if cmd == "pyinstaller":
+        return str(_ABSENT)
+    return _real_which(cmd, *args, **kwargs)
+
+
+importlib.util.find_spec = _find_spec
+shutil.which = _which
+"""
+
+
+def test_pyinstaller_guard_does_not_compare_resolved_parents() -> None:
+    needle = "".join(_DEFECTIVE_FRAGMENT.split())
+    offenders = []
+    for path in _GUARD_FILES:
+        haystack = "".join(path.read_text(encoding="utf-8").split())
+        if needle in haystack:
+            offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert not offenders, (
+        "the symlink-blind PyInstaller guard is back in: "
+        + ", ".join(offenders)
+        + f" -- {_DEFECTIVE_FRAGMENT} collapses onto the base interpreter's bin "
+        "directory inside a virtualenv, so the skip never fires. Ask "
+        'importlib.util.find_spec("PyInstaller") instead.'
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("COUNTER_RISK_GUARD_SUBPROCESS") == "1",
+    reason="guard subprocess re-entry",
+)
+def test_release_tests_skip_when_pyinstaller_unimportable(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "forcing"
+    plugin_dir.mkdir()
+    (plugin_dir / "_force_pyinstaller_absent.py").write_text(_FORCING_PLUGIN, encoding="utf-8")
+
+    env = os.environ.copy()
+    env["COUNTER_RISK_GUARD_SUBPROCESS"] = "1"
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(plugin_dir), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            _RELEASE_NODE_ID,
+            "-p",
+            "_force_pyinstaller_absent",
+            "-p",
+            "no:cacheprovider",
+            "-rs",
+            "-q",
+            "--no-header",
+            "--tb=no",
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    report = completed.stdout + completed.stderr
+
+    # The observable outcome is the whole assertion: SKIPPED, not FAILED. Re-deriving
+    # the defective predicate here and comparing it against importability would be a
+    # defect detector rather than a regression gate -- it would fail identically
+    # whether or not the production guard is fixed.
+    assert "1 skipped" in report, report
+    assert completed.returncode == 0, report
+    # Naming the reason pins WHICH guard skipped: `shutil.which` is forced to return a
+    # path, so the earlier `pyinstaller is None` guard cannot be the one that fired.
+    assert _EXPECTED_SKIP_REASON in report, report

--- a/tests/test_release_spec.py
+++ b/tests/test_release_spec.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -86,7 +86,7 @@ def test_release_spec_pyinstaller_build_outputs_expected_executable(
     pyinstaller = shutil.which("pyinstaller")
     if pyinstaller is None:
         pytest.skip("PyInstaller is not installed in this environment.")
-    if Path(pyinstaller).resolve().parent != Path(sys.executable).resolve().parent:
+    if importlib.util.find_spec("PyInstaller") is None:
         pytest.skip("PyInstaller is not installed in the active test environment.")
 
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:964 -->
> **Source:** Issue #964

Closes #964

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Two release tests decide whether PyInstaller is usable by comparing resolved interpreter
directories. `Path.resolve()` follows symlinks, and a virtualenv's `bin/python` is a symlink to the
base interpreter by default (`python -m venv`, `uv venv`), so both operands collapse to the base
interpreter's bin directory and the comparison is always equal — regardless of what is actually
installed in the active environment.

The defective guard is byte-identical at `tests/test_release_spec.py:89` and
`tests/integration/test_packaged_executable_assets.py:32`:

```python
if Path(pyinstaller).resolve().parent != Path(sys.executable).resolve().parent:
    pytest.skip("PyInstaller is not installed in the active test environment.")
```

Measured in a venv built from `requirements-dev.lock`, which does not carry `pyinstaller` (that pin
lives at `requirements.txt:11`):

```
which pyinstaller  -> a path OUTSIDE the venv
sys.executable     -> the venv python, whose resolve() lands on the base interpreter
guard says "parents differ, should skip"? -> False
is PyInstaller importable in the venv?    -> No module named 'PyInstaller'
```

So the guard reports "usable" while the import fails. Both tests then invoke a foreign PyInstaller
against the active environment's code and fail opaquely with a `CalledProcessError` naming
`release.spec` and a non-zero exit status. Nothing in that message names the real cause.

The missing behavior: the guard must key on whether `PyInstaller` is importable in the running
interpreter, which is what its own skip message already claims to test. As written, that skip
message is unreachable in the environments it was written for, and the resulting failure misdirects
exactly the person most likely to hit it — someone setting the repo up for the first time.

Remote CI is unaffected: `release-e2e.yml` installs `requirements.txt`, so `which` and importability
agree on that runner. This defect bites local developers and any environment that installs only the
dev lock.

#### Tasks
- [ ] Add `import importlib.util` to `tests/test_release_spec.py`.
- [ ] Replace the resolved-parent comparison at `tests/test_release_spec.py:89` with `if importlib.util.find_spec("PyInstaller") is None:`, keeping the existing skip message unchanged.
- [ ] Add `import importlib.util` to `tests/integration/test_packaged_executable_assets.py`.
- [ ] Replace the resolved-parent comparison at `tests/integration/test_packaged_executable_assets.py:32` with the same `importlib.util.find_spec` check, keeping the existing skip message unchanged.
- [ ] Check whether `sys` is still used in each edited file and remove the import only where it has become unused.
- [ ] Create a new test module `test_pyinstaller_guard.py` under `tests/` holding the two gates below.
- [ ] Add `test_pyinstaller_guard_does_not_compare_resolved_parents`, which reads both guard files and asserts neither still contains the resolved-parent comparison, naming any offending file in the assertion message.
- [ ] Add `test_release_tests_skip_when_pyinstaller_unimportable`, which runs the release test in a subprocess with `find_spec("PyInstaller")` forced to return `None` and asserts the reported outcome is `skipped` rather than `failed`.

#### Acceptance criteria
- [ ] `tests/test_pyinstaller_guard.py::test_pyinstaller_guard_does_not_compare_resolved_parents` passes.
- [ ] `tests/test_pyinstaller_guard.py::test_release_tests_skip_when_pyinstaller_unimportable` passes.
- [ ] **Deliberate-break demonstration.** Restore the resolved-parent comparison at `tests/test_release_spec.py:89` only, run `pytest tests/test_pyinstaller_guard.py::test_pyinstaller_guard_does_not_compare_resolved_parents`, and paste the FAILING output showing that file named as the offender. Revert the break, re-run the same node id, and paste the PASSING output. Both outputs must appear in the PR body.
- [ ] In an environment where `PyInstaller` is not importable, `pytest -rs` over both release node ids reports two SKIPPED lines with the reason `PyInstaller is not installed in the active test environment.` Paste that output.
- [ ] `ruff check .` and `black --check .` pass at the pinned versions (`ruff==0.16.4`, `black==26.5.1`).

**Head SHA:** a056b97e4a0ff6cec0aefed0b2a98bd378c940aa
**Latest Runs:** ⏭️ skipped — PR 46 Dependency Repair Contract
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/32806219704) |
| PR 46 Dependency Repair Contract | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/32806219914) |
<!-- auto-status-summary:end -->