### PR TITLE
fix(cli): call configure_logging from the CLI entry point so diagnostics reach the operator

### DIFF
--- a/src/counter_risk/cli/__init__.py
+++ b/src/counter_risk/cli/__init__.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 from counter_risk.config import WorkflowConfig, load_config
 from counter_risk.io.discover import discover_workflow_inputs, resolve_discovery_selections
+from counter_risk.logging import configure_logging
 from counter_risk.pipeline import run_fixture_replay, run_pipeline_with_config
 from counter_risk.runtime_paths import resolve_runtime_path
 
@@ -42,6 +43,23 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the top-level CLI parser."""
 
     parser = argparse.ArgumentParser(prog="counter-risk")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help=(
+            "Logging level for this invocation (default: INFO). Accepts any standard "
+            "level name, e.g. DEBUG, INFO, WARNING, ERROR."
+        ),
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to also write JSON-formatted log records to, in addition to "
+            "the console."
+        ),
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     run_parser = subparsers.add_parser("run", help="Run the Counter Risk pipeline")
@@ -479,6 +497,18 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    # Configure logging exactly once, here, before any subcommand dispatch. Every
+    # subcommand reaches this line -- including `gui`, which is how the packaged
+    # executable launches (release.spec builds src/counter_risk/cli/__main__.py, which
+    # calls this function). Until this call existed the root logger had no handler at
+    # runtime, so every `debug` and `info` record in the package emitted nothing and
+    # JsonFormatter never formatted a single production record.
+    #
+    # Deliberately NOT done at import time or in a library module: that would make
+    # handler installation a side effect of importing counter_risk, which breaks test
+    # isolation and any host embedding the package.
+    configure_logging(log_level=args.log_level, log_file=args.log_file)
 
     handler = getattr(args, "handler", None)
     if handler is None:

--- a/tests/test_counter_risk_logging.py
+++ b/tests/test_counter_risk_logging.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from counter_risk import logging as cr_logging
+from counter_risk.cli import main
 
 
 def test_resolve_level_handles_known_values() -> None:
@@ -77,3 +80,99 @@ def test_configure_logging_writes_json_file(tmp_path: Path) -> None:
     payload = json.loads(lines[0])
     assert payload["message"] == "pipeline started"
     assert payload["level"] == "INFO"
+
+
+_SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "counter_risk"
+_REPO_ROOT = _SRC_ROOT.parents[1]
+
+
+@pytest.fixture
+def restored_root_logger() -> Iterator[None]:
+    """Save and restore root logger state around a test that configures logging.
+
+    ``configure_logging`` clears the root handlers by design, so a test that lets the
+    CLI configure logging would otherwise leave a handler bound to this test's captured
+    stream attached for the remainder of the session.
+    """
+
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in saved_handlers:
+            root.addHandler(handler)
+        root.setLevel(saved_level)
+
+
+def _modules_calling(function_name: str) -> list[str]:
+    """Return every module under ``src/counter_risk`` that CALLS ``function_name``.
+
+    Deliberately an AST walk for a ``Call`` node rather than a substring search. A
+    substring search would be satisfied by the import line, by a mention in a comment,
+    or by a commented-out call -- none of which installs a log handler at runtime, which
+    is the property this is here to protect.
+    """
+
+    callers: list[str] = []
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Name):
+                name: str | None = func.id
+            elif isinstance(func, ast.Attribute):
+                name = func.attr
+            else:
+                name = None
+            if name == function_name:
+                callers.append(str(path.relative_to(_REPO_ROOT)))
+                break
+    return callers
+
+
+def test_configure_logging_has_a_production_caller() -> None:
+    callers = _modules_calling("configure_logging")
+    assert callers, (
+        "configure_logging has no production caller under src/counter_risk, so the root "
+        "logger has no handler at runtime: every debug/info record in the package emits "
+        "nothing and JsonFormatter never formats a production record. The CLI entry "
+        "point in src/counter_risk/cli/__init__.py is where the call belongs."
+    )
+
+
+def test_cli_main_configures_logging(restored_root_logger: None) -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    assert root.handlers == []
+
+    assert main([]) == 0
+
+    assert root.handlers, "counter-risk main() left the root logger with no handler"
+
+
+def test_pipeline_info_records_are_emitted_after_cli_configures_logging(
+    restored_root_logger: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main([]) == 0
+    capsys.readouterr()  # discard the help text main() prints when given no subcommand
+
+    # The record from src/counter_risk/pipeline/run.py that reports limit checking was
+    # silently disabled because config/limits.yml was unreachable.
+    logging.getLogger("counter_risk.pipeline.run").info(
+        "limit_breaches_skipped missing_limits_config path=%s", "config/limits.yml"
+    )
+
+    captured = capsys.readouterr()
+    assert captured.err.strip(), "an INFO record produced no output after the CLI ran"
+    payload = json.loads(captured.err.strip().splitlines()[-1])
+    assert payload["logger"] == "counter_risk.pipeline.run"
+    assert payload["level"] == "INFO"
+    assert "limit_breaches_skipped" in payload["message"]


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:965 -->
> **Source:** Issue #965

Closes #965

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`configure_logging` at `src/counter_risk/logging.py:38` has **zero production callers**. Its only
references anywhere in the repo are two tests: `tests/test_imports.py:15` (a `hasattr` assertion) and
`tests/test_counter_risk_logging.py:66`. The only code that installs a logging handler lives inside
that function (`src/counter_risk/logging.py:55` and `:62`).

Because nothing calls it, the root logger has no handler at runtime. Measured on an unconfigured
root logger: an `INFO` record produced empty stderr and empty stdout with `root.handlers == []`,
while a `WARNING` record reached bare stderr through `logging.lastResort`.

Call-site census in `src/`:

| level | call sites | reaches the operator |
|---|---|---|
| `debug` | 4 | no output at all |
| `info` | 33 | no output at all |
| `warning` | 27 | bare stderr, unformatted |
| `error` | 6 | bare stderr, unformatted |
| `exception` | 20 | bare stderr, unformatted |

So 37 diagnostic records in the shipped product emit nothing, and `JsonFormatter`
(`src/counter_risk/logging.py:12`) — written to make logs deterministic and auditable — never
formats a single record in production.

The missing behavior matters because the codebase deliberately degrades rather than crashing, and
records the degradation with a log call. `src/counter_risk/pipeline/run.py:2369` reports a missing
limits config at `INFO`, which means an operator whose `config/limits.yml` is unreachable sees a
clean successful run with all limit checking silently disabled. That specific path was reproduced
during the 2026-08-24 audit: a 9,999,999,999 exposure against the shipped 250M `severity: fail`
limit returned `breach_count: 0`, `has_breaches: False`, no warnings, run completed.

This is one seam. Fixing it raises the visibility of roughly a dozen separately-filed findings.

#### Tasks
- [ ] Add a `--log-level` argument and an optional `--log-file` argument to the top-level parser in `src/counter_risk/cli/__init__.py`, defaulting the level to `INFO`.
- [ ] Call `configure_logging` once in `main` in `src/counter_risk/cli/__init__.py`, before any subcommand dispatch, passing the parsed level and log file.
- [ ] Confirm the `gui` subcommand path also reaches that call, since the packaged executable launches through it.
- [ ] Add `test_cli_main_configures_logging` to `tests/test_counter_risk_logging.py`, asserting the root logger has at least one handler after `main` runs with a trivial argument list.
- [ ] Add `test_pipeline_info_records_are_emitted_after_cli_configures_logging` to `tests/test_counter_risk_logging.py`, asserting an `INFO` record from the `counter_risk.pipeline.run` logger appears in captured output once the CLI has configured logging.
- [ ] Add `test_configure_logging_has_a_production_caller` to `tests/test_counter_risk_logging.py`, asserting at least one non-test module under `src/counter_risk/` references `configure_logging`.

#### Acceptance criteria
- [ ] `tests/test_counter_risk_logging.py::test_configure_logging_has_a_production_caller` passes.
- [ ] `tests/test_counter_risk_logging.py::test_cli_main_configures_logging` passes.
- [ ] `tests/test_counter_risk_logging.py::test_pipeline_info_records_are_emitted_after_cli_configures_logging` passes.
- [ ] **Deliberate-break demonstration.** Comment out the `configure_logging` call in `src/counter_risk/cli/__init__.py`, run `pytest tests/test_counter_risk_logging.py::test_configure_logging_has_a_production_caller` and paste the FAILING output. Restore the call, re-run the same node id, and paste the PASSING output. Both must appear in the PR body.
- [ ] Run the pipeline with an absent `config/limits.yml` and paste output showing the previously-invisible `INFO` record from `src/counter_risk/pipeline/run.py:2369` now appearing on the operator's console.
- [ ] `ruff check .` and `black --check .` pass at the pinned versions (`ruff==0.16.4`, `black==26.5.1`).
- [ ] The full suite is no worse than the pre-change baseline of 1391 passed / 2 failed / 3 skipped.

**Head SHA:** fd63e1eea7e6e8ef86c6b5cb4da580cda3708807
**Latest Runs:** ⏭️ skipped — PR 46 Dependency Repair Contract
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Counter_Risk/actions/runs/32805987774) |
| PR 46 Dependency Repair Contract | ⏭️ skipped | [View run](https://github.com/stranske/Counter_Risk/actions/runs/32805987939) |
<!-- auto-status-summary:end -->