### PR TITLE
fix: reject signed WAL results outside maturity span

### DIFF
--- a/src/counter_risk/calculations/wal.py
+++ b/src/counter_risk/calculations/wal.py
@@ -30,7 +30,10 @@ many orders of magnitude outside the schedule's own maturity span (a correct WAL
 an exposure-weighted average of the row offsets, so it must lie between the earliest
 and latest of them). The guard below compares the signed total against the gross
 magnitude and refuses when the ratio falls below
-``_NEAR_CANCELLATION_RELATIVE_TOLERANCE``.
+``_NEAR_CANCELLATION_RELATIVE_TOLERANCE``. Less-extreme mixed-sign schedules
+can still have a usable-looking denominator while producing a signed weighted
+result outside the maturity span; that is likewise not a valid exposure-weighted
+average and is refused with the same diagnostic context.
 
 NOTE: for months where TIPS is present, this deterministic method reproduces the
 historical hand-entered WAL values to within ~0.5 day but not exactly; the sub-day
@@ -85,8 +88,21 @@ def calculate_wal(exposure_summary_path: Path | str, px_date: date | datetime | 
             "schedule's own maturity span."
         )
 
-    weighted_days = sum((row.maturity_date - px).days * row.total for row in schedule.rows)
-    return weighted_days / total_exposure
+    offsets = [(row.maturity_date - px).days for row in schedule.rows]
+    weighted_days = sum(
+        offset * row.total for offset, row in zip(offsets, schedule.rows, strict=True)
+    )
+    wal = weighted_days / total_exposure
+    earliest_maturity, latest_maturity = min(offsets), max(offsets)
+    if not earliest_maturity <= wal <= latest_maturity:
+        raise ValueError(
+            "Signed total exposure produced a weighted average life outside the "
+            f"schedule maturity span [{earliest_maturity}, {latest_maturity}]: "
+            f"WAL {wal!r}, signed total {total_exposure!r}, gross magnitude "
+            f"{gross_exposure!r}. This mixed-sign schedule has no meaningful "
+            "weighted average life under the signed weighting convention."
+        )
+    return wal
 
 
 def _coerce_px_date(px_date: date | datetime | str) -> date:

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -114,10 +114,29 @@ def test_wal_result_lies_within_the_schedule_maturity_span(tmp_path: Path) -> No
         except ValueError:
             continue
         returned_a_value = True
-        assert (
-            low <= wal <= high
-        ), f"WAL {wal:,.0f} days is outside the span [{low}, {high}] for schedule {name!r}"
+        message = f"WAL {wal:,.0f} days is outside the span [{low}, {high}] for schedule {name!r}"
+        assert low <= wal <= high, message
     assert returned_a_value, "no schedule returned a value; the span invariant was never exercised"
+
+
+def test_wal_raises_when_mixed_sign_result_escapes_maturity_span(tmp_path: Path) -> None:
+    # This is not close enough to flat for the relative denominator guard: the
+    # signed total is roughly 82% of gross exposure. It still produces a negative
+    # signed-weighted WAL, below the earliest one-year maturity, so the result is
+    # not a valid weighted average and must be rejected.
+    px = _NEAR_CANCELLING_PX
+    p = _write_schedule(
+        tmp_path / "out_of_span_mixed_sign.xlsx",
+        px=px,
+        rows=(
+            (datetime(2026, 11, 30), 1_000_000.00),
+            (datetime(2035, 11, 30), -100_000.00),
+        ),
+    )
+    with pytest.raises(ValueError, match="outside the schedule maturity span") as excinfo:
+        calculate_wal(p, px.date())
+    assert "signed total 900000.0" in str(excinfo.value)
+    assert "gross magnitude 1100000.0" in str(excinfo.value)
 
 
 def test_wal_returns_zero_only_for_empty_gross_exposure(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:963 -->
> **Source:** Issue #963

Closes #963

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`calculate_wal` in `src/counter_risk/calculations/wal.py:44-48` divides by a **signed** sum of row
totals, guarded only against exact zero:

```python
total_exposure = sum(row.total for row in schedule.rows)
if not math.isfinite(total_exposure):
    raise ValueError("Total exposure is not finite")
if total_exposure == 0:
    return 0.0
weighted_days = sum((row.maturity_date - px).days * row.total for row in schedule.rows)
return weighted_days / total_exposure
```

The `math.isfinite` check added by the previous audit is present and passes — a near-cancelling
denominator is perfectly finite, just close to zero. Executed against `calculate_wal` with a long
1,000,000.00 leg maturing in one year and a short 999,999.99 leg maturing in ten years:

```
signed net exposure : 0.010000000009313226
WAL (days)          : -328,799,996,041
WAL (years)         : -900,205,328
```

WAL is defined by the module docstring as an exposure-weighted average time-to-maturity in days from
the Px Date, so any correct result must fall inside the span of the schedule's own maturity dates —
here `[365, 3653]` days. The returned value is nine orders of magnitude outside it and negative.

The exact-cancellation case is worse because it is silent. A fully-hedged TIPS book sums to exactly
zero and returns `0.0`, and the docstring at `src/counter_risk/calculations/wal.py:14-18` declares
`0.0` to mean "there is no TIPS exposure to measure … That is the expected value for June 2026
onward, not a data error". So a hedged book and a wound-down book are indistinguishable in the
output.

Both paths reach the historical workbook through `src/counter_risk/outputs/historical_workbook.py:89`.

No existing test can catch this: `tests/test_wal.py` is 66 lines and contains no negative total, no
mixed-sign schedule, and no near-zero denominator.

#### Tasks
- [ ] In `src/counter_risk/calculations/wal.py`, compute the gross magnitude `sum(abs(row.total) for row in schedule.rows)` alongside the existing signed total.
- [ ] Raise `ValueError` naming both the signed and gross totals when the gross magnitude is non-zero but the signed total is negligible relative to it, using a documented relative threshold rather than an exact-zero comparison.
- [ ] In `src/counter_risk/calculations/wal.py`, keep returning `0.0` only when the gross magnitude is itself zero, which is the genuine no-TIPS-exposure case the docstring describes.
- [ ] Update the module docstring in `src/counter_risk/calculations/wal.py` to state that `0.0` means no gross exposure, and that a hedged-to-flat book raises rather than returning zero.
- [ ] Add `test_wal_raises_on_near_cancelling_signed_denominator` to `tests/test_wal.py` using a long leg at one year and an opposing short leg at ten years.
- [ ] Add `test_wal_result_lies_within_the_schedule_maturity_span` to `tests/test_wal.py`, asserting the result falls between the earliest and latest row offsets for any schedule that returns a value.
- [ ] Add `test_wal_returns_zero_only_for_empty_gross_exposure` to `tests/test_wal.py`, distinguishing an empty schedule from an exactly-hedged one.

#### Acceptance criteria
- [ ] `tests/test_wal.py::test_wal_raises_on_near_cancelling_signed_denominator` passes.
- [ ] `tests/test_wal.py::test_wal_result_lies_within_the_schedule_maturity_span` passes.
- [ ] `tests/test_wal.py::test_wal_returns_zero_only_for_empty_gross_exposure` passes.
- [ ] **Deliberate-break demonstration.** Restore the bare `if total_exposure == 0: return 0.0` guard in `src/counter_risk/calculations/wal.py`, run `pytest tests/test_wal.py::test_wal_result_lies_within_the_schedule_maturity_span` and paste the FAILING output, which must show the out-of-span value and the span. Revert, re-run the same node id, and paste the PASSING output. Both must appear in the PR body.
- [ ] All pre-existing tests in `tests/test_wal.py` still pass unchanged.
- [ ] `ruff check .` and `black --check .` pass at the pinned versions (`ruff==0.16.4`, `black==26.5.1`).

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WAL calculations now reject mixed-sign schedules when the result falls outside the maturity range.
  * Errors include diagnostic details to help identify invalid schedules.
  * Valid WAL calculations continue to return results as expected.

* **Documentation**
  * Clarified the validity rules for mixed-sign schedules and maturity spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->